### PR TITLE
feat:  introduce `stageTimeout` & `stageTimeoutIncrease` milestone entries

### DIFF
--- a/packages/configuration-generator/source/generators/milestones.test.ts
+++ b/packages/configuration-generator/source/generators/milestones.test.ts
@@ -47,6 +47,8 @@ describe<{
 						decimals: 8,
 						denomination: 1e8,
 					},
+					stageTimeout: 2000,
+					stageTimeoutIncrease: 2000,
 					vendorFieldLength: 255,
 				},
 			],

--- a/packages/configuration-generator/source/generators/milestones.ts
+++ b/packages/configuration-generator/source/generators/milestones.ts
@@ -26,6 +26,8 @@ export class MilestonesGenerator {
 					decimals: 8,
 					denomination: 1e8,
 				},
+				stageTimeout: 2000,
+				stageTimeoutIncrease: 2000,
 				vendorFieldLength: options.vendorFieldLength,
 			},
 		];

--- a/packages/consensus/source/scheduler.test.ts
+++ b/packages/consensus/source/scheduler.test.ts
@@ -7,7 +7,7 @@ describe<{
 	sandbox: Sandbox;
 	scheduler: Scheduler;
 }>("Scheduler", ({ beforeEach, it, assert, spy, clock }) => {
-	const delays = [1000, 2000, 4000];
+	const delays = [1000, 3000, 5000];
 
 	const consensus = {
 		onTimeoutPrecommit: () => {},
@@ -15,10 +15,18 @@ describe<{
 		onTimeoutPropose: () => {},
 	};
 
+	const config = {
+		getMilestone: () => ({
+			stageTimeout: 1000,
+			stageTimeoutIncrease: 2000,
+		}),
+	};
+
 	beforeEach((context) => {
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Consensus.Service).toConstantValue(consensus);
+		context.sandbox.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(config);
 
 		context.scheduler = context.sandbox.app.resolve(Scheduler);
 	});
@@ -52,7 +60,7 @@ describe<{
 		timerValues.push(fakeTimers.now);
 		fakeTimers.now = 0;
 
-		void scheduler.scheduleTimeoutPropose(1, 3);
+		void scheduler.scheduleTimeoutPropose(1, 2);
 		await fakeTimers.nextAsync();
 		timerValues.push(fakeTimers.now);
 
@@ -84,7 +92,7 @@ describe<{
 		timerValues.push(fakeTimers.now);
 		fakeTimers.now = 0;
 
-		void scheduler.scheduleTimeoutPrevote(1, 3);
+		void scheduler.scheduleTimeoutPrevote(1, 2);
 		await fakeTimers.nextAsync();
 		timerValues.push(fakeTimers.now);
 
@@ -116,7 +124,7 @@ describe<{
 		timerValues.push(fakeTimers.now);
 		fakeTimers.now = 0;
 
-		void scheduler.scheduleTimeoutPrecommit(1, 3);
+		void scheduler.scheduleTimeoutPrecommit(1, 2);
 		await fakeTimers.nextAsync();
 		timerValues.push(fakeTimers.now);
 

--- a/packages/consensus/source/scheduler.ts
+++ b/packages/consensus/source/scheduler.ts
@@ -9,6 +9,9 @@ export class Scheduler implements IScheduler {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 
+	@inject(Identifiers.Cryptography.Configuration)
+	private readonly cryptoConfiguration!: Contracts.Crypto.IConfiguration;
+
 	public async scheduleTimeoutPropose(height: number, round: number): Promise<void> {
 		await this.#wait(round);
 		await this.#getConsensus().onTimeoutPropose(height, round);
@@ -25,8 +28,10 @@ export class Scheduler implements IScheduler {
 	}
 
 	async #wait(round: number) {
-		// TODO: Find a better way to calculate the delay
-		await delay((round + 1) * 1000);
+		await delay(
+			this.cryptoConfiguration.getMilestone().stageTimeout +
+				round * this.cryptoConfiguration.getMilestone().stageTimeoutIncrease,
+		);
 	}
 
 	#getConsensus(): IConsensus {

--- a/packages/contracts/source/contracts/crypto/networks.ts
+++ b/packages/contracts/source/contracts/crypto/networks.ts
@@ -47,6 +47,8 @@ export type Milestone = {
 	reward: string;
 	satoshi: MilestoneSatoshi;
 	vendorFieldLength: number;
+	stageTimeout: number;
+	stageTimeoutIncrease: number;
 };
 
 export type MilestonePartial = Partial<Milestone> & {

--- a/packages/core/bin/config/testnet/crypto.json
+++ b/packages/core/bin/config/testnet/crypto.json
@@ -2637,6 +2637,8 @@
 				"decimals": 8,
 				"denomination": 100000000
 			},
+			"stageTimeout": 2000,
+			"stageTimeoutIncrease": 2000,
 			"vendorFieldLength": 255
 		},
 		{

--- a/packages/crypto-config/source/configuration.test.ts
+++ b/packages/crypto-config/source/configuration.test.ts
@@ -46,6 +46,8 @@ describe<{
 				multiPaymentLimit: 256,
 				reward: "0",
 				satoshi: { decimals: 8, denomination: 100_000_000 },
+				stageTimeout: 2000,
+				stageTimeoutIncrease: 2000,
 				vendorFieldLength: 255,
 			},
 			{
@@ -58,6 +60,8 @@ describe<{
 				multiPaymentLimit: 256,
 				reward: "200000000",
 				satoshi: { decimals: 8, denomination: 100_000_000 },
+				stageTimeout: 2000,
+				stageTimeoutIncrease: 2000,
 				vendorFieldLength: 255,
 			},
 		]);


### PR DESCRIPTION
## Summary

Add new milestone entries:
- stageTimeout -> represent default stage timeout value
- stageTimeoutIncrease -> represent timeout increase per each round

Changes:
- add values to milestones
- fix configuration-generator
- use values in consensus `Scheduler`

## Checklist


- [x] Tests _(if necessary)_
- [x] Ready to be merged
