### PR TITLE
fix: crypto messages serialization and deserialziation issues

### DIFF
--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -73,8 +73,6 @@ export interface IMessageFactory {
 	makePrecommitFromBytes(data: Buffer): Promise<IPrecommit>;
 }
 
-
-
 export type IMessageSerializableProposal = OptionalSignature<IProposalData>;
 export type IMessageSerializablePrevote = OptionalSignature<IPrevoteData>;
 export type IMessageSerializablePrecommit = OptionalSignature<IPrecommitData>;
@@ -83,15 +81,9 @@ export interface IMessageSerializeOptions {
 	excludeSignature?: boolean;
 }
 export interface IMessageSerializer {
-	serializeProposal(
-		proposal: IMessageSerializableProposal,
-		options?: IMessageSerializeOptions,
-	): Promise<Buffer>;
+	serializeProposal(proposal: IMessageSerializableProposal, options?: IMessageSerializeOptions): Promise<Buffer>;
 	serializePrevote(prevote: IMessageSerializablePrevote, options?: IMessageSerializeOptions): Promise<Buffer>;
-	serializePrecommit(
-		precommit: IMessageSerializablePrecommit,
-		options?: IMessageSerializeOptions,
-	): Promise<Buffer>;
+	serializePrecommit(precommit: IMessageSerializablePrecommit, options?: IMessageSerializeOptions): Promise<Buffer>;
 }
 
 export interface IMessageDeserializer {

--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -66,8 +66,11 @@ export type IMakePrecommitData = WithoutSignature<IPrecommitData>;
 
 export interface IMessageFactory {
 	makeProposal(data: IMakeProposalData, keyPair: IKeyPair): Promise<IProposal>;
+	makeProposalFromBytes(data: Buffer): Promise<IProposal>;
 	makePrevote(data: IMakePrevoteData, keyPair: IKeyPair): Promise<IPrevote>;
+	makePrevoteFromBytes(data: Buffer): Promise<IPrevote>;
 	makePrecommit(data: IMakePrecommitData, keyPair: IKeyPair): Promise<IPrecommit>;
+	makePrecommitFromBytes(data: Buffer): Promise<IPrecommit>;
 }
 
 

--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -94,9 +94,9 @@ export interface IMessageSerializer {
 }
 
 export interface IMessageDeserializer {
-	deserializeProposal(serialized: Buffer): Promise<IProposal>;
-	deserializePrevote(serialized: Buffer): Promise<IPrevote>;
-	deserializePrecommit(serialized: Buffer): Promise<IPrecommit>;
+	deserializeProposal(serialized: Buffer): Promise<IProposalData>;
+	deserializePrevote(serialized: Buffer): Promise<IPrevoteData>;
+	deserializePrecommit(serialized: Buffer): Promise<IPrecommitData>;
 }
 
 export interface IMessageVerificationResult {

--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -70,26 +70,24 @@ export interface IMessageFactory {
 	makePrecommit(data: IMakePrecommitData, keyPair: IKeyPair): Promise<IPrecommit>;
 }
 
-export interface IMessageSerializeOptions {
-	excludeSignature?: boolean;
-}
-export interface IMessageSerializeProposalOptions extends IMessageSerializeOptions {}
-export interface IMessageSerializePrevoteOptions extends IMessageSerializeOptions {}
-export interface IMessageSerializePrecommitOptions extends IMessageSerializeOptions {}
+
 
 export type IMessageSerializableProposal = OptionalSignature<IProposalData>;
 export type IMessageSerializablePrevote = OptionalSignature<IPrevoteData>;
 export type IMessageSerializablePrecommit = OptionalSignature<IPrecommitData>;
 
+export interface IMessageSerializeOptions {
+	excludeSignature?: boolean;
+}
 export interface IMessageSerializer {
 	serializeProposal(
 		proposal: IMessageSerializableProposal,
-		options?: IMessageSerializeProposalOptions,
+		options?: IMessageSerializeOptions,
 	): Promise<Buffer>;
-	serializePrevote(prevote: IMessageSerializablePrevote, options?: IMessageSerializePrevoteOptions): Promise<Buffer>;
+	serializePrevote(prevote: IMessageSerializablePrevote, options?: IMessageSerializeOptions): Promise<Buffer>;
 	serializePrecommit(
 		precommit: IMessageSerializablePrecommit,
-		options?: IMessageSerializePrecommitOptions,
+		options?: IMessageSerializeOptions,
 	): Promise<Buffer>;
 }
 

--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -5,7 +5,7 @@ export interface IProposalData {
 	height: number;
 	round: number;
 	validRound?: number;
-	block: IBlock;
+	block: { serialized: string };
 	validatorIndex: number;
 	signature: string;
 }
@@ -60,7 +60,7 @@ export interface IPrecommit {
 export type HasSignature = { signature: string };
 export type WithoutSignature<T> = Omit<T, "signature">;
 export type OptionalSignature<T extends HasSignature> = WithoutSignature<T> & Partial<Pick<T, "signature">>;
-export type IMakeProposalData = WithoutSignature<IProposalData>;
+export type IMakeProposalData = WithoutSignature<IProposalData & { block: IBlock }>;
 export type IMakePrevoteData = WithoutSignature<IPrevoteData>;
 export type IMakePrecommitData = WithoutSignature<IPrecommitData>;
 

--- a/packages/crypto-messages/source/deserializer.ts
+++ b/packages/crypto-messages/source/deserializer.ts
@@ -1,12 +1,11 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
-import { inject, injectable, tagged } from "@mainsail/container";
+import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { ByteBuffer } from "@mainsail/utils";
 
 @injectable()
 export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 	@inject(Identifiers.Cryptography.Serializer)
-	@tagged("type", "consensus")
 	private readonly serializer!: Contracts.Serializer.ISerializer;
 
 	public async deserializeProposal(serialized: Buffer): Promise<Contracts.Crypto.IProposal> {
@@ -29,7 +28,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 					type: "hex",
 				},
 				signature: {
-					type: "signature",
+					type: "consensusSignature",
 				},
 			},
 		});
