### PR TITLE
refactor(consensus): move enums to contracts

### DIFF
--- a/packages/consensus/source/consensus.test.ts
+++ b/packages/consensus/source/consensus.test.ts
@@ -2,7 +2,6 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 import { describe, Sandbox } from "@mainsail/test-framework";
 
 import { Consensus } from "./consensus";
-import { Step } from "./enums";
 
 type Context = {
 	sandbox: Sandbox;
@@ -111,7 +110,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 	});
 
 	it("#getStep - should return initial value", async ({ consensus }) => {
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#getLockedValue - should return initial value", async ({ consensus }) => {
@@ -136,7 +135,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 			lockedRound: undefined,
 			lockedValue: undefined,
 			round: 0,
-			step: Step.propose,
+			step: Contracts.Consensus.Step.Propose,
 			validRound: undefined,
 			validValue: undefined,
 		});
@@ -172,7 +171,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyScheduleTimeoutPropose.calledOnce();
 		spyLoggerInfo.calledWith(`>> Starting new round: ${2}/${0} with proposer ${validatorPublicKey}`);
 		spyLoggerInfo.calledWith(`No registered proposer for ${validatorPublicKey}`);
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#startRound - local validator should propose", async ({
@@ -226,7 +225,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spySchedulerClear.calledOnce();
 		spyScheduleTimeoutPropose.neverCalled();
 		spyLoggerInfo.calledWith(`>> Starting new round: ${2}/${0} with proposer ${validatorPublicKey}`);
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#startRound - local validator should locked value", async () => {});
@@ -234,11 +233,11 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 	it("#onProposal - should return if step !== propose", async ({ consensus, blockProcessor, roundState }) => {
 		const spyBlockProcessorProcess = spy(blockProcessor, "process");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onProposal(roundState);
 
 		spyBlockProcessorProcess.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onProposal - should return if height doesn't match", async ({ consensus, blockProcessor, roundState }) => {
@@ -248,7 +247,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onProposal(roundState);
 
 		spyBlockProcessorProcess.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposal - should return if round doesn't match", async ({ consensus, blockProcessor, roundState }) => {
@@ -258,7 +257,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onProposal(roundState);
 
 		spyBlockProcessorProcess.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposal - should return if proposal is undefined", async ({ consensus, blockProcessor, roundState }) => {
@@ -268,7 +267,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onProposal(roundState);
 
 		spyBlockProcessorProcess.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposal - should return if proposed validRound is defined", async ({
@@ -283,7 +282,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onProposal(roundState);
 
 		spyBlockProcessorProcess.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposal - should return if not from valid proposer", async ({ consensus }) => {});
@@ -337,7 +336,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrevote.calledWith(prevote);
 		spyLoggerInfo.calledWith(`Received proposal ${2}/${0} blockId: ${proposal.block.data.id}`);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onProposal - broadcast prevote undefined, if block is invalid", async ({
@@ -388,7 +387,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrevote.calledWith(prevote);
 		spyLoggerInfo.calledWith(`Received proposal ${2}/${0} blockId: ${proposal.block.data.id}`);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	// TODO: Handle on processor
@@ -448,7 +447,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrevote.calledWith(prevote);
 		spyLoggerInfo.calledWith(`Received proposal ${2}/${1} with locked blockId: ${proposal.block.data.id}`);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onProposalLocked - broadcast prevote block id, if block is valid and valid round is higher or equal than lockedRound ", async () => {});
@@ -501,7 +500,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrevote.calledOnce();
 		spyHandlerOnPrevote.calledWith(prevote);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onProposalLocked - broadcast prevote null, if block is valid and lockedRound is higher than validRound", async () => {});
@@ -510,20 +509,20 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		proposal.validRound = 0;
 		roundState.round = 1;
 		consensus.setRound(1);
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onProposalLocked - should return if step === precommit", async ({ consensus, roundState, proposal }) => {
 		proposal.validRound = 0;
 		roundState.round = 1;
 		consensus.setRound(1);
-		consensus.setStep(Step.precommit);
+		consensus.setStep(Contracts.Consensus.Step.Precommit);
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onProposalLocked - should return if height doesn't match", async ({ consensus, roundState, proposal }) => {
@@ -533,7 +532,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		roundState.height = 3;
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposalLocked - should return if round doesn't match", async ({ consensus, roundState, proposal }) => {
@@ -541,7 +540,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		roundState.round = 1;
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposalLocked - should return if proposal is undefined", async ({ consensus, roundState, proposal }) => {
@@ -551,7 +550,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		roundState.getProposal = () => undefined;
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposalLocked - should return if validRound is undefined", async ({ consensus, roundState, proposal }) => {
@@ -559,7 +558,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		consensus.setRound(1);
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposalLocked - should return if validRound is higher than round", async ({
@@ -572,7 +571,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		consensus.setRound(1);
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onProposalLocked - should return if validRound is equal to round", async ({
@@ -585,7 +584,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		consensus.setRound(1);
 		await consensus.onProposalLocked(roundState);
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onMajorityPrevote - should set locked values, valid values and precommit, when step === prevote", async ({
@@ -627,7 +626,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.undefined(consensus.getValidRound());
 		assert.undefined(consensus.getValidValue());
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		spyGetActiveValidators.calledOnce();
@@ -649,7 +648,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.equal(consensus.getLockedValue(), roundState);
 		assert.equal(consensus.getValidRound(), 0);
 		assert.equal(consensus.getValidValue(), roundState);
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onMajorityPrevote - should set valid values and precommit, when step === precommit", async ({
@@ -663,14 +662,14 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.undefined(consensus.getValidRound());
 		assert.undefined(consensus.getValidValue());
 
-		consensus.setStep(Step.precommit);
+		consensus.setStep(Contracts.Consensus.Step.Precommit);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
 		assert.undefined(consensus.getLockedValue());
 		assert.equal(consensus.getValidRound(), 0);
 		assert.equal(consensus.getValidValue(), roundState);
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onMajorityPrevote - should only be called once", async ({
@@ -709,7 +708,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.undefined(consensus.getValidRound());
 		assert.undefined(consensus.getValidValue());
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		spyGetActiveValidators.calledOnce();
@@ -726,9 +725,9 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.equal(consensus.getLockedValue(), roundState);
 		assert.equal(consensus.getValidRound(), 0);
 		assert.equal(consensus.getValidValue(), roundState);
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		spyGetActiveValidators.calledOnce();
@@ -745,11 +744,11 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		assert.equal(consensus.getLockedValue(), roundState);
 		assert.equal(consensus.getValidRound(), 0);
 		assert.equal(consensus.getValidValue(), roundState);
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrevote - should return if step === propose", async ({ consensus, roundState }) => {
-		consensus.setStep(Step.propose);
+		consensus.setStep(Contracts.Consensus.Step.Propose);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
@@ -760,7 +759,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 
 	it("#onMajorityPrevote - should return if height doesn't match", async ({ consensus, roundState }) => {
 		roundState.height = 3;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
@@ -771,7 +770,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 
 	it("#onMajorityPrevote - should return if round doesn't match", async ({ consensus, roundState }) => {
 		roundState.round = 1;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
@@ -782,7 +781,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 
 	it("#onMajorityPrevote - should return if proposal is undefined", async ({ consensus, roundState }) => {
 		roundState.getProposal = () => undefined;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
@@ -793,7 +792,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 
 	it("#onMajorityPrevote - should return if processor result is false", async ({ consensus, roundState }) => {
 		roundState.getProcessorResult = () => false;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevote(roundState);
 
 		assert.undefined(consensus.getLockedRound());
@@ -805,22 +804,22 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 	it("#onMajorityPrevoteAny - should schedule timeout prevote", async ({ consensus, scheduler, roundState }) => {
 		const spyScheduleTimeout = spy(scheduler, "scheduleTimeoutPrevote");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteAny(roundState);
 
 		spyScheduleTimeout.calledOnce();
 		spyScheduleTimeout.calledWith(2, 0);
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrevoteAny - should return if step !== prevote", async ({ consensus, scheduler, roundState }) => {
 		const spyScheduleTimeout = spy(scheduler, "scheduleTimeoutPrevote");
 
-		consensus.setStep(Step.propose);
+		consensus.setStep(Contracts.Consensus.Step.Propose);
 		await consensus.onMajorityPrevoteAny(roundState);
 
 		spyScheduleTimeout.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onMajorityPrevoteAny - should return if height doesn't match", async ({
@@ -831,11 +830,11 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		const spyScheduleTimeout = spy(scheduler, "scheduleTimeoutPrevote");
 
 		roundState.height = 3;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteAny(roundState);
 
 		spyScheduleTimeout.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrevoteAny - should return if height doesn't match", async ({
@@ -846,11 +845,11 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		const spyScheduleTimeout = spy(scheduler, "scheduleTimeoutPrevote");
 
 		roundState.round = 1;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteAny(roundState);
 
 		spyScheduleTimeout.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrevoteNull - should precommit", async ({
@@ -881,7 +880,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 		const spyHandlerOnPrecommit = spy(handler, "onPrecommit");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteNull(roundState);
 
 		spyGetActiveValidators.calledOnce();
@@ -896,42 +895,42 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrecommit.calledOnce();
 		spyHandlerOnPrecommit.calledWith(precommit);
 
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onMajorityPrevoteNull - should return if step !== prevote", async ({ consensus, roundState }) => {
-		consensus.setStep(Step.precommit);
+		consensus.setStep(Contracts.Consensus.Step.Precommit);
 		await consensus.onMajorityPrevoteNull(roundState);
 
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onMajorityPrevoteNull - should return if height doesn't match", async ({ consensus, roundState }) => {
 		roundState.height = 3;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteNull(roundState);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrevoteNull - should return if round doesn't match", async ({ consensus, roundState }) => {
 		roundState.round = 1;
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onMajorityPrevoteNull(roundState);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onMajorityPrecommitAny - should schedule timeout precommit", async ({ consensus, scheduler, roundState }) => {
 		const spyScheduleTimeout = spy(scheduler, "scheduleTimeoutPrecommit");
 
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 
 		await consensus.onMajorityPrecommitAny(roundState);
 
 		spyScheduleTimeout.calledOnce();
 		spyScheduleTimeout.calledWith(2, 0);
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onMajorityPrecommit - should commit & increase height", async ({
@@ -1133,27 +1132,27 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrevote.calledOnce();
 		spyHandlerOnPrevote.calledWith(prevote);
 
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onTimeoutPropose - should return if step === prevote", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrevote = spy(broadcaster, "broadcastPrevote");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onTimeoutPropose(2, 0);
 
 		spyBroadcastPrevote.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onTimeoutPropose - should return if step === precommit", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrevote = spy(broadcaster, "broadcastPrevote");
 
-		consensus.setStep(Step.precommit);
+		consensus.setStep(Contracts.Consensus.Step.Precommit);
 		await consensus.onTimeoutPropose(2, 0);
 
 		spyBroadcastPrevote.neverCalled();
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onTimeoutPropose - should return if height doesn't match", async ({ consensus, broadcaster }) => {
@@ -1162,7 +1161,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onTimeoutPropose(3, 0);
 
 		spyBroadcastPrevote.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onTimeoutPropose - should return if round doesn't match", async ({ consensus, broadcaster }) => {
@@ -1171,7 +1170,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		await consensus.onTimeoutPropose(2, 1);
 
 		spyBroadcastPrevote.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onTimeoutPrevote - should precommit null", async ({
@@ -1201,7 +1200,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 		const spyHandlerOnPrecommit = spy(handler, "onPrecommit");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onTimeoutPrevote(2, 0);
 
 		spyGetActiveValidators.calledOnce();
@@ -1216,47 +1215,47 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyHandlerOnPrecommit.calledOnce();
 		spyHandlerOnPrecommit.calledWith(precommit);
 
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onTimeoutPrevote - should return if step === propose", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 
-		consensus.setStep(Step.propose);
+		consensus.setStep(Contracts.Consensus.Step.Propose);
 		await consensus.onTimeoutPrevote(2, 0);
 
 		spyBroadcastPrecommit.neverCalled();
-		assert.equal(consensus.getStep(), Step.propose);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Propose);
 	});
 
 	it("#onTimeoutPrevote - should return if step === precommit", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 
-		consensus.setStep(Step.precommit);
+		consensus.setStep(Contracts.Consensus.Step.Precommit);
 		await consensus.onTimeoutPrevote(2, 0);
 
 		spyBroadcastPrecommit.neverCalled();
-		assert.equal(consensus.getStep(), Step.precommit);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Precommit);
 	});
 
 	it("#onTimeoutPrevote - should return if height doesn't match", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onTimeoutPrevote(3, 0);
 
 		spyBroadcastPrecommit.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	it("#onTimeoutPrevote - should return if round doesn't match", async ({ consensus, broadcaster }) => {
 		const spyBroadcastPrecommit = spy(broadcaster, "broadcastPrecommit");
 
-		consensus.setStep(Step.prevote);
+		consensus.setStep(Contracts.Consensus.Step.Prevote);
 		await consensus.onTimeoutPrevote(2, 1);
 
 		spyBroadcastPrecommit.neverCalled();
-		assert.equal(consensus.getStep(), Step.prevote);
+		assert.equal(consensus.getStep(), Contracts.Consensus.Step.Prevote);
 	});
 
 	each(
@@ -1272,7 +1271,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 			spyConsensusStartRound.calledOnce();
 			spyConsensusStartRound.calledWith(1);
 		},
-		[Step.propose, Step.prevote, Step.precommit],
+		[Contracts.Consensus.Step.Propose, Contracts.Consensus.Step.Prevote, Contracts.Consensus.Step.Precommit],
 	);
 
 	it("#onTimeoutPrecommit - should return if height doesn't match", async ({ consensus, broadcaster }) => {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -126,7 +126,12 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	public async onProposal(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		const proposal = roundState.getProposal();
 
-		if (this.#step !== Contracts.Consensus.Step.Propose || this.#isInvalidRoundState(roundState) || !proposal || proposal.validRound) {
+		if (
+			this.#step !== Contracts.Consensus.Step.Propose ||
+			this.#isInvalidRoundState(roundState) ||
+			!proposal ||
+			proposal.validRound
+		) {
 			return;
 		}
 

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -1,8 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
-import { Step } from "./enums";
-
 @injectable()
 export class Consensus implements Contracts.Consensus.IConsensusService {
 	@inject(Identifiers.BlockProcessor)
@@ -32,7 +30,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 	#height = 2;
 	#round = 0;
-	#step: Step = Step.propose;
+	#step: Contracts.Consensus.Step = Contracts.Consensus.Step.Propose;
 	#lockedValue?: Contracts.Consensus.IRoundState;
 	#lockedRound?: number = undefined;
 	#validValue?: Contracts.Consensus.IRoundState;
@@ -54,12 +52,12 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.#round = round;
 	}
 
-	public getStep(): Step {
+	public getStep(): Contracts.Consensus.Step {
 		return this.#step;
 	}
 
 	// TODO: Only for testing
-	public setStep(step: Step): void {
+	public setStep(step: Contracts.Consensus.Step): void {
 		this.#step = step;
 	}
 
@@ -100,7 +98,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 	public async startRound(round: number): Promise<void> {
 		this.#round = round;
-		this.#step = Step.propose;
+		this.#step = Contracts.Consensus.Step.Propose;
 		this.#didMajorityPrevote = false;
 		this.#didMajorityPrecommit = false;
 
@@ -128,7 +126,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	public async onProposal(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		const proposal = roundState.getProposal();
 
-		if (this.#step !== Step.propose || this.#isInvalidRoundState(roundState) || !proposal || proposal.validRound) {
+		if (this.#step !== Contracts.Consensus.Step.Propose || this.#isInvalidRoundState(roundState) || !proposal || proposal.validRound) {
 			return;
 		}
 
@@ -138,7 +136,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		const result = await this.processor.process(roundState);
 		roundState.setProcessorResult(result);
 
-		this.#step = Step.prevote;
+		this.#step = Contracts.Consensus.Step.Prevote;
 
 		await this.#prevote(result ? proposal.block.data.id : undefined);
 	}
@@ -147,7 +145,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	public async onProposalLocked(roundState: Contracts.Consensus.IRoundState): Promise<void> {
 		const proposal = roundState.getProposal();
 		if (
-			this.#step !== Step.propose ||
+			this.#step !== Contracts.Consensus.Step.Propose ||
 			this.#isInvalidRoundState(roundState) ||
 			!proposal ||
 			proposal.validRound === undefined ||
@@ -160,7 +158,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 			`Received proposal ${this.#height}/${this.#round} with locked blockId: ${proposal.block.data.id}`,
 		);
 
-		this.#step = Step.prevote;
+		this.#step = Contracts.Consensus.Step.Prevote;
 		if (!this.#lockedRound || this.#lockedRound <= proposal.validRound) {
 			const result = await this.processor.process(roundState);
 			roundState.setProcessorResult(result);
@@ -179,7 +177,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 		if (
 			this.#didMajorityPrevote ||
-			this.#step === Step.propose ||
+			this.#step === Contracts.Consensus.Step.Propose ||
 			this.#isInvalidRoundState(roundState) ||
 			!proposal ||
 			!roundState.getProcessorResult()
@@ -195,12 +193,12 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 		this.#didMajorityPrevote = true;
 
-		if (this.#step === Step.prevote) {
+		if (this.#step === Contracts.Consensus.Step.Prevote) {
 			this.#lockedValue = roundState;
 			this.#lockedRound = this.#round;
 			this.#validValue = roundState;
 			this.#validRound = this.#round;
-			this.#step = Step.precommit;
+			this.#step = Contracts.Consensus.Step.Precommit;
 
 			await this.#precommit(proposal.block.data.id);
 		} else {
@@ -210,7 +208,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	public async onMajorityPrevoteAny(roundState: Contracts.Consensus.IRoundState): Promise<void> {
-		if (this.#step !== Step.prevote || this.#isInvalidRoundState(roundState)) {
+		if (this.#step !== Contracts.Consensus.Step.Prevote || this.#isInvalidRoundState(roundState)) {
 			return;
 		}
 
@@ -218,13 +216,13 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	public async onMajorityPrevoteNull(roundState: Contracts.Consensus.IRoundState): Promise<void> {
-		if (this.#step !== Step.prevote || this.#isInvalidRoundState(roundState)) {
+		if (this.#step !== Contracts.Consensus.Step.Prevote || this.#isInvalidRoundState(roundState)) {
 			return;
 		}
 
 		// ADD: Log info
 
-		this.#step = Step.precommit;
+		this.#step = Contracts.Consensus.Step.Precommit;
 
 		await this.#precommit();
 	}
@@ -278,20 +276,20 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	}
 
 	public async onTimeoutPropose(height: number, round: number): Promise<void> {
-		if (this.#step !== Step.propose || this.#height !== height || this.#round !== round) {
+		if (this.#step !== Contracts.Consensus.Step.Propose || this.#height !== height || this.#round !== round) {
 			return;
 		}
 
-		this.#step = Step.prevote;
+		this.#step = Contracts.Consensus.Step.Prevote;
 		await this.#prevote();
 	}
 
 	public async onTimeoutPrevote(height: number, round: number): Promise<void> {
-		if (this.#step !== Step.prevote || this.#height !== height || this.#round !== round) {
+		if (this.#step !== Contracts.Consensus.Step.Prevote || this.#height !== height || this.#round !== round) {
 			return;
 		}
 
-		this.#step = Step.precommit;
+		this.#step = Contracts.Consensus.Step.Precommit;
 		await this.#precommit();
 	}
 

--- a/packages/consensus/source/enums.ts
+++ b/packages/consensus/source/enums.ts
@@ -1,5 +1,0 @@
-export enum Step {
-	propose = "propose",
-	prevote = "prevote",
-	precommit = "precommit",
-}

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -76,7 +76,6 @@ export interface IValidatorRepository {
 	getValidators(publicKeys: string[]): IValidator[];
 }
 
-
 export enum Step {
 	Propose = 0,
 	Prevote = 1,

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -75,3 +75,10 @@ export interface IValidatorRepository {
 	getValidator(publicKey: string): IValidator | undefined;
 	getValidators(publicKeys: string[]): IValidator[];
 }
+
+
+export enum Step {
+	Propose = 0,
+	Prevote = 1,
+	Precommit = 2,
+}

--- a/packages/contracts/source/contracts/crypto/enums.ts
+++ b/packages/contracts/source/contracts/crypto/enums.ts
@@ -14,4 +14,3 @@ export enum TransactionTypeGroup {
 	// Everything above is available to anyone
 	Reserved = 1000,
 }
-

--- a/packages/contracts/source/contracts/crypto/enums.ts
+++ b/packages/contracts/source/contracts/crypto/enums.ts
@@ -14,3 +14,4 @@ export enum TransactionTypeGroup {
 	// Everything above is available to anyone
 	Reserved = 1000,
 }
+


### PR DESCRIPTION
## Summary

Move step enums to contracts. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
