### PR TITLE
feat(validators): add formats

### DIFF
--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -22,9 +22,9 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
+		"ajv": "8.12.0",
 		"ajv-formats": "2.1.1",
-		"ajv-keywords": "5.1.0",
-		"ajv": "8.12.0"
+		"ajv-keywords": "5.1.0"
 	},
 	"devDependencies": {
 		"uvu": "^0.5.6"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -22,8 +22,9 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
-		"ajv": "8.12.0",
-		"ajv-keywords": "5.1.0"
+		"ajv-formats": "2.1.1",
+		"ajv-keywords": "5.1.0",
+		"ajv": "8.12.0"
 	},
 	"devDependencies": {
 		"uvu": "^0.5.6"

--- a/packages/validation/source/validator.ts
+++ b/packages/validation/source/validator.ts
@@ -1,6 +1,7 @@
 import { injectable, postConstruct } from "@mainsail/container";
 import { Contracts } from "@mainsail/contracts";
 import Ajv, { AnySchema, FormatDefinition, KeywordDefinition, Schema } from "ajv/dist/2020";
+import formats from "ajv-formats";
 import keywords from "ajv-keywords";
 
 @injectable()
@@ -15,6 +16,7 @@ export class Validator implements Contracts.Crypto.IValidator {
 		});
 
 		keywords(this.#ajv);
+		formats(this.#ajv);
 	}
 
 	public validate<T = any>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -2639,6 +2639,9 @@ importers:
       ajv:
         specifier: 8.12.0
         version: 8.12.0
+      ajv-formats:
+        specifier: 2.1.1
+        version: 2.1.1(ajv@8.12.0)
       ajv-keywords:
         specifier: 5.1.0
         version: 5.1.0(ajv@8.12.0)
@@ -6041,6 +6044,17 @@ packages:
       clean-stack: 4.2.0
       indent-string: 5.0.0
     dev: true
+
+  /ajv-formats@2.1.1(ajv@8.12.0):
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.12.0
+    dev: false
 
   /ajv-keywords@5.1.0(ajv@8.12.0):
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}


### PR DESCRIPTION
## Summary

Add formats defined in [ajv-formats ](https://github.com/ajv-validator/ajv-formats)package. Formats are added to support: ipv4 and ipv6 in p2p reply schemas. 

## Checklist

- [x] Ready to be merged