@@ -57,7 +56,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 					type: "blockId",
 				},
 				signature: {
-					type: "signature",
+					type: "consensusSignature",
 				},
 			},
 		});
@@ -85,7 +84,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 					type: "blockId",
 				},
 				signature: {
-					type: "signature",
+					type: "consensusSignature",
 				},
 			},
 		});

--- a/packages/crypto-messages/source/deserializer.ts
+++ b/packages/crypto-messages/source/deserializer.ts
@@ -8,7 +8,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 	@inject(Identifiers.Cryptography.Serializer)
 	private readonly serializer!: Contracts.Serializer.ISerializer;
 
-	public async deserializeProposal(serialized: Buffer): Promise<Contracts.Crypto.IProposal> {
+	public async deserializeProposal(serialized: Buffer): Promise<Contracts.Crypto.IProposalData> {
 		const proposal = {} as Contracts.Crypto.IProposal;
 
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);
@@ -36,7 +36,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 		return proposal;
 	}
 
-	public async deserializePrecommit(serialized: Buffer): Promise<Contracts.Crypto.IPrecommit> {
+	public async deserializePrecommit(serialized: Buffer): Promise<Contracts.Crypto.IPrecommitData> {
 		const precommit = {} as Contracts.Crypto.IPrecommit;
 
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);
@@ -64,7 +64,7 @@ export class Deserializer implements Contracts.Crypto.IMessageDeserializer {
 		return precommit;
 	}
 
-	public async deserializePrevote(serialized: Buffer): Promise<Contracts.Crypto.IPrevote> {
+	public async deserializePrevote(serialized: Buffer): Promise<Contracts.Crypto.IPrevoteData> {
 		const prevote = {} as Contracts.Crypto.IPrevote;
 
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);

--- a/packages/crypto-messages/source/factory.test.ts
+++ b/packages/crypto-messages/source/factory.test.ts
@@ -1,12 +1,13 @@
+import { Contracts } from "@mainsail/contracts";
+
 import crypto from "../../core/bin/config/testnet/crypto.json";
+import validatorsJson from "../../core/bin/config/testnet/validators.json";
 import { describe, Factories, Sandbox } from "../../test-framework";
+import { Types } from "../../test-framework/source/factories";
 import { blockData, serializedBlock } from "../test/fixtures/proposal";
 import { prepareSandbox } from "../test/helpers/prepare-sandbox";
 import { MessageFactory } from "./factory";
-import { Types } from "../../test-framework/source/factories";
 import { Verifier } from "./verifier";
-import { Contracts } from "@mainsail/contracts";
-import validatorsJson from "../../core/bin/config/testnet/validators.json";
 
 describe<{
 	sandbox: Sandbox;
@@ -22,9 +23,9 @@ describe<{
 		const identityFactory = await Factories.factory("Identity", crypto);
 		const identity = await identityFactory
 			.withOptions({
-				passphrase: validatorsJson.secrets[0],
-				keyType: "consensus",
 				app: context.sandbox.app,
+				keyType: "consensus",
+				passphrase: validatorsJson.secrets[0],
 			})
 			.make<Types.Identity>();
 
@@ -33,10 +34,10 @@ describe<{
 
 	it("#makeProposal - should correctly make signed proposal", async ({ factory, identity, verifier }) => {
 		const block: Contracts.Crypto.IBlock = {
+			data: blockData,
 			header: { ...blockData },
 			serialized: serializedBlock,
 			transactions: [],
-			data: blockData,
 		};
 
 		const proposal = await factory.makeProposal(
@@ -62,9 +63,9 @@ describe<{
 	it("#makePrecommit - should correctly make signed precommit", async ({ factory, identity, verifier }) => {
 		const precommit = await factory.makePrecommit(
 			{
+				blockId: blockData.id,
 				height: 1,
 				round: 1,
-				blockId: blockData.id,
 				validatorIndex: 0,
 			},
 			identity.keys,
@@ -83,9 +84,9 @@ describe<{
 	it("#makePrecommit - should correctly make signed precommit no block", async ({ factory, identity, verifier }) => {
 		const precommit = await factory.makePrecommit(
 			{
+				blockId: undefined,
 				height: 1,
 				round: 1,
-				blockId: undefined,
 				validatorIndex: 0,
 			},
 			identity.keys,
@@ -104,9 +105,9 @@ describe<{
 	it("#makePrevote - should correctly make signed prevote", async ({ factory, identity, verifier }) => {
 		const prevote = await factory.makePrevote(
 			{
+				blockId: blockData.id,
 				height: 1,
 				round: 1,
-				blockId: blockData.id,
 				validatorIndex: 0,
 			},
 			identity.keys,
@@ -125,9 +126,9 @@ describe<{
 	it("#makePrevote - should correctly make signed prevote no block", async ({ factory, identity, verifier }) => {
 		const prevote = await factory.makePrevote(
 			{
+				blockId: undefined,
 				height: 1,
 				round: 1,
-				blockId: undefined,
 				validatorIndex: 0,
 			},
 			identity.keys,

--- a/packages/crypto-messages/source/factory.ts
+++ b/packages/crypto-messages/source/factory.ts
@@ -11,7 +11,7 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 	private readonly serializer!: Contracts.Crypto.IMessageSerializer;
 
 	@inject(Identifiers.Cryptography.Message.Deserializer)
-	private readonly deserialzier!: Contracts.Crypto.IMessageDeserializer;
+	private readonly deserializer!: Contracts.Crypto.IMessageDeserializer;
 
 	@inject(Identifiers.Cryptography.Block.Factory)
 	private readonly blockFactory!: Contracts.Crypto.IBlockFactory;
@@ -30,7 +30,7 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 	}
 
 	public async makeProposalFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IProposal> {
-		const data = await this.deserialzier.deserializeProposal(bytes);
+		const data = await this.deserializer.deserializeProposal(bytes);
 		const block = await this.blockFactory.fromHex(data.block.serialized);
 
 		return new Proposal(data.height, data.round, block, data.validRound, data.validatorIndex, data.signature);
@@ -46,7 +46,7 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 	}
 
 	public async makePrevoteFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IPrecommit> {
-		const data = await this.deserialzier.deserializePrevote(bytes);
+		const data = await this.deserializer.deserializePrevote(bytes);
 		return new Prevote(data.height, data.round, data.blockId, data.validatorIndex, data.signature);
 	}
 
@@ -60,7 +60,7 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 	}
 
 	public async makePrecommitFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IPrecommit> {
-		const data = await this.deserialzier.deserializePrecommit(bytes);
+		const data = await this.deserializer.deserializePrecommit(bytes);
 		return new Precommit(data.height, data.round, data.blockId, data.validatorIndex, data.signature);
 	}
 }

--- a/packages/crypto-messages/source/precommit.test.ts
+++ b/packages/crypto-messages/source/precommit.test.ts
@@ -36,7 +36,7 @@ describe<{
 	});
 
 	it("#toString", async () => {
-		assert.equal(precommit.toString(), `{"height":1,"round":1}`);
+		assert.equal(precommit.toString(), `{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`);
 	});
 
 	it("#toData", async () => {

--- a/packages/crypto-messages/source/precommit.test.ts
+++ b/packages/crypto-messages/source/precommit.test.ts
@@ -36,7 +36,10 @@ describe<{
 	});
 
 	it("#toString", async () => {
-		assert.equal(precommit.toString(), `{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`);
+		assert.equal(
+			precommit.toString(),
+			`{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`,
+		);
 	});
 
 	it("#toData", async () => {

--- a/packages/crypto-messages/source/precommit.ts
+++ b/packages/crypto-messages/source/precommit.ts
@@ -40,6 +40,8 @@ export class Precommit implements Contracts.Crypto.IPrecommit {
 			blockId: this.#blockId,
 			height: this.#height,
 			round: this.#round,
+			signature: this.#signature,
+			validatorIndex: this.#validatorIndex,
 		});
 	}
 

--- a/packages/crypto-messages/source/prevote.test.ts
+++ b/packages/crypto-messages/source/prevote.test.ts
@@ -36,7 +36,10 @@ describe<{
 	});
 
 	it("#toString", async () => {
-		assert.equal(prevote.toString(), `{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`);
+		assert.equal(
+			prevote.toString(),
+			`{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`,
+		);
 	});
 
 	it("#toData", async () => {

--- a/packages/crypto-messages/source/prevote.test.ts
+++ b/packages/crypto-messages/source/prevote.test.ts
@@ -36,7 +36,7 @@ describe<{
 	});
 
 	it("#toString", async () => {
-		assert.equal(prevote.toString(), `{"height":1,"round":1}`);
+		assert.equal(prevote.toString(), `{"height":1,"round":1,"signature":"b22317bfdb10ba592724c27d0cdc51378e5cd94a12cd7e85c895d2a68e8589e8d3c5b3c80f4fe905ef67aa7827617d04110c5c5248f2bb36df97a58c541961ed0f2fcd0760e9de5ae1598f27638dd3ddaebeea08bf313832a57cfdb7f2baaa03","validatorIndex":0}`);
 	});
 
 	it("#toData", async () => {

--- a/packages/crypto-messages/source/prevote.ts
+++ b/packages/crypto-messages/source/prevote.ts
@@ -40,6 +40,8 @@ export class Prevote implements Contracts.Crypto.IPrevote {
 			blockId: this.#blockId,
 			height: this.#height,
 			round: this.#round,
+			signature: this.#signature,
+			validatorIndex: this.#validatorIndex,
 		});
 	}
 

--- a/packages/crypto-messages/source/serializer.ts
+++ b/packages/crypto-messages/source/serializer.ts
@@ -16,7 +16,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 
 	public async serializeProposal(
 		proposal: Contracts.Crypto.IMessageSerializableProposal,
-		options: Contracts.Crypto.IMessageSerializeProposalOptions = {},
+		options: Contracts.Crypto.IMessageSerializeOptions = {},
 	): Promise<Buffer> {
 		return this.serializer.serialize<Contracts.Crypto.IMessageSerializableProposal>(proposal, {
 			length:
@@ -54,7 +54,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 
 	public async serializePrecommit(
 		precommit: Contracts.Crypto.IPrecommitData,
-		options: Contracts.Crypto.IMessageSerializePrecommitOptions = {},
+		options: Contracts.Crypto.IMessageSerializeOptions = {},
 	): Promise<Buffer> {
 		return this.serializer.serialize<Contracts.Crypto.IPrecommitData>(precommit, {
 			length:
@@ -92,7 +92,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 
 	public async serializePrevote(
 		prevote: Contracts.Crypto.IPrevoteData,
-		options: Contracts.Crypto.IMessageSerializePrevoteOptions = {},
+		options: Contracts.Crypto.IMessageSerializeOptions = {},
 	): Promise<Buffer> {
 		return this.serializer.serialize<Contracts.Crypto.IPrevoteData>(prevote, {
 			length:

--- a/packages/crypto-messages/source/serializer.ts
+++ b/packages/crypto-messages/source/serializer.ts
@@ -5,7 +5,6 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 @injectable()
 export class Serializer implements Contracts.Crypto.IMessageSerializer {
 	@inject(Identifiers.Cryptography.Serializer)
-	@tagged("type", "consensus")
 	private readonly serializer!: Contracts.Serializer.ISerializer;
 
 	@inject(Identifiers.Cryptography.Size.Signature)
@@ -46,7 +45,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 					? {}
 					: {
 							signature: {
-								type: "signature",
+								type: "consensusSignature",
 							},
 					  }),
 			},
@@ -84,7 +83,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 					? {}
 					: {
 							signature: {
-								type: "signature",
+								type: "consensusSignature",
 							},
 					  }),
 			},
@@ -122,7 +121,7 @@ export class Serializer implements Contracts.Crypto.IMessageSerializer {
 					? {}
 					: {
 							signature: {
-								type: "signature",
+								type: "consensusSignature",
 							},
 					  }),
 			},

--- a/packages/crypto-messages/test/helpers/prepare-sandbox.ts
+++ b/packages/crypto-messages/test/helpers/prepare-sandbox.ts
@@ -1,28 +1,27 @@
 import { Identifiers } from "@mainsail/contracts";
 
 import crypto from "../../../core/bin/config/testnet/crypto.json";
-import { Sandbox } from "../../../test-framework";
-import { ServiceProvider as CoreSerializer } from "../../../serializer";
-import { ServiceProvider as CoreValidation } from "../../../validation";
-import { ServiceProvider as CoreCryptoConfig } from "../../../crypto-config";
-import { ServiceProvider as CoreCryptoHashBcrypto } from "../../../crypto-hash-bcrypto";
+import validatorsJson from "../../../core/bin/config/testnet/validators.json";
 import { ServiceProvider as CoreCryptoAddressBech32m } from "../../../crypto-address-bech32m";
-import { ServiceProvider as CoreCryptoWif } from "../../../crypto-wif";
+import { ServiceProvider as CryptoBlock } from "../../../crypto-block";
+import { ServiceProvider as CoreCryptoConfig } from "../../../crypto-config";
+import { Configuration } from "../../../crypto-config/source/configuration";
 import { ServiceProvider as CoreConsensusBls12381 } from "../../../crypto-consensus-bls12-381";
+import { ServiceProvider as CoreCryptoHashBcrypto } from "../../../crypto-hash-bcrypto";
 import { ServiceProvider as CoreCryptoKeyPairSchnorr } from "../../../crypto-key-pair-schnorr";
 import { ServiceProvider as CoreCryptoSignatureSchnorr } from "../../../crypto-signature-schnorr";
 import { ServiceProvider as CoreCryptoTransaction } from "../../../crypto-transaction";
-import { ServiceProvider as CoreTransactions } from "../../../transactions";
+import { ServiceProvider as CoreCryptoWif } from "../../../crypto-wif";
+import { ServiceProvider as CoreSerializer } from "../../../serializer";
 import { ServiceProvider as CoreState } from "../../../state";
+import { Sandbox } from "../../../test-framework";
+import { ServiceProvider as CoreTransactions } from "../../../transactions";
+import { ServiceProvider as CoreValidation } from "../../../validation";
 import { ServiceProvider as CoreValidatorSet } from "../../../validator-set-static";
-
-import { Configuration } from "../../../crypto-config/source/configuration";
-import validatorsJson from "../../../core/bin/config/testnet/validators.json";
-
-import { Serializer } from "../../source/serializer";
 import { Deserializer } from "../../source/deserializer";
-import { Verifier } from "../../source/verifier";
 import { MessageFactory } from "../../source/factory";
+import { Serializer } from "../../source/serializer";
+import { Verifier } from "../../source/verifier";
 
 export const prepareSandbox = async (context) => {
 	context.sandbox = new Sandbox();
@@ -41,6 +40,7 @@ export const prepareSandbox = async (context) => {
 	await context.sandbox.app.resolve(CoreConsensusBls12381).register();
 	await context.sandbox.app.resolve(CoreCryptoTransaction).register();
 	await context.sandbox.app.resolve(CoreTransactions).register();
+	await context.sandbox.app.resolve(CryptoBlock).register();
 
 	context.sandbox.app.bind(Identifiers.EventDispatcherService).toConstantValue({ dispatchSync: () => {} });
 
@@ -59,10 +59,10 @@ export const prepareSandbox = async (context) => {
 		"type",
 		"consensus",
 	);
-	for (let i = 0; i < validatorsJson.secrets.length; i++) {
-		const mnemonic = validatorsJson.secrets[i];
+	for (let index = 0; index < validatorsJson.secrets.length; index++) {
+		const mnemonic = validatorsJson.secrets[index];
 		const wallet = walletRepository.findByAddress(mnemonic);
-		wallet.setAttribute("validator.username", `genesis_${i + 1}`);
+		wallet.setAttribute("validator.username", `genesis_${index + 1}`);
 		wallet.setAttribute("consensus.publicKey", await consensusPublicKeyFactory.fromMnemonic(mnemonic));
 
 		walletRepository.index(wallet);

--- a/packages/p2p/source/socket-server/controllers/post-precommit.test.ts
+++ b/packages/p2p/source/socket-server/controllers/post-precommit.test.ts
@@ -7,7 +7,7 @@ describe<{
 	sandbox: Sandbox;
 	controller: PostPrecommitController;
 }>("PostProvoteController", ({ it, assert, beforeEach, stub, spy }) => {
-	const deserializer = { deserializePrecommit: () => {} };
+	const factory = { makePrecommitFromBytes: () => {} };
 	const handler = {
 		onPrecommit: () => {},
 	};
@@ -16,7 +16,7 @@ describe<{
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Consensus.Handler).toConstantValue(handler);
-		context.sandbox.app.bind(Identifiers.Cryptography.Message.Deserializer).toConstantValue(deserializer);
+		context.sandbox.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue(factory);
 
 		context.controller = context.sandbox.app.resolve(PostPrecommitController);
 	});
@@ -24,7 +24,7 @@ describe<{
 	it("#handle - should deserialize prevote and call onPrecommit handler", async ({ controller }) => {
 		const prevote = { height: 1 };
 
-		stub(deserializer, "deserializePrecommit").resolvedValue(prevote);
+		stub(factory, "makePrecommitFromBytes").resolvedValue(prevote);
 		const spyOnPrecommit = spy(handler, "onPrecommit");
 
 		await controller.handle({ payload: { precommit: Buffer.from("") } }, {});

--- a/packages/p2p/source/socket-server/controllers/post-precommit.ts
+++ b/packages/p2p/source/socket-server/controllers/post-precommit.ts
@@ -13,11 +13,11 @@ export class PostPrecommitController implements Contracts.P2P.Controller {
 	@inject(Identifiers.Consensus.Handler)
 	private readonly consensusHandler!: Contracts.Consensus.IHandler;
 
-	@inject(Identifiers.Cryptography.Message.Deserializer)
-	private readonly deserializer!: Contracts.Crypto.IMessageDeserializer;
+	@inject(Identifiers.Cryptography.Message.Factory)
+	private readonly factory!: Contracts.Crypto.IMessageFactory;
 
 	public async handle(request: Request, h: Hapi.ResponseToolkit): Promise<{}> {
-		const precommit = await this.deserializer.deserializePrecommit(request.payload.precommit);
+		const precommit = await this.factory.makePrecommitFromBytes(request.payload.precommit);
 
 		await this.consensusHandler.onPrecommit(precommit);
 

--- a/packages/p2p/source/socket-server/controllers/post-prevote.test.ts
+++ b/packages/p2p/source/socket-server/controllers/post-prevote.test.ts
@@ -7,7 +7,7 @@ describe<{
 	sandbox: Sandbox;
 	controller: PostPrevoteController;
 }>("PostProvoteController", ({ it, assert, beforeEach, stub, spy }) => {
-	const deserializer = { deserializePrevote: () => {} };
+	const factory = { makePrevoteFromBytes: () => {} };
 	const handler = {
 		onPrevote: () => {},
 	};
@@ -16,7 +16,7 @@ describe<{
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Consensus.Handler).toConstantValue(handler);
-		context.sandbox.app.bind(Identifiers.Cryptography.Message.Deserializer).toConstantValue(deserializer);
+		context.sandbox.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue(factory);
 
 		context.controller = context.sandbox.app.resolve(PostPrevoteController);
 	});
@@ -24,7 +24,7 @@ describe<{
 	it("#handle - should deserialize prevote and call onPrevote handler", async ({ controller }) => {
 		const prevote = { height: 1 };
 
-		stub(deserializer, "deserializePrevote").resolvedValue(prevote);
+		stub(factory, "makePrevoteFromBytes").resolvedValue(prevote);
 		const spyOnPrevote = spy(handler, "onPrevote");
 
 		await controller.handle({ payload: { prevote: Buffer.from("") } }, {});

--- a/packages/p2p/source/socket-server/controllers/post-prevote.ts
+++ b/packages/p2p/source/socket-server/controllers/post-prevote.ts
@@ -13,11 +13,11 @@ export class PostPrevoteController implements Contracts.P2P.Controller {
 	@inject(Identifiers.Consensus.Handler)
 	private readonly consensusHandler!: Contracts.Consensus.IHandler;
 
-	@inject(Identifiers.Cryptography.Message.Deserializer)
-	private readonly deserializer!: Contracts.Crypto.IMessageDeserializer;
+	@inject(Identifiers.Cryptography.Message.Factory)
+	private readonly factory!: Contracts.Crypto.IMessageFactory;
 
 	public async handle(request: Request, h: Hapi.ResponseToolkit): Promise<{}> {
-		const prevote = await this.deserializer.deserializePrevote(request.payload.prevote);
+		const prevote = await this.factory.makePrevoteFromBytes(request.payload.prevote);
 
 		await this.consensusHandler.onPrevote(prevote);
 

--- a/packages/p2p/source/socket-server/controllers/post-proposal.test.ts
+++ b/packages/p2p/source/socket-server/controllers/post-proposal.test.ts
@@ -7,7 +7,7 @@ describe<{
 	sandbox: Sandbox;
 	controller: PostProposalController;
 }>("PostProvoteController", ({ it, assert, beforeEach, stub, spy }) => {
-	const deserializer = { deserializeProposal: () => {} };
+	const factory = { makeProposalFromBytes: () => {} };
 	const handler = {
 		onProposal: () => {},
 	};
@@ -16,7 +16,7 @@ describe<{
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Consensus.Handler).toConstantValue(handler);
-		context.sandbox.app.bind(Identifiers.Cryptography.Message.Deserializer).toConstantValue(deserializer);
+		context.sandbox.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue(factory);
 
 		context.controller = context.sandbox.app.resolve(PostProposalController);
 	});
@@ -24,7 +24,7 @@ describe<{
 	it("#handle - should deserialize prevote and call onPrevote handler", async ({ controller }) => {
 		const prevote = { height: 1 };
 
-		stub(deserializer, "deserializeProposal").resolvedValue(prevote);
+		stub(factory, "makeProposalFromBytes").resolvedValue(prevote);
 		const spyOnPrevote = spy(handler, "onProposal");
 
 		await controller.handle({ payload: { proposal: Buffer.from("") } }, {});

--- a/packages/p2p/source/socket-server/controllers/post-proposal.ts
+++ b/packages/p2p/source/socket-server/controllers/post-proposal.ts
@@ -13,11 +13,11 @@ export class PostProposalController implements Contracts.P2P.Controller {
 	@inject(Identifiers.Consensus.Handler)
 	private readonly consensusHandler!: Contracts.Consensus.IHandler;
 
-	@inject(Identifiers.Cryptography.Message.Deserializer)
-	private readonly deserializer!: Contracts.Crypto.IMessageDeserializer;
+	@inject(Identifiers.Cryptography.Message.Factory)
+	private readonly factory!: Contracts.Crypto.IMessageFactory;
 
 	public async handle(request: Request, h: Hapi.ResponseToolkit): Promise<{}> {
-		const proposal = await this.deserializer.deserializeProposal(request.payload.proposal);
+		const proposal = await this.factory.makeProposalFromBytes(request.payload.proposal);
 
 		await this.consensusHandler.onProposal(proposal);
 

--- a/packages/p2p/source/socket-server/server.test.ts
+++ b/packages/p2p/source/socket-server/server.test.ts
@@ -53,7 +53,7 @@ describe<{ sandbox: Sandbox; server: Server }>("Server", ({ it, assert, beforeEa
 		context.sandbox.app.bind(Identifiers.StateStore).toConstantValue({});
 		context.sandbox.app.bind(Identifiers.PeerProcessor).toConstantValue({});
 		context.sandbox.app.bind(Identifiers.Consensus.Handler).toConstantValue({});
-		context.sandbox.app.bind(Identifiers.Cryptography.Message.Deserializer).toConstantValue({});
+		context.sandbox.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue({});
 
 		context.server = context.sandbox.app.resolve(ServerProxy);
 	});

--- a/packages/serializer/source/serializer.ts
+++ b/packages/serializer/source/serializer.ts
@@ -6,15 +6,19 @@ import { BigNumber, ByteBuffer } from "@mainsail/utils";
 @injectable()
 export class Serializer implements Contracts.Serializer.ISerializer {
 	@inject(Identifiers.Cryptography.Identity.AddressFactory)
+	@tagged("type", "wallet")
 	private readonly addressFactory!: Contracts.Crypto.IAddressFactory;
 
 	@inject(Identifiers.Cryptography.Identity.AddressSerializer)
+	@tagged("type", "wallet")
 	private readonly addressSerializer!: Contracts.Crypto.IAddressSerializer;
 
 	@inject(Identifiers.Cryptography.Identity.PublicKeySerializer)
+	@tagged("type", "wallet")
 	private readonly publicKeySerializer!: Contracts.Crypto.IPublicKeySerializer;
 
 	@inject(Identifiers.Cryptography.Signature)
+	@tagged("type", "wallet")
 	private readonly signatureSerializer!: Contracts.Crypto.ISignature;
 
 	@inject(Identifiers.Cryptography.Signature)

--- a/packages/serializer/source/serializer.ts
+++ b/packages/serializer/source/serializer.ts
@@ -232,7 +232,7 @@ export class Serializer implements Contracts.Serializer.ISerializer {
 			}
 
 			if (schema.type === "hex") {
-				target[property] = { serialized: source.readBytes(source.readUint32()).toString("hex") }
+				target[property] = { serialized: source.readBytes(source.readUint32()).toString("hex") };
 				continue;
 			}
 

--- a/packages/serializer/source/serializer.ts
+++ b/packages/serializer/source/serializer.ts
@@ -228,7 +228,7 @@ export class Serializer implements Contracts.Serializer.ISerializer {
 			}
 
 			if (schema.type === "hex") {
-				target[property] = source.readBytes(source.readUint32()).toString("hex");
+				target[property] = { serialized: source.readBytes(source.readUint32()).toString("hex") }
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

- use tagged values directly on serializer object instead on injects
- use consenusSignature type on crypto-messages
- extend factory with* fromBytes methods
- use proper types 
- use factory instead deserialzier on p2p

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

