### PR TITLE
feat(consensus): delayed start

### DIFF
--- a/packages/blockchain/source/state-machine/actions/initialize.ts
+++ b/packages/blockchain/source/state-machine/actions/initialize.ts
@@ -74,7 +74,7 @@ export class Initialize implements Action {
 			if (this.stateStore.getNetworkStart()) {
 				await this.app.get<Contracts.State.StateBuilder>(Identifiers.StateBuilder).run();
 				await this.transactionPool.readdTransactions();
-				await this.consensus.run();
+				void this.consensus.run();
 				await this.networkMonitor.boot();
 
 				return this.blockchain.dispatch("STARTED");
@@ -84,7 +84,7 @@ export class Initialize implements Action {
 				this.logger.notice("TEST SUITE DETECTED! SYNCING WALLETS AND STARTING IMMEDIATELY.");
 
 				await this.app.get<Contracts.State.StateBuilder>(Identifiers.StateBuilder).run();
-				await this.consensus.run();
+				void this.consensus.run();
 				await this.networkMonitor.boot();
 
 				return this.blockchain.dispatch("STARTED");
@@ -101,7 +101,7 @@ export class Initialize implements Action {
 
 			await this.transactionPool.readdTransactions();
 
-			await this.consensus.run();
+			void this.consensus.run();
 
 			await this.networkMonitor.boot();
 

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -93,6 +93,8 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		const lastBlock = this.state.getLastBlock();
 		this.#height = lastBlock.data.height + 1;
 
+		await this.scheduler.delayStart();
+
 		void this.startRound(this.#round);
 	}
 

--- a/packages/consensus/source/scheduler.ts
+++ b/packages/consensus/source/scheduler.ts
@@ -18,6 +18,23 @@ export class Scheduler implements Contracts.Consensus.IScheduler {
 	#timeoutPrevote?: NodeJS.Timeout;
 	#timeoutPrecommit?: NodeJS.Timeout;
 
+
+	// Temporary feature, to sync nodes faster
+	// Start every full 30 seconds
+	public async delayStart(): Promise<void> {
+		let differenceS = 60 - dayjs().second();
+
+		if(differenceS > 30) {
+			differenceS -= 30
+		}
+
+		if(differenceS < 15) {
+			differenceS += 15
+		}
+
+		await delay(differenceS * 1000 + 1000 - dayjs().millisecond());
+	}
+
 	public async delayProposal(): Promise<void> {
 		await delay(
 			Math.max(

--- a/packages/consensus/source/scheduler.ts
+++ b/packages/consensus/source/scheduler.ts
@@ -18,18 +18,17 @@ export class Scheduler implements Contracts.Consensus.IScheduler {
 	#timeoutPrevote?: NodeJS.Timeout;
 	#timeoutPrecommit?: NodeJS.Timeout;
 
-
 	// Temporary feature, to sync nodes faster
 	// Start every full 30 seconds
 	public async delayStart(): Promise<void> {
 		let differenceS = 60 - dayjs().second();
 
-		if(differenceS > 30) {
-			differenceS -= 30
+		if (differenceS > 30) {
+			differenceS -= 30;
 		}
 
-		if(differenceS < 15) {
-			differenceS += 15
+		if (differenceS < 15) {
+			differenceS += 15;
 		}
 
 		await delay(differenceS * 1000 + 1000 - dayjs().millisecond());

--- a/packages/contracts/source/contracts/consensus.ts
+++ b/packages/contracts/source/contracts/consensus.ts
@@ -55,6 +55,7 @@ export interface IHandler {
 }
 
 export interface IScheduler {
+	delayStart(): Promise<void>;
 	delayProposal(): Promise<void>;
 	scheduleTimeoutPropose(height: number, round: number): Promise<void>;
 	scheduleTimeoutPrevote(height: number, round: number): Promise<void>;


### PR DESCRIPTION
## Summary

Implements delayed start. It is mainly used for **testing purposes**.

Nodes start consensus on every full 30 second interval.  

## Checklist

- [x] Ready to be merged
