### PR TITLE
refactor: pass WalletRepostiory instance to TransactionHandler methods

### DIFF
--- a/packages/contracts/source/contracts/transactions.ts
+++ b/packages/contracts/source/contracts/transactions.ts
@@ -1,21 +1,25 @@
 import { IMultiSignatureAsset, ITransaction, ITransactionData, TransactionConstructor } from "./crypto";
 import { EventDispatcher } from "./kernel";
-import { Wallet } from "./state";
+import { Wallet, WalletRepository } from "./state";
 
 export type TransactionHandlerConstructor = new () => ITransactionHandler;
 
 export interface ITransactionHandler {
-	verify(transaction: ITransaction): Promise<boolean>;
+	verify(walletRepository: WalletRepository, transaction: ITransaction): Promise<boolean>;
 
-	throwIfCannotBeApplied(transaction: ITransaction, sender: Wallet): Promise<void>;
+	throwIfCannotBeApplied(
+		walletRepository: WalletRepository,
+		transaction: ITransaction,
+		sender: Wallet,
+	): Promise<void>;
 
-	apply(transaction: ITransaction): Promise<void>;
+	apply(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
-	revert(transaction: ITransaction): Promise<void>;
+	revert(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
-	applyToSender(transaction: ITransaction): Promise<void>;
+	applyToSender(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
-	revertForSender(transaction: ITransaction): Promise<void>;
+	revertForSender(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
 	emitEvents(transaction: ITransaction, emitter: EventDispatcher): void;
 
@@ -36,11 +40,11 @@ export interface ITransactionHandler {
 
 	isActivated(): Promise<boolean>;
 
-	bootstrap(transactions: ITransaction[]): Promise<void>;
+	bootstrap(walletRepository: WalletRepository, transactions: ITransaction[]): Promise<void>;
 
-	applyToRecipient(transaction: ITransaction): Promise<void>;
+	applyToRecipient(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
-	revertForRecipient(transaction: ITransaction): Promise<void>;
+	revertForRecipient(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 }
 
 export interface ITransactionHandlerRegistry {

--- a/packages/contracts/source/contracts/transactions.ts
+++ b/packages/contracts/source/contracts/transactions.ts
@@ -23,7 +23,7 @@ export interface ITransactionHandler {
 
 	emitEvents(transaction: ITransaction, emitter: EventDispatcher): void;
 
-	throwIfCannotEnterPool(transaction: ITransaction): Promise<void>;
+	throwIfCannotEnterPool(walletRepository: WalletRepository, transaction: ITransaction): Promise<void>;
 
 	verifySignatures(
 		wallet: Wallet,

--- a/packages/crypto-transaction-multi-signature-registration/source/handlers/multi-signature-registration.ts
+++ b/packages/crypto-transaction-multi-signature-registration/source/handlers/multi-signature-registration.ts
@@ -93,7 +93,10 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 		return super.throwIfCannotBeApplied(walletRepository, transaction, wallet);
 	}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 		AppUtils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(transaction.data.asset?.multiSignature);
 

--- a/packages/crypto-transaction-multi-signature-registration/source/handlers/multi-signature-registration.ts
+++ b/packages/crypto-transaction-multi-signature-registration/source/handlers/multi-signature-registration.ts
@@ -30,12 +30,15 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 		return MultiSignatureRegistrationTransaction;
 	}
 
-	public async bootstrap(transactions: Contracts.Crypto.ITransaction[]): Promise<void> {
+	public async bootstrap(
+		walletRepository: Contracts.State.WalletRepository,
+		transactions: Contracts.Crypto.ITransaction[],
+	): Promise<void> {
 		for (const transaction of this.allTransactions(transactions)) {
 			AppUtils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(transaction.asset?.multiSignature);
 
 			const multiSignature: Contracts.State.WalletMultiSignatureAttributes = transaction.asset.multiSignature;
-			const wallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(
+			const wallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(
 				await this.publicKeyFactory.fromMultiSignatureAsset(multiSignature),
 			);
 
@@ -44,7 +47,7 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 			}
 
 			wallet.setAttribute("multiSignature", multiSignature);
-			this.walletRepository.index(wallet);
+			walletRepository.index(wallet);
 		}
 	}
 
@@ -53,6 +56,7 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 	}
 
 	public async throwIfCannotBeApplied(
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
 		wallet: Contracts.State.Wallet,
 	): Promise<void> {
@@ -76,7 +80,7 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 		const multiSigPublicKey: string = await this.publicKeyFactory.fromMultiSignatureAsset(
 			data.asset.multiSignature,
 		);
-		const recipientWallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(multiSigPublicKey);
+		const recipientWallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(multiSigPublicKey);
 
 		if (recipientWallet.hasMultiSignature()) {
 			throw new Exceptions.MultiSignatureAlreadyRegisteredError();
@@ -86,7 +90,7 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 			throw new Exceptions.InvalidMultiSignatureError();
 		}
 
-		return super.throwIfCannotBeApplied(transaction, wallet);
+		return super.throwIfCannotBeApplied(walletRepository, transaction, wallet);
 	}
 
 	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
@@ -123,34 +127,46 @@ export class MultiSignatureRegistrationTransactionHandler extends Handlers.Trans
 		}
 	}
 
-	public async applyToSender(transaction: Contracts.Crypto.ITransaction): Promise<void> {
-		await super.applyToSender(transaction);
+	public async applyToSender(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
+		await super.applyToSender(walletRepository, transaction);
 	}
 
-	public async revertForSender(transaction: Contracts.Crypto.ITransaction): Promise<void> {
-		await super.revertForSender(transaction);
+	public async revertForSender(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
+		await super.revertForSender(walletRepository, transaction);
 		// Nothing else to do for the sender since the recipient wallet
 		// is made into a multi sig wallet.
 	}
 
-	public async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async applyToRecipient(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		const { data }: Contracts.Crypto.ITransaction = transaction;
 
 		AppUtils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(data.asset?.multiSignature);
 
-		const recipientWallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(
+		const recipientWallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(
 			await this.publicKeyFactory.fromMultiSignatureAsset(data.asset.multiSignature),
 		);
 
 		recipientWallet.setAttribute("multiSignature", data.asset.multiSignature);
 	}
 
-	public async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async revertForRecipient(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		const { data }: Contracts.Crypto.ITransaction = transaction;
 
 		AppUtils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(data.asset?.multiSignature);
 
-		const recipientWallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(
+		const recipientWallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(
 			await this.publicKeyFactory.fromMultiSignatureAsset(data.asset.multiSignature),
 		);
 

--- a/packages/crypto-transaction-transfer/source/handlers/transfer.ts
+++ b/packages/crypto-transaction-transfer/source/handlers/transfer.ts
@@ -49,7 +49,10 @@ export class TransferTransactionHandler extends Handlers.TransactionHandler {
 		return true;
 	}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		Utils.assert.defined<string>(transaction.data.recipientId);
 		const recipientId: string = transaction.data.recipientId;
 

--- a/packages/crypto-transaction-transfer/source/handlers/transfer.ts
+++ b/packages/crypto-transaction-transfer/source/handlers/transfer.ts
@@ -24,11 +24,12 @@ export class TransferTransactionHandler extends Handlers.TransactionHandler {
 		return TransferTransaction;
 	}
 
-	public async bootstrap(transactions: Contracts.Crypto.ITransaction[]): Promise<void> {
+	public async bootstrap(
+		walletRepository: Contracts.State.WalletRepository,
+		transactions: Contracts.Crypto.ITransaction[],
+	): Promise<void> {
 		for (const transaction of this.allTransactions(transactions)) {
-			this.walletRepository
-				.findByAddress(transaction.recipientId)
-				.increaseBalance(BigNumber.make(transaction.amount));
+			walletRepository.findByAddress(transaction.recipientId).increaseBalance(BigNumber.make(transaction.amount));
 		}
 	}
 
@@ -37,10 +38,11 @@ export class TransferTransactionHandler extends Handlers.TransactionHandler {
 	}
 
 	public async throwIfCannotBeApplied(
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
 		sender: Contracts.State.Wallet,
 	): Promise<void> {
-		return super.throwIfCannotBeApplied(transaction, sender);
+		return super.throwIfCannotBeApplied(walletRepository, transaction, sender);
 	}
 
 	public hasVendorField(): boolean {
@@ -59,18 +61,24 @@ export class TransferTransactionHandler extends Handlers.TransactionHandler {
 		}
 	}
 
-	public async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async applyToRecipient(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		Utils.assert.defined<string>(transaction.data.recipientId);
 
-		const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.recipientId);
+		const recipient: Contracts.State.Wallet = walletRepository.findByAddress(transaction.data.recipientId);
 
 		recipient.increaseBalance(transaction.data.amount);
 	}
 
-	public async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async revertForRecipient(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		Utils.assert.defined<string>(transaction.data.recipientId);
 
-		const recipient: Contracts.State.Wallet = this.walletRepository.findByAddress(transaction.data.recipientId);
+		const recipient: Contracts.State.Wallet = walletRepository.findByAddress(transaction.data.recipientId);
 
 		recipient.decreaseBalance(transaction.data.amount);
 	}

--- a/packages/crypto-transaction-validator-registration/source/handlers/validator-registration.ts
+++ b/packages/crypto-transaction-validator-registration/source/handlers/validator-registration.ts
@@ -83,7 +83,10 @@ export class ValidatorRegistrationTransactionHandler extends Handlers.Transactio
 		emitter.dispatch(AppEnums.ValidatorEvent.Registered, transaction.data);
 	}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
 		const hasSender: boolean = await this.poolQuery

--- a/packages/crypto-transaction-validator-resignation/source/handlers/validator-resignation.ts
+++ b/packages/crypto-transaction-validator-resignation/source/handlers/validator-resignation.ts
@@ -24,15 +24,16 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 		return ValidatorResignationTransaction;
 	}
 
-	public async bootstrap(transactions: Contracts.Crypto.ITransaction[]): Promise<void> {
+	public async bootstrap(
+		walletRepository: Contracts.State.WalletRepository,
+		transactions: Contracts.Crypto.ITransaction[],
+	): Promise<void> {
 		for (const transaction of this.allTransactions(transactions)) {
 			AppUtils.assert.defined<string>(transaction.senderPublicKey);
 
-			const wallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(
-				transaction.senderPublicKey,
-			);
+			const wallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(transaction.senderPublicKey);
 			wallet.setAttribute("validator.resigned", true);
-			this.walletRepository.index(wallet);
+			walletRepository.index(wallet);
 		}
 	}
 	public async isActivated(): Promise<boolean> {
@@ -40,6 +41,7 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 	}
 
 	public async throwIfCannotBeApplied(
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
 		wallet: Contracts.State.Wallet,
 	): Promise<void> {
@@ -52,7 +54,7 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 		}
 
 		const requiredValidatorsCount: number = this.configuration.getMilestone().activeValidators;
-		const currentValidatorsCount: number = this.walletRepository
+		const currentValidatorsCount: number = walletRepository
 			.allByUsername()
 			.filter((w) => w.hasAttribute("validator.resigned") === false).length;
 
@@ -60,7 +62,7 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 			throw new Exceptions.NotEnoughValidatorsError();
 		}
 
-		return super.throwIfCannotBeApplied(transaction, wallet);
+		return super.throwIfCannotBeApplied(walletRepository, transaction, wallet);
 	}
 
 	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {
@@ -87,36 +89,44 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 		}
 	}
 
-	public async applyToSender(transaction: Contracts.Crypto.ITransaction): Promise<void> {
-		await super.applyToSender(transaction);
+	public async applyToSender(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
+		await super.applyToSender(walletRepository, transaction);
 
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-		const senderWallet = await this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+		const senderWallet = await walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
 		senderWallet.setAttribute("validator.resigned", true);
 
-		this.walletRepository.index(senderWallet);
+		walletRepository.index(senderWallet);
 	}
 
-	public async revertForSender(transaction: Contracts.Crypto.ITransaction): Promise<void> {
-		await super.revertForSender(transaction);
+	public async revertForSender(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
+		await super.revertForSender(walletRepository, transaction);
 
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
-		const senderWallet = await this.walletRepository.findByPublicKey(transaction.data.senderPublicKey);
+		const senderWallet = await walletRepository.findByPublicKey(transaction.data.senderPublicKey);
 
 		senderWallet.forgetAttribute("validator.resigned");
 
-		this.walletRepository.index(senderWallet);
+		walletRepository.index(senderWallet);
 	}
 
 	public async applyToRecipient(
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
 		// tslint:disable-next-line: no-empty
 	): Promise<void> {}
 
 	public async revertForRecipient(
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
 		// tslint:disable-next-line: no-empty
 	): Promise<void> {}

--- a/packages/crypto-transaction-validator-resignation/source/handlers/validator-resignation.ts
+++ b/packages/crypto-transaction-validator-resignation/source/handlers/validator-resignation.ts
@@ -70,7 +70,10 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 		emitter.dispatch(AppEnums.ValidatorEvent.Resigned, transaction.data);
 	}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
 		const hasSender: boolean = await this.poolQuery
@@ -79,7 +82,7 @@ export class ValidatorResignationTransactionHandler extends Handlers.Transaction
 			.has();
 
 		if (hasSender) {
-			const wallet: Contracts.State.Wallet = await this.walletRepository.findByPublicKey(
+			const wallet: Contracts.State.Wallet = await walletRepository.findByPublicKey(
 				transaction.data.senderPublicKey,
 			);
 			throw new Exceptions.PoolError(

--- a/packages/crypto-transaction-vote/source/handlers/vote.test.ts
+++ b/packages/crypto-transaction-vote/source/handlers/vote.test.ts
@@ -110,7 +110,9 @@ describe<{
 
 		const transactions = [getTransaction(["validatorPublicKey"], [])];
 
-		await assert.resolves(() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]));
+		await assert.resolves(() =>
+			handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
+		);
 
 		spyHasAttribute.calledOnce();
 		spyHasAttribute.calledWith("vote");
@@ -126,7 +128,7 @@ describe<{
 		const transactions = [getTransaction(["validatorPublicKey"], [])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.AlreadyVotedError,
 		);
 
@@ -145,7 +147,9 @@ describe<{
 
 		const transactions = [getTransaction([], ["validatorPublicKey"])];
 
-		await assert.resolves(() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]));
+		await assert.resolves(() =>
+			handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
+		);
 
 		spyHasAttribute.calledOnce();
 		spyHasAttribute.calledWith("vote");
@@ -165,7 +169,7 @@ describe<{
 		const transactions = [getTransaction([], ["validatorPublicKey"])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.NoVoteError,
 		);
 
@@ -185,7 +189,7 @@ describe<{
 		const transactions = [getTransaction([], ["validatorPublicKey"])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.UnvoteMismatchError,
 		);
 
@@ -198,11 +202,14 @@ describe<{
 		spySetAttribute.neverCalled();
 	});
 
-	it("#bootstrap -  shoudl throw if transaction contains 0 votes and unvotes", async ({ handler }) => {
+	it("#bootstrap -  shoudl throw if transaction contains 0 votes and unvotes", async ({
+		handler,
+		walletRepository,
+	}) => {
 		const transactions = [getTransaction([], [])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.EmptyVoteError,
 		);
 
@@ -210,11 +217,11 @@ describe<{
 		spySetAttribute.neverCalled();
 	});
 
-	it("#bootstrap -  shoudl throw on max votes exceeded", async ({ handler }) => {
+	it("#bootstrap -  shoudl throw on max votes exceeded", async ({ handler, walletRepository }) => {
 		const transactions = [getTransaction(["validatorPublicKey", "secondValidatorPublicKey"], [])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.MaxVotesExceeededError,
 		);
 
@@ -222,11 +229,11 @@ describe<{
 		spySetAttribute.neverCalled();
 	});
 
-	it("#bootstrap -  shoudl throw on max unotes exceeded", async ({ handler }) => {
+	it("#bootstrap -  shoudl throw on max unotes exceeded", async ({ handler, walletRepository }) => {
 		const transactions = [getTransaction([], ["validatorPublicKey", "secondValidatorPublicKey"])];
 
 		await assert.rejects(
-			() => handler.bootstrap(transactions as Contracts.Crypto.ITransaction[]),
+			() => handler.bootstrap(walletRepository, transactions as Contracts.Crypto.ITransaction[]),
 			Exceptions.MaxUnvotesExceeededError,
 		);
 
@@ -243,6 +250,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.throwIfCannotBeApplied(
+				walletRepository,
 				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
 				wallet as Contracts.State.Wallet,
 			),
@@ -263,6 +271,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -284,6 +293,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -304,6 +314,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -325,6 +336,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.throwIfCannotBeApplied(
+				walletRepository,
 				getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 				wallet as Contracts.State.Wallet,
 			),
@@ -349,6 +361,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.throwIfCannotBeApplied(
+				walletRepository,
 				getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 				wallet as Contracts.State.Wallet,
 			),
@@ -368,6 +381,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -387,6 +401,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -408,6 +423,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -429,6 +445,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.throwIfCannotBeApplied(
+				walletRepository,
 				getTransaction(["secondValidatorPublicKey"], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
 				wallet as Contracts.State.Wallet,
 			),
@@ -446,6 +463,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction([], []) as Contracts.Crypto.ITransaction,
 					wallet as Contracts.State.Wallet,
 				),
@@ -461,6 +479,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction(
 						["ValidatorPublicKey", "secondValidatorPublicKey"],
 						[],
@@ -479,6 +498,7 @@ describe<{
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotBeApplied(
+					walletRepository,
 					getTransaction(
 						[],
 						["ValidatorPublicKey", "secondValidatorPublicKey"],
@@ -541,22 +561,26 @@ describe<{
 		});
 	});
 
-	it("throwIfCannotEnterPool - should pass", async ({ handler, poolQuery }) => {
+	it("throwIfCannotEnterPool - should pass", async ({ handler, poolQuery, walletRepository }) => {
 		const spyHas = stub(poolQuery, "has").returnValue(false);
 
 		await assert.resolves(() =>
-			handler.throwIfCannotEnterPool(getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction),
+			handler.throwIfCannotEnterPool(
+				walletRepository,
+				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
+			),
 		);
 
 		spyHas.calledOnce();
 	});
 
-	it("throwIfCannotEnterPool - should throw", async ({ handler, poolQuery }) => {
+	it("throwIfCannotEnterPool - should throw", async ({ handler, poolQuery, walletRepository }) => {
 		const spyHas = stub(poolQuery, "has").returnValue(true);
 
 		await assert.rejects(
 			() =>
 				handler.throwIfCannotEnterPool(
+					walletRepository,
 					getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
 				),
 			Exceptions.PoolError,
@@ -570,7 +594,10 @@ describe<{
 		const spySuper = stub(Handlers.TransactionHandler.prototype, "applyToSender");
 
 		await assert.resolves(() =>
-			handler.applyToSender(getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction),
+			handler.applyToSender(
+				walletRepository,
+				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
+			),
 		);
 
 		spySuper.calledOnce();
@@ -583,7 +610,10 @@ describe<{
 		const spySuper = stub(Handlers.TransactionHandler.prototype, "applyToSender");
 
 		await assert.resolves(() =>
-			handler.applyToSender(getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction),
+			handler.applyToSender(
+				walletRepository,
+				getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
+			),
 		);
 
 		spySuper.calledOnce();
@@ -597,6 +627,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.applyToSender(
+				walletRepository,
 				getTransaction(["validatorPublicKey"], ["secondValidatorPublicKey"]) as Contracts.Crypto.ITransaction,
 			),
 		);
@@ -612,7 +643,10 @@ describe<{
 		const spySuper = stub(Handlers.TransactionHandler.prototype, "revertForSender");
 
 		await assert.resolves(() =>
-			handler.revertForSender(getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction),
+			handler.revertForSender(
+				walletRepository,
+				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
+			),
 		);
 
 		spySuper.calledOnce();
@@ -625,7 +659,10 @@ describe<{
 		const spySuper = stub(Handlers.TransactionHandler.prototype, "revertForSender");
 
 		await assert.resolves(() =>
-			handler.revertForSender(getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction),
+			handler.revertForSender(
+				walletRepository,
+				getTransaction([], ["validatorPublicKey"]) as Contracts.Crypto.ITransaction,
+			),
 		);
 
 		spySuper.calledOnce();
@@ -642,6 +679,7 @@ describe<{
 
 		await assert.resolves(() =>
 			handler.revertForSender(
+				walletRepository,
 				getTransaction(["validatorPublicKey"], ["secondValidatorPublicKey"]) as Contracts.Crypto.ITransaction,
 			),
 		);
@@ -652,15 +690,21 @@ describe<{
 		spySetAttribute.calledWith("vote", "secondValidatorPublicKey");
 	});
 
-	it("applyToRecipient - should pass", async ({ handler }) => {
+	it("applyToRecipient - should pass", async ({ handler, walletRepository }) => {
 		await assert.resolves(() =>
-			handler.applyToRecipient(getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction),
+			handler.applyToRecipient(
+				walletRepository,
+				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
+			),
 		);
 	});
 
-	it("revertForRecipient - should pass", async ({ handler }) => {
+	it("revertForRecipient - should pass", async ({ handler, walletRepository }) => {
 		await assert.resolves(() =>
-			handler.revertForRecipient(getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction),
+			handler.revertForRecipient(
+				walletRepository,
+				getTransaction(["validatorPublicKey"], []) as Contracts.Crypto.ITransaction,
+			),
 		);
 	});
 });

--- a/packages/crypto-transaction-vote/source/handlers/vote.ts
+++ b/packages/crypto-transaction-vote/source/handlers/vote.ts
@@ -136,7 +136,10 @@ export class VoteTransactionHandler extends Handlers.TransactionHandler {
 		}
 	}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {
 		Utils.assert.defined<string>(transaction.data.senderPublicKey);
 
 		const hasSender: boolean = await this.poolQuery

--- a/packages/fees-burn/source/mutator.ts
+++ b/packages/fees-burn/source/mutator.ts
@@ -6,6 +6,7 @@ import { BigNumber } from "@mainsail/utils";
 @injectable()
 export class BurnFeeMutator implements Contracts.State.ValidatorMutator {
 	@inject(Identifiers.WalletRepository)
+	@tagged("state", "blockchain")
 	private readonly walletRepository: Contracts.State.WalletRepository;
 
 	@inject(Identifiers.PluginConfiguration)

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -92,7 +92,7 @@ export class BlockProcessor implements Contracts.BlockProcessor.Processor {
 						"blockchain",
 					);
 					const handler = await registry.getActivatedHandlerForData(transaction.data);
-					await handler.verify(transaction);
+					await handler.verify(this.walletRepository, transaction);
 				}
 
 				// @TODO: check if we can remove this duplicate verification

--- a/packages/state/source/block-state.ts
+++ b/packages/state/source/block-state.ts
@@ -63,7 +63,7 @@ export class BlockState implements Contracts.State.BlockState {
 	public async applyTransaction(transaction: Contracts.Crypto.ITransaction): Promise<void> {
 		const transactionHandler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-		await transactionHandler.apply(transaction);
+		await transactionHandler.apply(this.walletRepository, transaction);
 
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 
@@ -98,7 +98,7 @@ export class BlockState implements Contracts.State.BlockState {
 			recipient = this.walletRepository.findByAddress(transaction.data.recipientId);
 		}
 
-		await transactionHandler.revert(transaction);
+		await transactionHandler.revert(this.walletRepository, transaction);
 
 		// @ts-ignore - Revert vote balance updates
 		await this.#revertVoteBalances(sender, recipient, data);

--- a/packages/state/source/block-state.ts
+++ b/packages/state/source/block-state.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, multiInject } from "@mainsail/container";
+import { inject, injectable, multiInject, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Utils as AppUtils } from "@mainsail/kernel";
 import { BigNumber } from "@mainsail/utils";
@@ -10,6 +10,7 @@ export class BlockState implements Contracts.State.BlockState {
 	public readonly app: Contracts.Kernel.Application;
 
 	@inject(Identifiers.WalletRepository)
+	@tagged("state", "blockchain")
 	private readonly walletRepository: Contracts.State.WalletRepository;
 
 	@inject(Identifiers.TransactionHandlerRegistry)

--- a/packages/state/source/database-interactions.ts
+++ b/packages/state/source/database-interactions.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, tagged } from "@mainsail/container";
+import { inject, injectable } from "@mainsail/container";
 import { Constants, Contracts, Identifiers } from "@mainsail/contracts";
 import { Enums } from "@mainsail/kernel";
 
@@ -19,7 +19,6 @@ export class DatabaseInteraction {
 	private readonly stateStore!: Contracts.State.StateStore;
 
 	@inject(Identifiers.TransactionHandlerRegistry)
-	@tagged("state", "blockchain")
 	private handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
 
 	@inject(Identifiers.EventDispatcherService)

--- a/packages/state/source/database-interactions.ts
+++ b/packages/state/source/database-interactions.ts
@@ -13,7 +13,6 @@ export class DatabaseInteraction {
 	private readonly databaseService: Contracts.Database.IDatabaseService;
 
 	@inject(Identifiers.BlockState)
-	@tagged("state", "blockchain")
 	private readonly blockState!: Contracts.State.BlockState;
 
 	@inject(Identifiers.StateStore)

--- a/packages/state/source/mutators/balance.ts
+++ b/packages/state/source/mutators/balance.ts
@@ -1,10 +1,11 @@
-import { inject, injectable } from "@mainsail/container";
+import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { BigNumber } from "@mainsail/utils";
 
 @injectable()
 export class BalanceMutator implements Contracts.State.ValidatorMutator {
 	@inject(Identifiers.WalletRepository)
+	@tagged("state", "blockchain")
 	private readonly walletRepository: Contracts.State.WalletRepository;
 
 	public async apply(wallet: Contracts.State.Wallet, block: Contracts.Crypto.IBlockData): Promise<void> {

--- a/packages/state/source/state-builder.ts
+++ b/packages/state/source/state-builder.ts
@@ -54,7 +54,7 @@ export class StateBuilder {
 				await this.#buildSentTransactions(transactions);
 
 				for (const handler of registeredHandlers.values()) {
-					await handler.bootstrap(transactions);
+					await handler.bootstrap(this.walletRepository, transactions);
 				}
 			}
 

--- a/packages/state/source/transaction-validator.ts
+++ b/packages/state/source/transaction-validator.ts
@@ -5,7 +5,6 @@ import { strictEqual } from "assert";
 @injectable()
 export class TransactionValidator implements Contracts.State.TransactionValidator {
 	@inject(Identifiers.TransactionHandlerRegistry)
-	@tagged("state", "clone")
 	private readonly handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
 
 	// TODO: provide walletRepository

--- a/packages/state/source/transaction-validator.ts
+++ b/packages/state/source/transaction-validator.ts
@@ -8,6 +8,11 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
 	@tagged("state", "clone")
 	private readonly handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
 
+	// TODO: provide walletRepository
+	@inject(Identifiers.WalletRepository)
+	@tagged("state", "blockchain")
+	private walletRepository!: Contracts.State.WalletRepository;
+
 	@inject(Identifiers.Cryptography.Transaction.Factory)
 	private readonly transactionFactory: Contracts.Crypto.ITransactionFactory;
 
@@ -17,6 +22,6 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
 		);
 		strictEqual(transaction.id, deserialized.id);
 		const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
-		await handler.apply(transaction);
+		await handler.apply(this.walletRepository, transaction);
 	}
 }

--- a/packages/state/source/transaction-validator.ts
+++ b/packages/state/source/transaction-validator.ts
@@ -7,7 +7,6 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
 	@inject(Identifiers.TransactionHandlerRegistry)
 	private readonly handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
 
-	// TODO: provide walletRepository
 	@inject(Identifiers.WalletRepository)
 	@tagged("state", "blockchain")
 	private walletRepository!: Contracts.State.WalletRepository;

--- a/packages/state/test/setup.ts
+++ b/packages/state/test/setup.ts
@@ -293,7 +293,7 @@ export const setUp = async (setUpOptions = setUpDefaults, skipBoot = false): Pro
 
 	sandbox.app.bind(Identifiers.State.ValidatorMutator).to(MockValidatorMutator).inSingletonScope();
 
-	const blockState = sandbox.app.getTagged<BlockState>(Identifiers.BlockState, "state", "blockchain");
+	const blockState = sandbox.app.get<BlockState>(Identifiers.BlockState);
 
 	const dPosState = sandbox.app.getTagged<DposState>(Identifiers.DposState, "state", "blockchain");
 

--- a/packages/transaction-pool/source/actions/apply-transaction.ts
+++ b/packages/transaction-pool/source/actions/apply-transaction.ts
@@ -5,7 +5,8 @@ export class ApplyTransactionAction extends Services.Triggers.Action {
 	public async execute(arguments_: Types.ActionArguments): Promise<void> {
 		const handler: Contracts.Transactions.ITransactionHandler = arguments_.handler;
 		const transaction: Contracts.Crypto.ITransaction = arguments_.transaction;
+		const walletRepository: Contracts.State.WalletRepository = arguments_.walletRepository;
 
-		return handler.apply(transaction);
+		return handler.apply(walletRepository, transaction);
 	}
 }

--- a/packages/transaction-pool/source/actions/revert-transaction.ts
+++ b/packages/transaction-pool/source/actions/revert-transaction.ts
@@ -5,7 +5,8 @@ export class RevertTransactionAction extends Services.Triggers.Action {
 	public async execute(arguments_: Types.ActionArguments): Promise<void> {
 		const handler: Contracts.Transactions.ITransactionHandler = arguments_.handler;
 		const transaction: Contracts.Crypto.ITransaction = arguments_.transaction;
+		const walletRepository: Contracts.State.WalletRepository = arguments_.walletRepository;
 
-		return handler.revert(transaction);
+		return handler.revert(walletRepository, transaction);
 	}
 }

--- a/packages/transaction-pool/source/actions/throw-if-cannot-enter-pool.ts
+++ b/packages/transaction-pool/source/actions/throw-if-cannot-enter-pool.ts
@@ -5,7 +5,8 @@ export class ThrowIfCannotEnterPoolAction extends Services.Triggers.Action {
 	public async execute(arguments_: Types.ActionArguments): Promise<void> {
 		const handler: Contracts.Transactions.ITransactionHandler = arguments_.handler;
 		const transaction: Contracts.Crypto.ITransaction = arguments_.transaction;
+		const walletRepository: Contracts.State.WalletRepository = arguments_.walletRepository;
 
-		return handler.throwIfCannotEnterPool(transaction);
+		return handler.throwIfCannotEnterPool(walletRepository, transaction);
 	}
 }

--- a/packages/transaction-pool/source/actions/verify-transaction.ts
+++ b/packages/transaction-pool/source/actions/verify-transaction.ts
@@ -5,7 +5,8 @@ export class VerifyTransactionAction extends Services.Triggers.Action {
 	public async execute(arguments_: Types.ActionArguments): Promise<boolean> {
 		const handler: Contracts.Transactions.ITransactionHandler = arguments_.handler;
 		const transaction: Contracts.Crypto.ITransaction = arguments_.transaction;
+		const walletRepository: Contracts.State.WalletRepository = arguments_.walletRepository;
 
-		return handler.verify(transaction);
+		return handler.verify(walletRepository, transaction);
 	}
 }

--- a/packages/transaction-pool/source/sender-state.test.ts
+++ b/packages/transaction-pool/source/sender-state.test.ts
@@ -18,6 +18,7 @@ describe<{
 	transaction: Contracts.Crypto.ITransaction;
 	config: Configuration;
 	slots: Slots;
+	walletRepository: any;
 }>("SenderState", ({ it, assert, beforeAll, stub, spy }) => {
 	beforeAll((context) => {
 		context.configuration = {
@@ -39,12 +40,15 @@ describe<{
 			dispatch: () => {},
 		};
 
+		context.walletRepository = {};
+
 		context.container = new Container();
 		context.container.bind(Identifiers.PluginConfiguration).toConstantValue(context.configuration);
 		context.container.bind(Identifiers.TransactionHandlerRegistry).toConstantValue(context.handlerRegistry);
 		context.container.bind(Identifiers.TransactionPoolExpirationService).toConstantValue(context.expirationService);
 		context.container.bind(Identifiers.TriggerService).toConstantValue(context.triggers);
 		context.container.bind(Identifiers.EventDispatcherService).toConstantValue(context.emitter);
+		context.container.bind(Identifiers.WalletRepository).toConstantValue(context.walletRepository);
 		context.container.bind(Identifiers.Cryptography.Configuration).to(Configuration).inSingletonScope();
 		context.container
 			.bind(Identifiers.Cryptography.Time.BlockTimeCalculator)
@@ -165,7 +169,11 @@ describe<{
 		});
 
 		handlerStub.calledWith(context.transaction.data);
-		triggersStub.calledWith("verifyTransaction", { handler, transaction: context.transaction });
+		triggersStub.calledWith("verifyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 	});
 
 	it("apply - should throw when state is corrupted", async (context) => {
@@ -198,10 +206,18 @@ describe<{
 		});
 
 		handlerStub.calledNthWith(0, context.transaction.data);
-		triggerStub.calledNthWith(0, "revertTransaction", { handler, transaction: context.transaction });
+		triggerStub.calledNthWith(0, "revertTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 
 		handlerStub.calledNthWith(1, context.transaction.data);
-		triggerStub.calledNthWith(1, "verifyTransaction", { handler, transaction: context.transaction });
+		triggerStub.calledNthWith(1, "verifyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 	});
 
 	it("apply - should throw when transaction fails to apply", async (context) => {
@@ -229,9 +245,21 @@ describe<{
 		});
 
 		handlerStub.calledWith(context.transaction.data);
-		triggerStub.calledNthWith(0, "verifyTransaction", { handler, transaction: context.transaction });
-		triggerStub.calledNthWith(1, "throwIfCannotEnterPool", { handler, transaction: context.transaction });
-		triggerStub.calledNthWith(2, "applyTransaction", { handler, transaction: context.transaction });
+		triggerStub.calledNthWith(0, "verifyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
+		triggerStub.calledNthWith(1, "throwIfCannotEnterPool", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
+		triggerStub.calledNthWith(2, "applyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 	});
 
 	it("apply - should call handler to apply transaction", async (context) => {
@@ -252,9 +280,21 @@ describe<{
 		await senderState.apply(context.transaction);
 
 		handlerStub.calledWith(context.transaction.data);
-		triggerStub.calledNthWith(0, "verifyTransaction", { handler, transaction: context.transaction });
-		triggerStub.calledNthWith(1, "throwIfCannotEnterPool", { handler, transaction: context.transaction });
-		triggerStub.calledNthWith(2, "applyTransaction", { handler, transaction: context.transaction });
+		triggerStub.calledNthWith(0, "verifyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
+		triggerStub.calledNthWith(1, "throwIfCannotEnterPool", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
+		triggerStub.calledNthWith(2, "applyTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 	});
 
 	it("revert - should call handler to revert transaction", async (context) => {
@@ -267,6 +307,10 @@ describe<{
 		await senderState.revert(context.transaction);
 
 		handlerStub.calledWith(context.transaction.data);
-		triggerStub.calledWith("revertTransaction", { handler, transaction: context.transaction });
+		triggerStub.calledWith("revertTransaction", {
+			handler,
+			transaction: context.transaction,
+			walletRepository: context.walletRepository,
+		});
 	});
 });

--- a/packages/transaction-pool/source/sender-state.ts
+++ b/packages/transaction-pool/source/sender-state.ts
@@ -8,9 +8,7 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 	@tagged("plugin", "transaction-pool")
 	private readonly configuration!: Providers.PluginConfiguration;
 
-	// TODO: Remove tagged TransactionHandlerRegistry
 	@inject(Identifiers.TransactionHandlerRegistry)
-	@tagged("state", "copy-on-write")
 	private readonly handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
 
 	@inject(Identifiers.WalletRepository)

--- a/packages/transaction-pool/source/sender-state.ts
+++ b/packages/transaction-pool/source/sender-state.ts
@@ -8,9 +8,14 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 	@tagged("plugin", "transaction-pool")
 	private readonly configuration!: Providers.PluginConfiguration;
 
+	// TODO: Remove tagged TransactionHandlerRegistry
 	@inject(Identifiers.TransactionHandlerRegistry)
 	@tagged("state", "copy-on-write")
 	private readonly handlerRegistry!: Contracts.Transactions.ITransactionHandlerRegistry;
+
+	@inject(Identifiers.WalletRepository)
+	@tagged("state", "copy-on-write")
+	private walletRepository!: Contracts.State.WalletRepository;
 
 	@inject(Identifiers.TransactionPoolExpirationService)
 	private readonly expirationService!: Contracts.TransactionPool.ExpirationService;
@@ -46,14 +51,28 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 		const handler: Contracts.Transactions.ITransactionHandler =
 			await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-		if (await this.triggers.call("verifyTransaction", { handler, transaction })) {
+		if (
+			await this.triggers.call("verifyTransaction", {
+				handler,
+				transaction,
+				walletRepository: this.walletRepository,
+			})
+		) {
 			if (this.#corrupt) {
 				throw new Exceptions.RetryTransactionError(transaction);
 			}
 
 			try {
-				await this.triggers.call("throwIfCannotEnterPool", { handler, transaction });
-				await this.triggers.call("applyTransaction", { handler, transaction });
+				await this.triggers.call("throwIfCannotEnterPool", {
+					handler,
+					transaction,
+					walletRepository: this.walletRepository,
+				});
+				await this.triggers.call("applyTransaction", {
+					handler,
+					transaction,
+					walletRepository: this.walletRepository,
+				});
 			} catch (error) {
 				throw new Exceptions.TransactionFailedToApplyError(transaction, error);
 			}
@@ -67,7 +86,11 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 			const handler: Contracts.Transactions.ITransactionHandler =
 				await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
 
-			await this.triggers.call("revertTransaction", { handler, transaction });
+			await this.triggers.call("revertTransaction", {
+				handler,
+				transaction,
+				walletRepository: this.walletRepository,
+			});
 		} catch (error) {
 			this.#corrupt = true;
 			throw error;

--- a/packages/transactions/source/handlers/transaction.ts
+++ b/packages/transactions/source/handlers/transaction.ts
@@ -153,7 +153,10 @@ export abstract class TransactionHandler implements Contracts.Transactions.ITran
 
 	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {}
 
-	public async throwIfCannotEnterPool(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	public async throwIfCannotEnterPool(
+		walletRepository: Contracts.State.WalletRepository,
+		transaction: Contracts.Crypto.ITransaction,
+	): Promise<void> {}
 
 	public async verifySignatures(
 		wallet: Contracts.State.Wallet,

--- a/packages/transactions/source/handlers/transaction.ts
+++ b/packages/transactions/source/handlers/transaction.ts
@@ -5,7 +5,7 @@ import { BigNumber } from "@mainsail/utils";
 
 // @TODO revisit the implementation, container usage and arguments after database rework
 @injectable()
-export abstract class TransactionHandler {
+export abstract class TransactionHandler implements Contracts.Transactions.ITransactionHandler {
 	@inject(Identifiers.Application)
 	protected readonly app!: Contracts.Kernel.Application;
 
@@ -196,7 +196,10 @@ export abstract class TransactionHandler {
 
 	public abstract isActivated(): Promise<boolean>;
 
-	public abstract bootstrap(transactions: Contracts.Crypto.ITransaction[]): Promise<void>;
+	public abstract bootstrap(
+		walletRepository: Contracts.State.WalletRepository,
+		transactions: Contracts.Crypto.ITransaction[],
+	): Promise<void>;
 
 	public abstract applyToRecipient(
 		walletRepository: Contracts.State.WalletRepository,


### PR DESCRIPTION
## Summary

 Pass WalletRepostiory instance directly to TransactionHandler methods.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
