### PR TITLE
refactor(crypto): make block id and transactions mandatory

### DIFF
--- a/packages/contracts/source/contracts/crypto/block.ts
+++ b/packages/contracts/source/contracts/crypto/block.ts
@@ -16,7 +16,7 @@ export interface IBlock {
 }
 
 export interface IBlockData {
-	id?: string;
+	id: string;
 
 	timestamp: number;
 	version: number;
@@ -31,11 +31,11 @@ export interface IBlockData {
 	generatorPublicKey: string;
 
 	serialized?: string;
-	transactions?: ITransactionData[];
+	transactions: ITransactionData[];
 }
 
 export interface IBlockJson {
-	id?: string;
+	id: string;
 
 	timestamp: number;
 	version: number;
@@ -50,7 +50,7 @@ export interface IBlockJson {
 	generatorPublicKey: string;
 
 	serialized?: string;
-	transactions?: ITransactionJson[];
+	transactions: ITransactionJson[];
 }
 
 export interface IBlockDeserializer {
@@ -72,7 +72,7 @@ export interface IBlockFactory {
 export interface IBlockSerializer {
 	size(block: IBlock): number;
 
-	serialize(block: IBlockData, includeSignature?: boolean): Promise<Buffer>;
+	serialize(block: IBlockData): Promise<Buffer>;
 
 	serializeWithTransactions(block: IBlockData): Promise<Buffer>;
 }

--- a/packages/contracts/source/contracts/crypto/block.ts
+++ b/packages/contracts/source/contracts/crypto/block.ts
@@ -69,12 +69,14 @@ export interface IBlockFactory {
 	fromData(data: IBlockData): Promise<IBlock | undefined>;
 }
 
+export type IBlockDataSerializable = Omit<IBlockData, "id">;
+
 export interface IBlockSerializer {
 	size(block: IBlock): number;
 
-	serialize(block: IBlockData): Promise<Buffer>;
+	serialize(block: IBlockDataSerializable): Promise<Buffer>;
 
-	serializeWithTransactions(block: IBlockData): Promise<Buffer>;
+	serializeWithTransactions(block: IBlockDataSerializable): Promise<Buffer>;
 }
 
 export interface IBlockVerifier {

--- a/packages/crypto-block/source/id.factory.ts
+++ b/packages/crypto-block/source/id.factory.ts
@@ -9,7 +9,7 @@ export class IDFactory {
 	@inject(Identifiers.Cryptography.Block.Serializer)
 	private readonly serializer: Contracts.Crypto.IBlockSerializer;
 
-	public async make(data: Contracts.Crypto.IBlockData): Promise<string> {
+	public async make(data: Contracts.Crypto.IBlockDataSerializable): Promise<string> {
 		return (await this.hashFactory.sha256(await this.serializer.serialize(data))).toString("hex");
 	}
 }

--- a/packages/crypto-block/source/serializer.ts
+++ b/packages/crypto-block/source/serializer.ts
@@ -31,8 +31,8 @@ export class Serializer implements Contracts.Crypto.IBlockSerializer {
 		return size;
 	}
 
-	public async serialize(block: Contracts.Crypto.IBlockData): Promise<Buffer> {
-		return this.serializer.serialize<Contracts.Crypto.IBlockData>(block, {
+	public async serialize(block: Contracts.Crypto.IBlockDataSerializable): Promise<Buffer> {
+		return this.serializer.serialize<Contracts.Crypto.IBlockDataSerializable>(block, {
 			length: 2_000_000,
 			schema: {
 				version: {
@@ -72,8 +72,8 @@ export class Serializer implements Contracts.Crypto.IBlockSerializer {
 		});
 	}
 
-	public async serializeWithTransactions(block: Contracts.Crypto.IBlockData): Promise<Buffer> {
-		return this.serializer.serialize<Contracts.Crypto.IBlockData>(block, {
+	public async serializeWithTransactions(block: Contracts.Crypto.IBlockDataSerializable): Promise<Buffer> {
+		return this.serializer.serialize<Contracts.Crypto.IBlockDataSerializable>(block, {
 			length: 2_000_000,
 			schema: {
 				version: {
@@ -111,7 +111,6 @@ export class Serializer implements Contracts.Crypto.IBlockSerializer {
 				},
 				transactions: {
 					type: "transactions",
-					required: false, // @TODO: this should always have a default value but doesn't right now
 				},
 			},
 		});

--- a/packages/database/source/database-service.test.ts
+++ b/packages/database/source/database-service.test.ts
@@ -84,7 +84,7 @@ describe<{
 		context.sandbox.app.useDataPath(dirSync().name);
 
 		context.sandbox.app.bind(Identifiers.LogService).toConstantValue({
-			info: () => {},
+			info: () => { },
 		});
 
 		await context.sandbox.app.resolve(CoreCryptoConfig).register();
@@ -156,22 +156,6 @@ describe<{
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.BlockStorage).getKeysCount(), 1);
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.BlockHeightStorage).getKeysCount(), 1);
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.TransactionStorage).getKeysCount(), 2);
-	});
-
-	it("#saveBlocks - should fail to save block without id", async ({ databaseService }) => {
-		await assert.rejects(
-			() =>
-				databaseService.saveBlocks([
-					{
-						// @ts-ignore
-						data: {
-							height: 1,
-							id: undefined,
-						},
-					},
-				]),
-			"Failed to store block 1 because it has no ID.",
-		);
 	});
 
 	it("#getBlock - should return undefined if block doesn't exists", async ({ databaseService }) => {

--- a/packages/database/source/database-service.test.ts
+++ b/packages/database/source/database-service.test.ts
@@ -84,7 +84,7 @@ describe<{
 		context.sandbox.app.useDataPath(dirSync().name);
 
 		context.sandbox.app.bind(Identifiers.LogService).toConstantValue({
-			info: () => { },
+			info: () => {},
 		});
 
 		await context.sandbox.app.resolve(CoreCryptoConfig).register();

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -101,16 +101,10 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 
 	public async saveBlocks(blocks: Contracts.Crypto.IBlock[]): Promise<void> {
 		for (const block of blocks) {
-			const blockID: string | undefined = block.data.id;
+			if (!this.blockStorage.doesExist(block.data.id)) {
+				await this.blockStorage.put(block.data.id, Buffer.from(block.serialized, "hex"));
 
-			if (!blockID) {
-				throw new Error(`Failed to store block ${block.data.height} because it has no ID.`);
-			}
-
-			if (!this.blockStorage.doesExist(blockID)) {
-				await this.blockStorage.put(blockID, Buffer.from(block.serialized, "hex"));
-
-				await this.blockStorageById.put(block.data.height, blockID);
+				await this.blockStorageById.put(block.data.height, block.data.id);
 
 				for (const transaction of block.transactions) {
 					await this.transactionStorage.put(transaction.data.id, transaction.serialized);

--- a/packages/p2p/source/peer-verifier.ts
+++ b/packages/p2p/source/peer-verifier.ts
@@ -231,8 +231,6 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
 			const probesHeightById = {};
 
 			for (const b of ourBlocks) {
-				Utils.assert.defined<string>(b.data.id);
-
 				probesIdByHeight[b.data.height] = b.data.id;
 				probesHeightById[b.data.id] = b.data.height;
 			}

--- a/packages/processor/source/handlers/exception-handler.ts
+++ b/packages/processor/source/handlers/exception-handler.ts
@@ -1,6 +1,5 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { Utils } from "@mainsail/kernel";
 
 import { AcceptBlockHandler } from "./accept-block-handler";
 
@@ -19,8 +18,6 @@ export class ExceptionHandler implements Contracts.BlockProcessor.Handler {
 	private readonly databaseService!: Contracts.Database.IDatabaseService;
 
 	public async execute(block: Contracts.Crypto.IBlock): Promise<Contracts.BlockProcessor.ProcessorResult> {
-		Utils.assert.defined<string>(block.data.id);
-
 		const id: string = block.data.id;
 
 		// Ensure the block has not been forged yet, as an exceptional block bypasses all other checks.

--- a/packages/state/source/stores/state.ts
+++ b/packages/state/source/stores/state.ts
@@ -227,11 +227,7 @@ export class StateStore implements Contracts.State.StateStore {
 		}
 
 		return this.getLastBlocksData(true)
-			.filter((block) => {
-				Utils.assert.defined<string>(block.id);
-
-				return idsHash[block.id];
-			})
+			.filter((block) => idsHash[block.id])
 			.toArray() as Contracts.Crypto.IBlockData[];
 	}
 

--- a/packages/state/source/stores/state.ts
+++ b/packages/state/source/stores/state.ts
@@ -199,11 +199,7 @@ export class StateStore implements Contracts.State.StateStore {
 		return this.#lastBlocks
 			.valueSeq()
 			.reverse()
-			.map((b) => {
-				Utils.assert.defined<string>(b.data.id);
-
-				return b.data.id;
-			})
+			.map((b) => b.data.id)
 			.toArray();
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
The `id` and `transactions` fields of `IBlockData` and `IBlockJson` are now mandatory. Also get rid of some obsolete asserts.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
