### PR TITLE
refactor(contracts): make Block interfaces readonly

### DIFF
--- a/packages/contracts/source/contracts/crypto/block.ts
+++ b/packages/contracts/source/contracts/crypto/block.ts
@@ -32,7 +32,6 @@ export interface IBlockData {
 	payloadHash: string;
 	generatorPublicKey: string;
 
-	serialized?: string;
 	transactions: ITransactionData[];
 }
 

--- a/packages/contracts/source/contracts/crypto/block.ts
+++ b/packages/contracts/source/contracts/crypto/block.ts
@@ -3,55 +3,55 @@ import { BigNumber } from "@mainsail/utils";
 import { ITransaction, ITransactionData, ITransactionJson } from "./transactions";
 
 export interface IBlockVerification {
-	verified: boolean;
-	errors: string[];
-	containsMultiSignatures: boolean;
+	readonly verified: boolean;
+	readonly errors: string[];
+	readonly containsMultiSignatures: boolean;
 }
 
 export type IBlockHeader = Exclude<IBlockData, "transactions">;
 
 export interface IBlock {
-	data: IBlockData;
-	header: IBlockHeader;
-	serialized: string;
-	transactions: ITransaction[];
+	readonly data: IBlockData;
+	readonly header: IBlockHeader;
+	readonly serialized: string;
+	readonly transactions: ITransaction[];
 }
 
 export interface IBlockData {
-	id: string;
+	readonly id: string;
 
-	timestamp: number;
-	version: number;
-	height: number;
-	previousBlock: string;
-	numberOfTransactions: number;
-	totalAmount: BigNumber;
-	totalFee: BigNumber;
-	reward: BigNumber;
-	payloadLength: number;
-	payloadHash: string;
-	generatorPublicKey: string;
+	readonly timestamp: number;
+	readonly version: number;
+	readonly height: number;
+	readonly previousBlock: string;
+	readonly numberOfTransactions: number;
+	readonly totalAmount: BigNumber;
+	readonly totalFee: BigNumber;
+	readonly reward: BigNumber;
+	readonly payloadLength: number;
+	readonly payloadHash: string;
+	readonly generatorPublicKey: string;
 
-	transactions: ITransactionData[];
+	readonly transactions: ITransactionData[];
 }
 
 export interface IBlockJson {
-	id: string;
+	readonly id: string;
 
-	timestamp: number;
-	version: number;
-	height: number;
-	previousBlock: string;
-	numberOfTransactions: number;
-	totalAmount: string;
-	totalFee: string;
-	reward: string;
-	payloadLength: number;
-	payloadHash: string;
-	generatorPublicKey: string;
+	readonly timestamp: number;
+	readonly version: number;
+	readonly height: number;
+	readonly previousBlock: string;
+	readonly numberOfTransactions: number;
+	readonly totalAmount: string;
+	readonly totalFee: string;
+	readonly reward: string;
+	readonly payloadLength: number;
+	readonly payloadHash: string;
+	readonly generatorPublicKey: string;
 
-	serialized?: string;
-	transactions: ITransactionJson[];
+	readonly serialized?: string;
+	readonly transactions: ITransactionJson[];
 }
 
 export interface IBlockDeserializer {

--- a/packages/contracts/source/index.ts
+++ b/packages/contracts/source/index.ts
@@ -4,3 +4,4 @@ export * as Constants from "./constants";
 export * as Contracts from "./contracts";
 export * as Exceptions from "./exceptions";
 export * from "./identifiers";
+export * as Utils from "./utils";

--- a/packages/contracts/source/utils.ts
+++ b/packages/contracts/source/utils.ts
@@ -1,0 +1,3 @@
+export type Mutable<T> = {
+	-readonly [P in keyof T]: T[P];
+};

--- a/packages/crypto-block/source/deserializer.ts
+++ b/packages/crypto-block/source/deserializer.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { inject, injectable, tagged } from "@mainsail/container";
-import { Contracts, Identifiers } from "@mainsail/contracts";
+import { Contracts, Identifiers, Utils } from "@mainsail/contracts";
 import { TransactionFactory } from "@mainsail/crypto-transaction";
 import { ByteBuffer } from "@mainsail/utils";
 
@@ -23,9 +23,8 @@ export class Deserializer implements Contracts.Crypto.IBlockDeserializer {
 	): Promise<{ data: Contracts.Crypto.IBlockData; transactions: Contracts.Crypto.ITransaction[] }> {
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);
 
-		const header = await this.#deserializeBufferHeader(buffer);
+		const block: Utils.Mutable<Contracts.Crypto.IBlockData> = await this.#deserializeBufferHeader(buffer);
 
-		const block = header as Contracts.Crypto.IBlockData;
 		let transactions: Contracts.Crypto.ITransaction[] = [];
 
 		if (buffer.getRemainderLength() > 0) {
@@ -40,7 +39,7 @@ export class Deserializer implements Contracts.Crypto.IBlockDeserializer {
 	public async deserializeHeader(serialized: Buffer): Promise<Contracts.Crypto.IBlockHeader> {
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);
 
-		const header = await this.#deserializeBufferHeader(buffer);
+		const header: Utils.Mutable<Contracts.Crypto.IBlockData> = await this.#deserializeBufferHeader(buffer);
 
 		header.id = await this.idFactory.make(header);
 

--- a/packages/crypto-block/source/factory.ts
+++ b/packages/crypto-block/source/factory.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "@mainsail/container";
-import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
+import { Contracts, Exceptions, Identifiers, Utils } from "@mainsail/contracts";
 import { BigNumber } from "@mainsail/utils";
 
 import { sealBlock } from "./block";
@@ -19,7 +19,7 @@ export class BlockFactory implements Contracts.Crypto.IBlockFactory {
 	@inject(Identifiers.Cryptography.Validator)
 	private readonly validator!: Contracts.Crypto.IValidator;
 
-	public async make(data: Contracts.Crypto.IBlockData): Promise<Contracts.Crypto.IBlock> {
+	public async make(data: Utils.Mutable<Contracts.Crypto.IBlockData>): Promise<Contracts.Crypto.IBlock> {
 		data.id = await this.idFactory.make(data);
 
 		return this.fromData(data);
@@ -35,7 +35,7 @@ export class BlockFactory implements Contracts.Crypto.IBlockFactory {
 
 	public async fromJson(json: Contracts.Crypto.IBlockJson): Promise<Contracts.Crypto.IBlock> {
 		// @ts-ignore
-		const data: Contracts.Crypto.IBlockData = { ...json };
+		const data: Utils.Mutable<Contracts.Crypto.IBlockData> = { ...json };
 		data.totalAmount = BigNumber.make(data.totalAmount);
 		data.totalFee = BigNumber.make(data.totalFee);
 		data.reward = BigNumber.make(data.reward);

--- a/packages/crypto-block/source/verifier.ts
+++ b/packages/crypto-block/source/verifier.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "@mainsail/container";
-import { Contracts, Identifiers } from "@mainsail/contracts";
+import { Contracts, Identifiers, Utils } from "@mainsail/contracts";
 import { BigNumber } from "@mainsail/utils";
 
 @injectable()
@@ -21,7 +21,7 @@ export class Verifier implements Contracts.Crypto.IBlockVerifier {
 
 	public async verify(block: Contracts.Crypto.IBlock): Promise<Contracts.Crypto.IBlockVerification> {
 		const blockData: Contracts.Crypto.IBlockData = block.data;
-		const result: Contracts.Crypto.IBlockVerification = {
+		const result: Utils.Mutable<Contracts.Crypto.IBlockVerification> = {
 			containsMultiSignatures: false,
 			errors: [],
 			verified: false,


### PR DESCRIPTION

## Summary

Make interfaces readonly. Introduce Mutable TS util, that makes readonly fields on object mutable. 

## Checklist


- [x] Ready to be merged


