### PR TITLE
refactor(consensus): use `RoundState` as block, walletRespository and processor result holder

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
+import { Utils } from "@mainsail/kernel";
 import delay from "delay";
 
 import { IBroadcaster, IHandler, IScheduler } from "./types";
@@ -86,10 +87,13 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		}
 	}
 
-	public async onProposal(proposal: Contracts.Crypto.IProposal): Promise<void> {
+	public async onProposal(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		if (this.#step !== Step.propose) {
 			return;
 		}
+
+		const proposal = roundState.getProposal();
+		Utils.assert.defined(proposal);
 
 		this.logger.info(`Received proposal for ${this.#height}/${this.#round}`);
 
@@ -104,10 +108,13 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		}
 	}
 
-	public async onMajorityPrevote(proposal: Contracts.Crypto.IProposal): Promise<void> {
+	public async onMajorityPrevote(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		if (this.#step !== Step.prevote) {
 			return;
 		}
+
+		const proposal = roundState.getProposal();
+		Utils.assert.defined(proposal);
 
 		this.logger.info(`Received +2/3 prevotes for ${this.#height}/${this.#round}`);
 
@@ -122,10 +129,13 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		}
 	}
 
-	public async onMajorityPrecommit(proposal: Contracts.Crypto.IProposal): Promise<void> {
+	public async onMajorityPrecommit(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		if (this.#step !== Step.precommit) {
 			return;
 		}
+
+		const proposal = roundState.getProposal();
+		Utils.assert.defined(proposal);
 
 		this.logger.info(`Received +2/3 precommits for ${this.#height}/${this.#round}`);
 

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -31,7 +31,7 @@ export class Handler implements IHandler {
 		const roundState = this.roundStateRepo.getRoundState(data.height, data.round);
 		roundState.setProposal(proposal);
 
-		await this.#getConsensus().onProposal(proposal);
+		await this.#getConsensus().onProposal(roundState);
 	}
 
 	async onPrevote(prevote: Contracts.Crypto.IPrevote): Promise<void> {
@@ -78,11 +78,11 @@ export class Handler implements IHandler {
 		const consensus = this.#getConsensus();
 
 		if (roundState.hasMajorityPrevotes()) {
-			await consensus.onMajorityPrevote(proposal);
+			await consensus.onMajorityPrevote(roundState);
 		}
 
 		if (roundState.hasMajorityPrecommits()) {
-			await consensus.onMajorityPrecommit(proposal);
+			await consensus.onMajorityPrecommit(roundState);
 		}
 	}
 

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -8,6 +8,10 @@ export class RoundState {
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration: Contracts.Crypto.IConfiguration;
 
+	@inject(Identifiers.WalletRepository)
+	@tagged("state", "clone")
+	private readonly walletRepository!: Contracts.State.WalletRepository;
+
 	@inject(Identifiers.Cryptography.Identity.PublicKeyFactory)
 	@tagged("type", "consensus")
 	private readonly publicKeyFactory: Contracts.Crypto.IPublicKeyFactory;
@@ -19,6 +23,10 @@ export class RoundState {
 	#proposal?: Contracts.Crypto.IProposal;
 	#prevotes = new Map<string, Contracts.Crypto.IPrevote>();
 	#precommits = new Map<string, Contracts.Crypto.IPrecommit>();
+
+	public getWalletRepository(): Contracts.State.WalletRepository {
+		return this.walletRepository;
+	}
 
 	public setProposal(proposal: Contracts.Crypto.IProposal): void {
 		this.#proposal = proposal;

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -21,6 +21,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	private readonly signatureFactory: Contracts.Crypto.ISignature;
 
 	#proposal?: Contracts.Crypto.IProposal;
+	#processorResult?: Contracts.BlockProcessor.ProcessorResult;
 	#prevotes = new Map<string, Contracts.Crypto.IPrevote>();
 	#precommits = new Map<string, Contracts.Crypto.IPrecommit>();
 
@@ -34,6 +35,14 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 
 	public getProposal(): Contracts.Crypto.IProposal | undefined {
 		return this.#proposal;
+	}
+
+	public setProcessorResult(processorResult: Contracts.BlockProcessor.ProcessorResult): void {
+		this.#processorResult = processorResult;
+	}
+
+	public getProcessorResult(): Contracts.BlockProcessor.ProcessorResult | undefined {
+		return this.#processorResult;
 	}
 
 	public addPrevote(prevote: Contracts.Crypto.IPrevote): void {

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -4,7 +4,7 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 import { IValidatorSetMajority } from "./types";
 
 @injectable()
-export class RoundState {
+export class RoundState implements Contracts.Consensus.IRoundState {
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration: Contracts.Crypto.IConfiguration;
 

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -3,13 +3,15 @@ import { WalletRepository } from "./state";
 
 export interface IRoundState {
 	getWalletRepository(): WalletRepository;
+	getProposal(): IProposal | undefined;
+	setProposal(proposal: IProposal): void;
 }
 
 export interface IConsensusService {
 	run(): Promise<void>;
-	onProposal(proposal: IProposal): Promise<void>;
-	onMajorityPrevote(proposal: IPrevote): Promise<void>;
-	onMajorityPrecommit(proposal: IPrecommit): Promise<void>;
+	onProposal(roudnState: IRoundState): Promise<void>;
+	onMajorityPrevote(roundState: IRoundState): Promise<void>;
+	onMajorityPrecommit(roundState: IRoundState): Promise<void>;
 	onTimeoutPropose(height: number, round: number): Promise<void>;
 	onTimeoutPrevote(height: number, round: number): Promise<void>;
 	onTimeoutPrecommit(height: number, round: number): Promise<void>;

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -1,3 +1,4 @@
+import { ProcessorResult } from "./block-processor";
 import { IBlock, IKeyPair, IPrecommit, IPrevote, IProposal } from "./crypto";
 import { WalletRepository } from "./state";
 
@@ -5,6 +6,8 @@ export interface IRoundState {
 	getWalletRepository(): WalletRepository;
 	getProposal(): IProposal | undefined;
 	setProposal(proposal: IProposal): void;
+	setProcessorResult(processorResult: ProcessorResult): void;
+	getProcessorResult(): ProcessorResult;
 }
 
 export interface IConsensusService {

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -1,4 +1,9 @@
 import { IBlock, IKeyPair, IPrecommit, IPrevote, IProposal } from "./crypto";
+import { WalletRepository } from "./state";
+
+export interface IRoundState {
+	getWalletRepository(): WalletRepository;
+}
 
 export interface IConsensusService {
 	run(): Promise<void>;


### PR DESCRIPTION
## Summary

Use RoundState as central object to hold block, walletRepostiory and processor result. 

Process block on proposal. 

For each instance of RoundState new WalletRepostioryClone is created.

## Checklist

- [x] Ready to be merged

