### PR TITLE
feat(consensus): extended message handling 

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -227,11 +227,16 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	public async onMajorityPrecommitAny(roundState: Contracts.Consensus.IRoundState): Promise<void> {
+		if (this.#isInvalidRoundState(roundState)) {
+			return;
+		}
+
 		void this.scheduler.scheduleTimeoutPrecommit(this.#roundState.height, this.#roundState.round);
 	}
 
 	public async onMajorityPrecommit(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		const proposal = roundState.getProposal();
+		// TODO: Round can be any
 		if (this.#didMajorityPrecommit || this.#isInvalidRoundState(roundState) || !proposal) {
 			return;
 		}

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -233,7 +233,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 			return;
 		}
 
-		void this.scheduler.scheduleTimeoutPrecommit(this.#roundState.height, this.#roundState.round);
+		void this.scheduler.scheduleTimeoutPrecommit(this.#height, this.#round);
 	}
 
 	public async onMajorityPrecommit(roundState: Contracts.Consensus.IRoundState): Promise<void> {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -3,6 +3,7 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 import delay from "delay";
 
 import { Step } from "./enums";
+import { RoundStateRepository } from "./round-state-repository";
 
 @injectable()
 export class Consensus implements Contracts.Consensus.IConsensusService {
@@ -25,14 +26,16 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	@inject(Identifiers.Consensus.ValidatorRepository)
 	private readonly validatorsRepository!: Contracts.Consensus.IValidatorRepository;
 
-	@inject(Identifiers.ValidatorSet)
-	private readonly validatorSet!: Contracts.ValidatorSet.IValidatorSet;
+	// TODO: Add interface
+	@inject(Identifiers.Consensus.RoundStateRepository)
+	private readonly roundStateRepository!: RoundStateRepository;
 
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;
 
 	#height = 2;
 	#round = 0;
+	#roundState!: Contracts.Consensus.IRoundState;
 	#step: Step = Step.propose;
 	#lockedValue?: Contracts.Consensus.IRoundState;
 	#lockedRound?: number = undefined;
@@ -104,19 +107,21 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.#step = Step.propose;
 		this.#didMajorityPrevote = false;
 		this.#didMajorityPrecommit = false;
-
 		this.scheduler.clear();
 
-		const proposerPublicKey = await this.#getProposerPublicKey(this.#height, round);
-		const proposer = this.validatorsRepository.getValidator(proposerPublicKey);
+		this.#roundState = await this.roundStateRepository.getRoundState(this.#height, this.#round);
 
-		this.logger.info(`>> Starting new round: ${this.#height}/${this.#round} with proposer ${proposerPublicKey}`);
+		const proposer = this.validatorsRepository.getValidator(this.#roundState.proposer);
+
+		this.logger.info(
+			`>> Starting new round: ${this.#height}/${this.#round} with proposer ${this.#roundState.proposer}`,
+		);
 
 		if (proposer) {
 			// TODO: Error handling
 			await this.#propose(proposer);
 		} else {
-			this.logger.info(`No registered proposer for ${proposerPublicKey}`);
+			this.logger.info(`No registered proposer for ${this.#roundState.proposer}`);
 
 			// TODO: Can we call this even even proposer is known?
 			await this.scheduler.scheduleTimeoutPropose(this.#height, this.#round);
@@ -329,7 +334,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	async #prevote(value?: string): Promise<void> {
-		for (const validator of this.validatorsRepository.getValidators(await this.#getActiveValidators())) {
+		for (const validator of this.validatorsRepository.getValidators(this.#roundState.validators)) {
 			const precommit = await validator.prevote(this.#height, this.#round, value);
 
 			await this.broadcaster.broadcastPrevote(precommit);
@@ -338,22 +343,11 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	async #precommit(value?: string): Promise<void> {
-		for (const validator of this.validatorsRepository.getValidators(await this.#getActiveValidators())) {
+		for (const validator of this.validatorsRepository.getValidators(this.#roundState.validators)) {
 			const precommit = await validator.precommit(this.#height, this.#round, value);
 
 			await this.broadcaster.broadcastPrecommit(precommit);
 			await this.handler.onPrecommit(precommit);
 		}
-	}
-
-	async #getProposerPublicKey(height: number, round: number): Promise<string> {
-		const activeValidators = await this.validatorSet.getActiveValidators();
-		return activeValidators[0].getAttribute("consensus.publicKey");
-	}
-
-	async #getActiveValidators(): Promise<string[]> {
-		const activeValidators = await this.validatorSet.getActiveValidators();
-
-		return activeValidators.map((wallet) => wallet.getAttribute("consensus.publicKey"));
 	}
 }

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -27,7 +27,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 		}
 
 		const roundState = this.roundStateRepo.getRoundState(proposal.height, proposal.round);
-		roundState.setProposal(proposal);
+		roundState.addProposal(proposal);
 
 		await this.#getConsensus().onProposal(roundState);
 	}

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
-import { RoundState } from "./round-state";
 import { RoundStateRepository } from "./round-state-repository";
 
 @injectable()
@@ -77,7 +76,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 		return message.height === this.#getConsensus().getHeight() && message.round >= this.#getConsensus().getRound();
 	}
 
-	async #handle(roundState: RoundState): Promise<void> {
+	async #handle(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		const consensus = this.#getConsensus();
 
 		await consensus.onProposal(roundState);

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -30,8 +30,6 @@ export class Handler implements Contracts.Consensus.IHandler {
 		}
 
 		const roundState = await this.roundStateRepo.getRoundState(proposal.height, proposal.round);
-		roundState.addProposal(proposal);
-
 		if (roundState.addProposal(proposal)) {
 			await this.#handle(roundState);
 		}
@@ -87,6 +85,8 @@ export class Handler implements Contracts.Consensus.IHandler {
 		}
 
 		const consensus = this.#getConsensus();
+
+		await consensus.onProposal(roundState);
 
 		if (roundState.hasMajorityPrevotes()) {
 			await consensus.onMajorityPrevote(roundState);

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -19,6 +19,10 @@ export class Handler implements Contracts.Consensus.IHandler {
 	private readonly verifier!: Contracts.Crypto.IMessageVerifier;
 
 	async onProposal(proposal: Contracts.Crypto.IProposal): Promise<void> {
+		if (!this.#isValidHeightAndRound(proposal)) {
+			return;
+		}
+
 		// TODO: Move verification to p2p handler
 		const { errors } = await this.verifier.verifyProposal(proposal);
 		if (errors.length > 0) {
@@ -33,6 +37,10 @@ export class Handler implements Contracts.Consensus.IHandler {
 	}
 
 	async onPrevote(prevote: Contracts.Crypto.IPrevote): Promise<void> {
+		if (!this.#isValidHeightAndRound(prevote)) {
+			return;
+		}
+
 		// TODO: Move verification to p2p handler
 		const { errors } = await this.verifier.verifyPrevote(prevote);
 		if (errors.length > 0) {
@@ -48,6 +56,10 @@ export class Handler implements Contracts.Consensus.IHandler {
 	}
 
 	async onPrecommit(precommit: Contracts.Crypto.IPrecommit): Promise<void> {
+		if (!this.#isValidHeightAndRound(precommit)) {
+			return;
+		}
+
 		// TODO: Move verification to p2p handler
 		const { errors } = await this.verifier.verifyPrecommit(precommit);
 		if (errors.length > 0) {
@@ -62,6 +74,10 @@ export class Handler implements Contracts.Consensus.IHandler {
 		roundState.addPrecommit(precommit);
 
 		await this.#handle(roundState);
+	}
+
+	#isValidHeightAndRound(message: { height: number; round: number }): boolean {
+		return message.height === this.#getConsensus().getHeight() && message.round >= this.#getConsensus().getRound();
 	}
 
 	async #handle(roundState: RoundState): Promise<void> {

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
-import { Consensus } from "./consensus";
 import { RoundState } from "./round-state";
 import { RoundStateRepository } from "./round-state-repository";
 
@@ -109,7 +108,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 		}
 	}
 
-	#getConsensus(): Consensus {
-		return this.app.get<Consensus>(Identifiers.Consensus.Service);
+	#getConsensus(): Contracts.Consensus.IConsensusService {
+		return this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
 	}
 }

--- a/packages/consensus/source/handler.ts
+++ b/packages/consensus/source/handler.ts
@@ -26,7 +26,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 			return;
 		}
 
-		const roundState = this.roundStateRepo.getRoundState(proposal.height, proposal.round);
+		const roundState = await this.roundStateRepo.getRoundState(proposal.height, proposal.round);
 		roundState.addProposal(proposal);
 
 		await this.#getConsensus().onProposal(roundState);
@@ -40,7 +40,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 			return;
 		}
 
-		const roundState = this.roundStateRepo.getRoundState(prevote.height, prevote.round);
+		const roundState = await this.roundStateRepo.getRoundState(prevote.height, prevote.round);
 
 		roundState.addPrevote(prevote);
 
@@ -57,7 +57,7 @@ export class Handler implements Contracts.Consensus.IHandler {
 			return;
 		}
 
-		const roundState = this.roundStateRepo.getRoundState(precommit.height, precommit.round);
+		const roundState = await this.roundStateRepo.getRoundState(precommit.height, precommit.round);
 
 		roundState.addPrecommit(precommit);
 

--- a/packages/consensus/source/round-state-repository.ts
+++ b/packages/consensus/source/round-state-repository.ts
@@ -10,18 +10,18 @@ export class RoundStateRepository {
 
 	#roundStates = new Map<string, RoundState>();
 
-	getRoundState(height, round): RoundState {
+	async getRoundState(height, round): Promise<RoundState> {
 		const key = `${height}-${round}`;
 
 		if (!this.#roundStates.has(key)) {
-			this.#roundStates.set(key, this.#createRoundState(height, round));
+			this.#roundStates.set(key, await this.#createRoundState(height, round));
 		}
 
 		return this.#roundStates.get(key)!;
 	}
 
 	// TODO: Bind to factory
-	#createRoundState(height: number, round: number): RoundState {
+	#createRoundState(height: number, round: number): Promise<RoundState> {
 		return this.app.resolve(RoundState).configure(height, round);
 	}
 }

--- a/packages/consensus/source/round-state-repository.ts
+++ b/packages/consensus/source/round-state-repository.ts
@@ -8,9 +8,9 @@ export class RoundStateRepository {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 
-	#roundStates = new Map<string, RoundState>();
+	#roundStates = new Map<string, Contracts.Consensus.IRoundState>();
 
-	async getRoundState(height, round): Promise<RoundState> {
+	async getRoundState(height, round): Promise<Contracts.Consensus.IRoundState> {
 		const key = `${height}-${round}`;
 
 		if (!this.#roundStates.has(key)) {
@@ -21,7 +21,7 @@ export class RoundStateRepository {
 	}
 
 	// TODO: Bind to factory
-	#createRoundState(height: number, round: number): Promise<RoundState> {
+	#createRoundState(height: number, round: number): Promise<Contracts.Consensus.IRoundState> {
 		return this.app.resolve(RoundState).configure(height, round);
 	}
 }

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -90,14 +90,22 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	}
 
 	public addPrevote(prevote: Contracts.Crypto.IPrevote): boolean {
-		this.#prevotes.set(prevote.validatorPublicKey, prevote);
+		if (this.#prevotes.has(prevote.validatorPublicKey)) {
+			// TODO: Handle evidence
 
+			return false;
+		}
+
+		this.#prevotes.set(prevote.validatorPublicKey, prevote);
 		return true;
 	}
 
 	public addPrecommit(precommit: Contracts.Crypto.IPrecommit): boolean {
-		this.#precommits.set(precommit.validatorPublicKey, precommit);
+		if (this.#precommits.has(precommit.validatorPublicKey)) {
+			return false;
+		}
 
+		this.#precommits.set(precommit.validatorPublicKey, precommit);
 		return true;
 	}
 

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -46,7 +46,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return this.walletRepository;
 	}
 
-	public setProposal(proposal: Contracts.Crypto.IProposal): void {
+	public addProposal(proposal: Contracts.Crypto.IProposal): void {
 		this.#proposal = proposal;
 	}
 

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -30,6 +30,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	#prevotes = new Map<string, Contracts.Crypto.IPrevote>();
 	#precommits = new Map<string, Contracts.Crypto.IPrecommit>();
 	#validators = new Map<string, Contracts.State.Wallet>();
+	#proposer!: string;
 
 	get height(): number {
 		return this.#height;
@@ -37,6 +38,14 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 
 	get round(): number {
 		return this.#round;
+	}
+
+	get validators(): string[] {
+		return [...this.#validators.keys()];
+	}
+
+	get proposer(): string {
+		return this.#proposer;
 	}
 
 	public async configure(height: number, round: number): Promise<RoundState> {
@@ -48,6 +57,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 			const consensuPublicKey = validator.getAttribute<string>("consensus.publicKey");
 			this.#validators.set(consensuPublicKey, validator);
 		}
+		this.#proposer = validators[0].getAttribute<string>("consensus.publicKey");
 
 		return this;
 	}

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -126,14 +126,30 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	}
 
 	public hasMajorityPrevotes(): boolean {
-		return this.#isMajority(this.#prevotes.size);
+		if (!this.#proposal) {
+			return false;
+		}
+
+		return this.#isMajority(this.#getPrevoteCount(this.#proposal.block.data.id));
 	}
 
 	public hasMajorityPrevotesAny(): boolean {
 		return this.#isMajority(this.#prevotes.size);
 	}
 
+	public hasMajorityPrevotesNull(): boolean {
+		return this.#isMajority(this.#getPrevoteCount());
+	}
+
 	public hasMajorityPrecommits(): boolean {
+		if (!this.#proposal) {
+			return false;
+		}
+
+		return this.#isMajority(this.#getPrecommitCount(this.#proposal.block.data.id));
+	}
+
+	public hasMajorityPrecommitsAny(): boolean {
 		return this.#isMajority(this.#precommits.size);
 	}
 
@@ -157,19 +173,19 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return size >= this.configuration.getMilestone().activeValidators / 3 + 1;
 	}
 
-	#increasePrevoteCount(blockId: string | undefined): void {
+	#increasePrevoteCount(blockId?: string): void {
 		this.#prevotesCount.set(blockId, this.#getPrevoteCount(blockId) + 1);
 	}
 
-	#getPrevoteCount(blockId: string | undefined): number {
+	#getPrevoteCount(blockId?: string): number {
 		return this.#prevotesCount.get(blockId) ?? 0;
 	}
 
-	#increasePrecommitCount(blockId: string | undefined): void {
+	#increasePrecommitCount(blockId?: string): void {
 		this.#precommitsCount.set(blockId, this.#getPrecommitCount(blockId) + 1);
 	}
 
-	#getPrecommitCount(blockId: string | undefined): number {
+	#getPrecommitCount(blockId?: string): number {
 		return this.#precommitsCount.get(blockId) ?? 0;
 	}
 

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -47,6 +47,11 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	}
 
 	public addProposal(proposal: Contracts.Crypto.IProposal): boolean {
+		if (this.#proposal) {
+			// TODO: Handle evidence
+			return false;
+		}
+
 		this.#proposal = proposal;
 
 		return true;

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -1,8 +1,6 @@
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
-import { IValidatorSetMajority } from "./types";
-
 @injectable()
 export class RoundState implements Contracts.Consensus.IRoundState {
 	@inject(Identifiers.Cryptography.Configuration)
@@ -189,15 +187,17 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return this.#precommitsCount.get(blockId) ?? 0;
 	}
 
-	public async aggregateMajorityPrevotes(): Promise<IValidatorSetMajority> {
+	public async aggregateMajorityPrevotes(): Promise<Contracts.Consensus.IValidatorSetMajority> {
 		return this.#aggregateValidatorSetMajority(this.#prevotes);
 	}
 
-	public async aggregateMajorityPrecommits(): Promise<IValidatorSetMajority> {
+	public async aggregateMajorityPrecommits(): Promise<Contracts.Consensus.IValidatorSetMajority> {
 		return this.#aggregateValidatorSetMajority(this.#precommits);
 	}
 
-	async #aggregateValidatorSetMajority(majority: Map<string, { signature: string }>): Promise<IValidatorSetMajority> {
+	async #aggregateValidatorSetMajority(
+		majority: Map<string, { signature: string }>,
+	): Promise<Contracts.Consensus.IValidatorSetMajority> {
 		const publicKeys: Buffer[] = [];
 		const signatures: Buffer[] = [];
 

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -46,8 +46,10 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return this.walletRepository;
 	}
 
-	public addProposal(proposal: Contracts.Crypto.IProposal): void {
+	public addProposal(proposal: Contracts.Crypto.IProposal): boolean {
 		this.#proposal = proposal;
+
+		return true;
 	}
 
 	public getProposal(): Contracts.Crypto.IProposal | undefined {
@@ -62,12 +64,16 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return !!this.#processorResult;
 	}
 
-	public addPrevote(prevote: Contracts.Crypto.IPrevote): void {
+	public addPrevote(prevote: Contracts.Crypto.IPrevote): boolean {
 		this.#prevotes.set(prevote.validatorPublicKey, prevote);
+
+		return true;
 	}
 
-	public addPrecommit(precommit: Contracts.Crypto.IPrecommit): void {
+	public addPrecommit(precommit: Contracts.Crypto.IPrecommit): boolean {
 		this.#precommits.set(precommit.validatorPublicKey, precommit);
+
+		return true;
 	}
 
 	public hasMajorityPrevotes(): boolean {

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -28,7 +28,9 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 	#proposal?: Contracts.Crypto.IProposal;
 	#processorResult?: boolean;
 	#prevotes = new Map<string, Contracts.Crypto.IPrevote>();
+	#prevotesCount = new Map<string | undefined, number>();
 	#precommits = new Map<string, Contracts.Crypto.IPrecommit>();
+	#precommitsCount = new Map<string | undefined, number>();
 	#validators = new Map<string, Contracts.State.Wallet>();
 	#proposer!: string;
 
@@ -105,6 +107,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		}
 
 		this.#prevotes.set(prevote.validatorPublicKey, prevote);
+		this.#increasePrevoteCount(prevote.blockId);
 		return true;
 	}
 
@@ -118,6 +121,7 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		}
 
 		this.#precommits.set(precommit.validatorPublicKey, precommit);
+		this.#increasePrecommitCount(precommit.blockId);
 		return true;
 	}
 
@@ -151,6 +155,22 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 
 	#isMinority(size: number): boolean {
 		return size >= this.configuration.getMilestone().activeValidators / 3 + 1;
+	}
+
+	#increasePrevoteCount(blockId: string | undefined): void {
+		this.#prevotesCount.set(blockId, this.#getPrevoteCount(blockId) + 1);
+	}
+
+	#getPrevoteCount(blockId: string | undefined): number {
+		return this.#prevotesCount.get(blockId) ?? 0;
+	}
+
+	#increasePrecommitCount(blockId: string | undefined): void {
+		this.#precommitsCount.set(blockId, this.#getPrecommitCount(blockId) + 1);
+	}
+
+	#getPrecommitCount(blockId: string | undefined): number {
+		return this.#precommitsCount.get(blockId) ?? 0;
 	}
 
 	public async aggregateMajorityPrevotes(): Promise<IValidatorSetMajority> {

--- a/packages/consensus/source/types.ts
+++ b/packages/consensus/source/types.ts
@@ -1,5 +1,0 @@
-export interface IValidatorSetMajority {
-	aggSignature: string;
-	aggPublicKey: string;
-	validatorSet: Set<Buffer>;
-}

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -6,7 +6,7 @@ export interface IRoundState {
 	round: number;
 	getWalletRepository(): WalletRepositoryClone;
 	getProposal(): IProposal | undefined;
-	addProposal(proposal: IProposal): void;
+	addProposal(proposal: IProposal): boolean;
 	setProcessorResult(processorResult: boolean): void;
 	getProcessorResult(): boolean;
 }

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -6,7 +6,7 @@ export interface IRoundState {
 	round: number;
 	getWalletRepository(): WalletRepositoryClone;
 	getProposal(): IProposal | undefined;
-	setProposal(proposal: IProposal): void;
+	addProposal(proposal: IProposal): void;
 	setProcessorResult(processorResult: boolean): void;
 	getProcessorResult(): boolean;
 }

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -17,9 +17,14 @@ export interface IConsensusService {
 	run(): Promise<void>;
 	getHeight(): number;
 	getRound(): number;
-	onProposal(roudnState: IRoundState): Promise<void>;
+	onProposal(roundState: IRoundState): Promise<void>;
+	onProposalLocked(roudnState: IRoundState): Promise<void>;
 	onMajorityPrevote(roundState: IRoundState): Promise<void>;
+	onMajorityPrevoteAny(roundState: IRoundState): Promise<void>;
+	onMajorityPrevoteNull(roundState: IRoundState): Promise<void>;
+	onMajorityPrecommitAny(roundState: IRoundState): Promise<void>;
 	onMajorityPrecommit(roundState: IRoundState): Promise<void>;
+	onMinorityWithHigherRound(roundState: IRoundState): Promise<void>;
 	onTimeoutPropose(height: number, round: number): Promise<void>;
 	onTimeoutPrevote(height: number, round: number): Promise<void>;
 	onTimeoutPrecommit(height: number, round: number): Promise<void>;

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -1,6 +1,13 @@
 import { IBlock, IKeyPair, IPrecommit, IPrevote, IProposal } from "./crypto";
 import { WalletRepositoryClone } from "./state";
 
+// TODO: Move to crypto
+export interface IValidatorSetMajority {
+	aggSignature: string;
+	aggPublicKey: string;
+	validatorSet: Set<Buffer>;
+}
+
 export interface IRoundState {
 	readonly height: number;
 	readonly round: number;
@@ -11,6 +18,16 @@ export interface IRoundState {
 	addProposal(proposal: IProposal): boolean;
 	setProcessorResult(processorResult: boolean): void;
 	getProcessorResult(): boolean;
+	addPrevote(prevote: IPrevote): boolean;
+	addPrecommit(precommit: IPrecommit): boolean;
+	hasMajorityPrevotes(): boolean;
+	hasMajorityPrevotesAny(): boolean;
+	hasMajorityPrevotesNull(): boolean;
+	hasMajorityPrecommits(): boolean;
+	hasMajorityPrecommitsAny(): boolean;
+	hasMinorityPrevotesOrPrecommits(): boolean;
+	aggregateMajorityPrevotes(): Promise<IValidatorSetMajority>;
+	aggregateMajorityPrecommits(): Promise<IValidatorSetMajority>;
 }
 
 export interface IConsensusService {

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -15,6 +15,8 @@ export interface IRoundState {
 
 export interface IConsensusService {
 	run(): Promise<void>;
+	getHeight(): number;
+	getRound(): number;
 	onProposal(roudnState: IRoundState): Promise<void>;
 	onMajorityPrevote(roundState: IRoundState): Promise<void>;
 	onMajorityPrecommit(roundState: IRoundState): Promise<void>;

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -2,8 +2,10 @@ import { IBlock, IKeyPair, IPrecommit, IPrevote, IProposal } from "./crypto";
 import { WalletRepositoryClone } from "./state";
 
 export interface IRoundState {
-	height: number;
-	round: number;
+	readonly height: number;
+	readonly round: number;
+	readonly validators: string[];
+	readonly proposer: string;
 	getWalletRepository(): WalletRepositoryClone;
 	getProposal(): IProposal | undefined;
 	addProposal(proposal: IProposal): boolean;

--- a/packages/validator-set-static/source/index.ts
+++ b/packages/validator-set-static/source/index.ts
@@ -5,6 +5,7 @@ import { ValidatorSet } from "./validator-set";
 
 export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {
+		// TODO: Rename attribute
 		this.app.get<Services.Attributes.AttributeSet>(Identifiers.WalletAttributes).set("consensus.publicKey");
 
 		this.app.bind(Identifiers.ValidatorSet).toConstantValue(await this.app.resolve(ValidatorSet).configure());


### PR DESCRIPTION
## Summary

Improve message handling:
- Accept only one message per validator
- Call consensus only when accepted 
- Count messages and support for different ids 

Other:
- Call all consensus methods
- Set validators on round creation
- Add contracts

## Checklist

- [x] Ready to be merged
