### PR TITLE
feat(p2p): limit downloads

### DIFF
--- a/packages/contracts/source/contracts/p2p/endpoints.ts
+++ b/packages/contracts/source/contracts/p2p/endpoints.ts
@@ -1,7 +1,8 @@
 import Hapi from "@hapi/hapi";
 
 import { IBlockData } from "../crypto";
-import { IHeaderData, PeerBroadcast, PeerPingResponse } from "./peer";
+import { IHeaderData } from "./header";
+import { PeerBroadcast, PeerPingResponse } from "./peer";
 
 export interface IGetBlocksRequest extends Hapi.Request {
 	payload: {

--- a/packages/contracts/source/contracts/p2p/header-service.ts
+++ b/packages/contracts/source/contracts/p2p/header-service.ts
@@ -1,0 +1,7 @@
+import { IHeader, IHeaderData } from "./header";
+import { Peer } from "./peer";
+
+export interface IHeaderService {
+	getHeader(): IHeader;
+	handle(peer: Peer, header: IHeaderData): Promise<void>;
+}

--- a/packages/contracts/source/contracts/p2p/header-service.ts
+++ b/packages/contracts/source/contracts/p2p/header-service.ts
@@ -1,7 +1,6 @@
-import { IHeader, IHeaderData } from "./header";
+import { IHeaderData } from "./header";
 import { Peer } from "./peer";
 
 export interface IHeaderService {
-	getHeader(): IHeader;
 	handle(peer: Peer, header: IHeaderData): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/header.ts
+++ b/packages/contracts/source/contracts/p2p/header.ts
@@ -1,6 +1,6 @@
 import { IHeaderData, Peer } from "./peer";
 
-export interface IHeader {
+export interface IHeaderService {
 	getHeader(): IHeaderData;
 	handle(peer: Peer, header: IHeaderData): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/header.ts
+++ b/packages/contracts/source/contracts/p2p/header.ts
@@ -10,7 +10,7 @@ export type IHeaderData = {
 
 export interface IHeader {
 	toData(): IHeaderData;
-	// hasHigherHeight(headerData: IHeaderData): boolean;
-	// hasMissingProposal(headerData: IHeaderData): boolean;
-	// hasMissingMessages(headerData: IHeaderData): boolean;
+	canDownloadBlocks(headerData: IHeaderData): boolean;
+	canDownloadProposal(headerData: IHeaderData): boolean;
+	canDownloadMessages(headerData: IHeaderData): boolean;
 }

--- a/packages/contracts/source/contracts/p2p/header.ts
+++ b/packages/contracts/source/contracts/p2p/header.ts
@@ -14,3 +14,5 @@ export interface IHeader {
 	canDownloadProposal(headerData: IHeaderData): boolean;
 	canDownloadMessages(headerData: IHeaderData): boolean;
 }
+
+export type HeaderFactory = () => IHeader;

--- a/packages/contracts/source/contracts/p2p/header.ts
+++ b/packages/contracts/source/contracts/p2p/header.ts
@@ -1,13 +1,16 @@
-import { IHeaderData, Peer } from "./peer";
+export type IHeaderData = {
+	version: string;
+	height: number;
+	round: number;
+	step: number;
+	proposedBlockId: string | null;
+	validatorsSignedPrevote: boolean[];
+	validatorsSignedPrecommit: boolean[];
+};
 
 export interface IHeader {
 	toData(): IHeaderData;
 	// hasHigherHeight(headerData: IHeaderData): boolean;
 	// hasMissingProposal(headerData: IHeaderData): boolean;
 	// hasMissingMessages(headerData: IHeaderData): boolean;
-}
-
-export interface IHeaderService {
-	getHeader(): IHeader;
-	handle(peer: Peer, header: IHeaderData): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/header.ts
+++ b/packages/contracts/source/contracts/p2p/header.ts
@@ -1,6 +1,13 @@
 import { IHeaderData, Peer } from "./peer";
 
+export interface IHeader {
+	toData(): IHeaderData;
+	// hasHigherHeight(headerData: IHeaderData): boolean;
+	// hasMissingProposal(headerData: IHeaderData): boolean;
+	// hasMissingMessages(headerData: IHeaderData): boolean;
+}
+
 export interface IHeaderService {
-	getHeader(): IHeaderData;
+	getHeader(): IHeader;
 	handle(peer: Peer, header: IHeaderData): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/index.ts
+++ b/packages/contracts/source/contracts/p2p/index.ts
@@ -4,6 +4,7 @@ export * from "./broadcaster";
 export * from "./chunk-cache";
 export * from "./endpoints";
 export * from "./header";
+export * from "./header-service";
 export * from "./nes-client";
 export * from "./network-monitor";
 export * from "./network-state";

--- a/packages/contracts/source/contracts/p2p/peer-repository.ts
+++ b/packages/contracts/source/contracts/p2p/peer-repository.ts
@@ -2,31 +2,20 @@ import { Peer } from "./peer";
 
 export interface PeerRepository {
 	getPeers(): Peer[];
-
 	hasPeers(): boolean;
 
 	getPeer(ip: string): Peer;
-
 	setPeer(peer: Peer): void;
-
 	forgetPeer(peer: Peer): void;
-
 	hasPeer(ip: string): boolean;
 
 	getPendingPeers(): Peer[];
-
 	hasPendingPeers(): boolean;
 
 	getPendingPeer(ip: string): Peer;
-
 	setPendingPeer(peer: Peer): void;
-
 	forgetPendingPeer(peer: Peer): void;
-
 	hasPendingPeer(ip: string): boolean;
-
-	getPeersWithHigherBlock(): Peer[];
-	getPeersWithProposal(): Peer[];
 
 	getSameSubnetPeers(ip: string): Peer[];
 }

--- a/packages/contracts/source/contracts/p2p/peer-repository.ts
+++ b/packages/contracts/source/contracts/p2p/peer-repository.ts
@@ -25,5 +25,7 @@ export interface PeerRepository {
 
 	hasPendingPeer(ip: string): boolean;
 
+	getPeersWithHigherBlock(ip: string): Peer[];
+
 	getSameSubnetPeers(ip: string): Peer[];
 }

--- a/packages/contracts/source/contracts/p2p/peer-repository.ts
+++ b/packages/contracts/source/contracts/p2p/peer-repository.ts
@@ -25,7 +25,8 @@ export interface PeerRepository {
 
 	hasPendingPeer(ip: string): boolean;
 
-	getPeersWithHigherBlock(ip: string): Peer[];
+	getPeersWithHigherBlock(): Peer[];
+	getPeersWithProposal(): Peer[];
 
 	getSameSubnetPeers(ip: string): Peer[];
 }

--- a/packages/contracts/source/contracts/p2p/peer.ts
+++ b/packages/contracts/source/contracts/p2p/peer.ts
@@ -1,16 +1,7 @@
 import { Dayjs } from "dayjs";
 
 import { Queue } from "../kernel";
-
-export type IHeaderData = {
-	version: string;
-	height: number;
-	round: number;
-	step: number;
-	proposedBlockId: string | null;
-	validatorsSignedPrevote: boolean[];
-	validatorsSignedPrecommit: boolean[];
-};
+import { IHeaderData } from "./header";
 
 export interface PeerPorts {
 	[name: string]: number;

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -119,6 +119,7 @@ export const Identifiers = {
 	PeerConnector: Symbol.for("Peer<Connector>"),
 	PeerDownloader: Symbol.for("Peer<Downloader>"),
 	PeerFactory: Symbol.for("Factory<Peer>"),
+	PeerHeaderFactory: Symbol.for("Factory<PeerHeader>"),
 	PeerHeaderService: Symbol.for("Peer<HeaderService>"),
 	PeerNetworkMonitor: Symbol.for("Peer<NetworkMonitor>"),
 	PeerProcessor: Symbol.for("Peer<Processor>"),

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -117,6 +117,7 @@ export const Identifiers = {
 	PeerChunkCache: Symbol.for("Peer<ChunkCache>"),
 	PeerCommunicator: Symbol.for("Peer<Communicator>"),
 	PeerConnector: Symbol.for("Peer<Connector>"),
+	PeerDownloader: Symbol.for("Peer<Downloader>"),
 	PeerFactory: Symbol.for("Factory<Peer>"),
 	PeerHeader: Symbol.for("Peer<Header>"),
 	PeerNetworkMonitor: Symbol.for("Peer<NetworkMonitor>"),

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -119,7 +119,7 @@ export const Identifiers = {
 	PeerConnector: Symbol.for("Peer<Connector>"),
 	PeerDownloader: Symbol.for("Peer<Downloader>"),
 	PeerFactory: Symbol.for("Factory<Peer>"),
-	PeerHeader: Symbol.for("Peer<Header>"),
+	PeerHeaderService: Symbol.for("Peer<HeaderService>"),
 	PeerNetworkMonitor: Symbol.for("Peer<NetworkMonitor>"),
 	PeerProcessor: Symbol.for("Peer<Processor>"),
 	PeerRepository: Symbol.for("Peer<Repository>"),

--- a/packages/p2p/source/block-downloader.ts
+++ b/packages/p2p/source/block-downloader.ts
@@ -25,6 +25,8 @@ export class BlockDownloader implements Contracts.P2P.BlockDownloader {
 	#maxParallelDownloads = 10;
 
 	public async downloadBlocksFromHeight(fromBlockHeight: number): Promise<Contracts.Crypto.IBlockData[]> {
+		return [];
+
 		const peersAll: Contracts.P2P.Peer[] = this.repository.getPeers();
 
 		if (peersAll.length === 0) {

--- a/packages/p2p/source/block-downloader.ts
+++ b/packages/p2p/source/block-downloader.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-one-iteration-loop */
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";

--- a/packages/p2p/source/constants.ts
+++ b/packages/p2p/source/constants.ts
@@ -1,10 +1,12 @@
 import { Constants } from "@mainsail/contracts";
 
 export const constants = {
+	CHECK_HEADER_DELAY: 300,
 	// maximum number of blocks we can download at once
 	DEFAULT_MAX_PAYLOAD: 20 * Constants.Units.MEGABYTE,
 	// default maxPayload value on the server WS socket
 	DEFAULT_MAX_PAYLOAD_CLIENT: 100 * Constants.Units.KILOBYTE,
-	MAX_DOWNLOAD_BLOCKS: 400, // default maxPayload value on the client WS socket
+	MAX_DOWNLOAD_BLOCKS: 400,
+	// default maxPayload value on the client WS socket
 	MAX_PEERS_GETPEERS: 2000,
 };

--- a/packages/p2p/source/downloader.ts
+++ b/packages/p2p/source/downloader.ts
@@ -18,49 +18,87 @@ export class Downloader {
 	@inject(Identifiers.Cryptography.Block.Factory)
 	private readonly blockFactory!: Contracts.Crypto.IBlockFactory;
 
+	#isDownloadingBlocks = false;
+	#isDownloadingProposal = false;
+	#isDownloadingMessages = false;
+
 	public async downloadBlocks(peer: Contracts.P2P.Peer): Promise<void> {
-		console.log("Downloading blocks");
+		if (this.#isDownloadingBlocks) {
+			return;
+		}
 
-		const result = await this.communicator.getBlocks(peer, {
-			fromHeight: this.state.getLastBlock().data.height + 1,
-		});
+		this.#isDownloadingBlocks = true;
 
-		const blocks = await Promise.all(
-			result.blocks.map(async (hex) => await this.blockFactory.fromCommittedBytes(Buffer.from(hex, "hex"))),
-		);
+		try {
+			const result = await this.communicator.getBlocks(peer, {
+				fromHeight: this.state.getLastBlock().data.height + 1,
+			});
 
-		for (const block of blocks) {
-			await this.handler.onCommittedBlock(block);
+			const blocks = await Promise.all(
+				result.blocks.map(async (hex) => await this.blockFactory.fromCommittedBytes(Buffer.from(hex, "hex"))),
+			);
+
+			for (const block of blocks) {
+				await this.handler.onCommittedBlock(block);
+			}
+		} catch {
+			// TODO: Handle errors
+		} finally {
+			this.#isDownloadingBlocks = false;
 		}
 	}
 
 	// TODO: Handle errors & response checks
 	public async downloadProposal(peer: Contracts.P2P.Peer): Promise<void> {
-		const result = await this.communicator.getProposal(peer);
-
-		if (result.proposal.length === 0) {
+		if (this.#isDownloadingProposal) {
 			return;
 		}
 
-		const proposal = await this.messageFactory.makeProposalFromBytes(Buffer.from(result.proposal, "hex"));
+		this.#isDownloadingProposal = true;
 
-		await this.handler.onProposal(proposal);
+		try {
+			const result = await this.communicator.getProposal(peer);
+
+			if (result.proposal.length === 0) {
+				return;
+			}
+
+			const proposal = await this.messageFactory.makeProposalFromBytes(Buffer.from(result.proposal, "hex"));
+
+			await this.handler.onProposal(proposal);
+		} catch {
+			// TODO: Handle errors
+		} finally {
+			this.#isDownloadingProposal = false;
+		}
 	}
 
 	// TODO: Handle errors
 	public async downloadMessages(peer: Contracts.P2P.Peer): Promise<void> {
-		const result = await this.communicator.getMessages(peer);
-
-		for (const prevoteHex of result.prevotes) {
-			const prevote = await this.messageFactory.makePrevoteFromBytes(Buffer.from(prevoteHex, "hex"));
-
-			await this.handler.onPrevote(prevote);
+		if (this.#isDownloadingMessages) {
+			return;
 		}
 
-		for (const precommitHex of result.precommits) {
-			const precommit = await this.messageFactory.makePrecommitFromBytes(Buffer.from(precommitHex, "hex"));
+		this.#isDownloadingMessages = true;
 
-			await this.handler.onPrecommit(precommit);
+		try {
+			const result = await this.communicator.getMessages(peer);
+
+			for (const prevoteHex of result.prevotes) {
+				const prevote = await this.messageFactory.makePrevoteFromBytes(Buffer.from(prevoteHex, "hex"));
+
+				await this.handler.onPrevote(prevote);
+			}
+
+			for (const precommitHex of result.precommits) {
+				const precommit = await this.messageFactory.makePrecommitFromBytes(Buffer.from(precommitHex, "hex"));
+
+				await this.handler.onPrecommit(precommit);
+			}
+		} catch {
+			// TODO: Handle errors
+		} finally {
+			this.#isDownloadingMessages = false;
 		}
 	}
 }

--- a/packages/p2p/source/downloader.ts
+++ b/packages/p2p/source/downloader.ts
@@ -34,6 +34,14 @@ export class Downloader {
 		}
 	}
 
+	public tryToDownloadProposal(): void {
+		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeersWithProposal());
+
+		if (peers.length > 0) {
+			void this.downloadProposal(peers[0]);
+		}
+	}
+
 	public async downloadBlocks(peer: Contracts.P2P.Peer): Promise<void> {
 		if (this.#isDownloadingBlocks) {
 			return;

--- a/packages/p2p/source/downloader.ts
+++ b/packages/p2p/source/downloader.ts
@@ -27,7 +27,7 @@ export class Downloader {
 	#isDownloadingMessages = false;
 
 	public tryToDownloadBlocks(): void {
-		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeersWithHigherBlock());
+		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
 
 		if (peers.length > 0) {
 			void this.downloadBlocks(peers[0]);
@@ -35,10 +35,18 @@ export class Downloader {
 	}
 
 	public tryToDownloadProposal(): void {
-		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeersWithProposal());
+		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
 
 		if (peers.length > 0) {
 			void this.downloadProposal(peers[0]);
+		}
+	}
+
+	public tryToDownloadMessages(): void {
+		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
+
+		if (peers.length > 0) {
+			void this.downloadMessages(peers[0]);
 		}
 	}
 

--- a/packages/p2p/source/downloader.ts
+++ b/packages/p2p/source/downloader.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { shuffle } from "@mainsail/utils";
+import { randomNumber } from "@mainsail/utils";
 
 @injectable()
 export class Downloader {
@@ -27,26 +27,26 @@ export class Downloader {
 	#isDownloadingMessages = false;
 
 	public tryToDownloadBlocks(): void {
-		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
+		const peers = this.repository.getPeers();
 
 		if (peers.length > 0) {
-			void this.downloadBlocks(peers[0]);
+			void this.downloadBlocks(this.#getRandomPeer(peers));
 		}
 	}
 
 	public tryToDownloadProposal(): void {
-		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
+		const peers = this.repository.getPeers();
 
 		if (peers.length > 0) {
-			void this.downloadProposal(peers[0]);
+			void this.downloadProposal(this.#getRandomPeer(peers));
 		}
 	}
 
 	public tryToDownloadMessages(): void {
-		const peers = shuffle<Contracts.P2P.Peer>(this.repository.getPeers());
+		const peers = this.repository.getPeers();
 
 		if (peers.length > 0) {
-			void this.downloadMessages(peers[0]);
+			void this.downloadMessages(this.#getRandomPeer(peers));
 		}
 	}
 
@@ -131,5 +131,9 @@ export class Downloader {
 		} finally {
 			this.#isDownloadingMessages = false;
 		}
+	}
+
+	#getRandomPeer(peers: Contracts.P2P.Peer[]): Contracts.P2P.Peer {
+		return peers[randomNumber(0, peers.length - 1)];
 	}
 }

--- a/packages/p2p/source/header-service.ts
+++ b/packages/p2p/source/header-service.ts
@@ -3,6 +3,7 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 
 import { constants } from "./constants";
 import { Downloader } from "./downloader";
+import { Header } from "./header";
 
 export interface CompareResponse {
 	downloadBlocks?: true;
@@ -17,29 +18,8 @@ export class HeaderService implements Contracts.P2P.IHeaderService {
 
 	#pending = new Set<Contracts.P2P.Peer>();
 
-	public getHeader(): Contracts.P2P.IHeaderData {
-		const consensus = this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
-		const roundStateRepo = this.app.get<Contracts.Consensus.IRoundStateRepository>(
-			Identifiers.Consensus.RoundStateRepository,
-		);
-
-		const height = consensus.getHeight();
-		const round = consensus.getRound();
-		const step = consensus.getStep();
-
-		const roundState = roundStateRepo.getRoundState(height, round);
-		const proposal = roundState.getProposal();
-
-		return {
-			height,
-			// eslint-disable-next-line unicorn/no-null
-			proposedBlockId: proposal ? proposal.block.block.data.id : null,
-			round,
-			step,
-			validatorsSignedPrecommit: roundState.getValidatorsSignedPrecommit(),
-			validatorsSignedPrevote: roundState.getValidatorsSignedPrevote(),
-			version: this.app.version(),
-		};
+	public getHeader(): Contracts.P2P.IHeader {
+		return this.app.resolve(Header);
 	}
 
 	public async handle(peer: Contracts.P2P.Peer, header: Contracts.P2P.IHeaderData): Promise<void> {

--- a/packages/p2p/source/header-service.ts
+++ b/packages/p2p/source/header-service.ts
@@ -11,7 +11,7 @@ export interface CompareResponse {
 }
 
 @injectable()
-export class Header implements Contracts.P2P.IHeaderService {
+export class HeaderService implements Contracts.P2P.IHeaderService {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
+import { constants } from "./constants";
 import { Downloader } from "./downloader";
 
 export interface CompareResponse {
@@ -74,7 +75,7 @@ export class Header implements Contracts.P2P.IHeader {
 	async #delay(peer: Contracts.P2P.Peer): Promise<void> {
 		this.#pending.add(peer);
 
-		await new Promise((resolve) => setTimeout(resolve, 300));
+		await new Promise((resolve) => setTimeout(resolve, constants.CHECK_HEADER_DELAY));
 
 		this.#pending.delete(peer);
 	}

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -1,0 +1,42 @@
+import { inject, injectable } from "@mainsail/container";
+import { Contracts, Identifiers } from "@mainsail/contracts";
+
+@injectable()
+export class Header implements Contracts.P2P.IHeader {
+	@inject(Identifiers.Application)
+	private readonly app!: Contracts.Kernel.Application;
+
+	public readonly height: number;
+	public readonly round: number;
+	public readonly step: Contracts.Consensus.Step;
+
+	#roundState: Contracts.Consensus.IRoundState;
+
+	public constructor() {
+		const consensus = this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
+		const roundStateRepo = this.app.get<Contracts.Consensus.IRoundStateRepository>(
+			Identifiers.Consensus.RoundStateRepository,
+		);
+
+		this.height = consensus.getHeight();
+		this.round = consensus.getRound();
+		this.step = consensus.getStep();
+
+		this.#roundState = roundStateRepo.getRoundState(this.height, this.round);
+	}
+
+	public toData(): Contracts.P2P.IHeaderData {
+		const proposal = this.#roundState.getProposal();
+
+		return {
+			height: this.height,
+			// eslint-disable-next-line unicorn/no-null
+			proposedBlockId: proposal ? proposal.block.block.data.id : null,
+			round: this.round,
+			step: this.step,
+			validatorsSignedPrecommit: this.#roundState.getValidatorsSignedPrecommit(),
+			validatorsSignedPrevote: this.#roundState.getValidatorsSignedPrevote(),
+			version: this.app.version(),
+		};
+	}
+}

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -11,7 +11,7 @@ export interface CompareResponse {
 }
 
 @injectable()
-export class Header implements Contracts.P2P.IHeader {
+export class Header implements Contracts.P2P.IHeaderService {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -42,7 +42,9 @@ export class Header implements Contracts.P2P.IHeader {
 	public async handle(peer: Contracts.P2P.Peer, header: Contracts.P2P.IHeaderData): Promise<void> {
 		peer.state = header;
 
-		const result = await this.#compare(header);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const result = await this.#compare(peer);
 
 		const downloader = this.app.get<Downloader>(Identifiers.PeerDownloader);
 
@@ -59,7 +61,8 @@ export class Header implements Contracts.P2P.IHeader {
 		}
 	}
 
-	async #compare(header: Contracts.P2P.IHeaderData): Promise<CompareResponse> {
+	async #compare(peer: Contracts.P2P.Peer): Promise<CompareResponse> {
+		const header = peer.state;
 		const consensus = this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
 
 		const height = consensus.getHeight();

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -6,6 +6,12 @@ export class Header implements Contracts.P2P.IHeader {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 
+	@inject(Identifiers.Consensus.Service)
+	private readonly consensus!: Contracts.Consensus.IConsensusService;
+
+	@inject(Identifiers.Consensus.RoundStateRepository)
+	private readonly roundStateRepo!: Contracts.Consensus.IRoundStateRepository;
+
 	public height!: number;
 	public round!: number;
 	public step!: Contracts.Consensus.Step;
@@ -14,16 +20,11 @@ export class Header implements Contracts.P2P.IHeader {
 
 	@postConstruct()
 	public init() {
-		const consensus = this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
-		const roundStateRepo = this.app.get<Contracts.Consensus.IRoundStateRepository>(
-			Identifiers.Consensus.RoundStateRepository,
-		);
+		this.height = this.consensus.getHeight();
+		this.round = this.consensus.getRound();
+		this.step = this.consensus.getStep();
 
-		this.height = consensus.getHeight();
-		this.round = consensus.getRound();
-		this.step = consensus.getStep();
-
-		this.#roundState = roundStateRepo.getRoundState(this.height, this.round);
+		this.#roundState = this.roundStateRepo.getRoundState(this.height, this.round);
 	}
 
 	public toData(): Contracts.P2P.IHeaderData {

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -44,7 +44,7 @@ export class Header implements Contracts.P2P.IHeader {
 
 		const result = await this.#compare(header);
 
-		const downloader = this.app.resolve<Downloader>(Downloader);
+		const downloader = this.app.get<Downloader>(Identifiers.PeerDownloader);
 
 		if (result.downloadBlocks) {
 			await downloader.downloadBlocks(peer);

--- a/packages/p2p/source/header.ts
+++ b/packages/p2p/source/header.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from "@mainsail/container";
+import { inject, injectable, postConstruct } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 
 @injectable()
@@ -6,13 +6,14 @@ export class Header implements Contracts.P2P.IHeader {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 
-	public readonly height: number;
-	public readonly round: number;
-	public readonly step: Contracts.Consensus.Step;
+	public height!: number;
+	public round!: number;
+	public step!: Contracts.Consensus.Step;
 
-	#roundState: Contracts.Consensus.IRoundState;
+	#roundState!: Contracts.Consensus.IRoundState;
 
-	public constructor() {
+	@postConstruct()
+	public init() {
 		const consensus = this.app.get<Contracts.Consensus.IConsensusService>(Identifiers.Consensus.Service);
 		const roundStateRepo = this.app.get<Contracts.Consensus.IRoundStateRepository>(
 			Identifiers.Consensus.RoundStateRepository,

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -6,7 +6,6 @@ import delay from "delay";
 
 import { constants } from "./constants";
 import { Routes, SocketErrors } from "./enums";
-import { HeaderService } from "./header-service";
 import { PeerVerifier } from "./peer-verifier";
 import { RateLimiter } from "./rate-limiter";
 import { replySchemas } from "./reply-schemas";
@@ -29,8 +28,11 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 	@inject(Identifiers.PeerConnector)
 	private readonly connector!: Contracts.P2P.PeerConnector;
 
+	@inject(Identifiers.PeerHeaderFactory)
+	private readonly headerFactory!: Contracts.P2P.HeaderFactory;
+
 	@inject(Identifiers.PeerHeaderService)
-	private readonly headerService!: HeaderService;
+	private readonly headerService!: Contracts.P2P.IHeaderService;
 
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;
@@ -257,7 +259,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 				codec.request.serialize({
 					...payload,
 					headers: {
-						...this.headerService.getHeader().toData(),
+						...this.headerFactory().toData(),
 					},
 				}),
 				timeout,

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -257,7 +257,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 				codec.request.serialize({
 					...payload,
 					headers: {
-						...this.headerService.getHeader(),
+						...this.headerService.getHeader().toData(),
 					},
 				}),
 				timeout,

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -29,8 +29,8 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 	@inject(Identifiers.PeerConnector)
 	private readonly connector!: Contracts.P2P.PeerConnector;
 
-	@inject(Identifiers.PeerHeader)
-	private readonly header!: Header;
+	@inject(Identifiers.PeerHeaderService)
+	private readonly headerService!: Header;
 
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;
@@ -257,7 +257,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 				codec.request.serialize({
 					...payload,
 					headers: {
-						...this.header.getHeader(),
+						...this.headerService.getHeader(),
 					},
 				}),
 				timeout,
@@ -276,7 +276,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 				throw validationError;
 			}
 
-			void this.header.handle(peer, parsedResponsePayload.headers);
+			void this.headerService.handle(peer, parsedResponsePayload.headers);
 		} catch (error) {
 			await this.handleSocketError(peer, event, error, disconnectOnError);
 			return;

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -6,7 +6,7 @@ import delay from "delay";
 
 import { constants } from "./constants";
 import { Routes, SocketErrors } from "./enums";
-import { Header } from "./header";
+import { HeaderService } from "./header-service";
 import { PeerVerifier } from "./peer-verifier";
 import { RateLimiter } from "./rate-limiter";
 import { replySchemas } from "./reply-schemas";
@@ -30,7 +30,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 	private readonly connector!: Contracts.P2P.PeerConnector;
 
 	@inject(Identifiers.PeerHeaderService)
-	private readonly headerService!: Header;
+	private readonly headerService!: HeaderService;
 
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;

--- a/packages/p2p/source/peer-discoverer.ts
+++ b/packages/p2p/source/peer-discoverer.ts
@@ -1,7 +1,8 @@
-import { inject } from "@mainsail/container";
+import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Services, Utils } from "@mainsail/kernel";
 
+@injectable()
 export class PeerDiscoverer implements Contracts.P2P.PeerDiscoverer {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;

--- a/packages/p2p/source/peer-repository.ts
+++ b/packages/p2p/source/peer-repository.ts
@@ -74,6 +74,12 @@ export class PeerRepository implements Contracts.P2P.PeerRepository {
 		return this.getPeers().filter((peer) => peer.state.height > height);
 	}
 
+	public getPeersWithProposal(): Contracts.P2P.Peer[] {
+		const height = this.state.getLastBlock().data.height;
+
+		return this.getPeers().filter((peer) => peer.state.height === height + 1 && peer.state.proposedBlockId);
+	}
+
 	public getSameSubnetPeers(ip: string): Contracts.P2P.Peer[] {
 		return this.getPeers().filter((peer) => {
 			if (!Utils.IpAddress.isIPv6Address(peer.ip) && !Utils.IpAddress.isIPv6Address(ip)) {

--- a/packages/p2p/source/peer-repository.ts
+++ b/packages/p2p/source/peer-repository.ts
@@ -1,11 +1,14 @@
-import { injectable } from "@mainsail/container";
-import { Contracts } from "@mainsail/contracts";
+import { inject, injectable } from "@mainsail/container";
+import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 import { cidr } from "ip";
 
 // @TODO review the implementation
 @injectable()
 export class PeerRepository implements Contracts.P2P.PeerRepository {
+	@inject(Identifiers.StateStore)
+	private readonly state!: Contracts.State.StateStore;
+
 	readonly #peers: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 	readonly #peersPending: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 
@@ -63,6 +66,12 @@ export class PeerRepository implements Contracts.P2P.PeerRepository {
 
 	public hasPendingPeer(ip: string): boolean {
 		return this.#peersPending.has(ip);
+	}
+
+	public getPeersWithHigherBlock(): Contracts.P2P.Peer[] {
+		const height = this.state.getLastBlock().data.height;
+
+		return this.getPeers().filter((peer) => peer.state.height > height);
 	}
 
 	public getSameSubnetPeers(ip: string): Contracts.P2P.Peer[] {

--- a/packages/p2p/source/peer-repository.ts
+++ b/packages/p2p/source/peer-repository.ts
@@ -1,14 +1,11 @@
-import { inject, injectable } from "@mainsail/container";
-import { Contracts, Identifiers } from "@mainsail/contracts";
+import { injectable } from "@mainsail/container";
+import { Contracts } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 import { cidr } from "ip";
 
 // @TODO review the implementation
 @injectable()
 export class PeerRepository implements Contracts.P2P.PeerRepository {
-	@inject(Identifiers.PeerHeaderService)
-	private readonly headerService!: Contracts.P2P.IHeaderService;
-
 	readonly #peers: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 	readonly #peersPending: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 
@@ -66,21 +63,6 @@ export class PeerRepository implements Contracts.P2P.PeerRepository {
 
 	public hasPendingPeer(ip: string): boolean {
 		return this.#peersPending.has(ip);
-	}
-
-	public getPeersWithHigherBlock(): Contracts.P2P.Peer[] {
-		const header = this.headerService.getHeader();
-		return this.getPeers().filter((peer) => header.canDownloadBlocks(peer.state));
-	}
-
-	public getPeersWithProposal(): Contracts.P2P.Peer[] {
-		const header = this.headerService.getHeader();
-		return this.getPeers().filter((peer) => header.canDownloadProposal(peer.state));
-	}
-
-	public getPeersWithMessages(): Contracts.P2P.Peer[] {
-		const header = this.headerService.getHeader();
-		return this.getPeers().filter((peer) => header.canDownloadMessages(peer.state));
 	}
 
 	public getSameSubnetPeers(ip: string): Contracts.P2P.Peer[] {

--- a/packages/p2p/source/peer-repository.ts
+++ b/packages/p2p/source/peer-repository.ts
@@ -6,8 +6,8 @@ import { cidr } from "ip";
 // @TODO review the implementation
 @injectable()
 export class PeerRepository implements Contracts.P2P.PeerRepository {
-	@inject(Identifiers.StateStore)
-	private readonly state!: Contracts.State.StateStore;
+	@inject(Identifiers.PeerHeaderService)
+	private readonly headerService!: Contracts.P2P.IHeaderService;
 
 	readonly #peers: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
 	readonly #peersPending: Map<string, Contracts.P2P.Peer> = new Map<string, Contracts.P2P.Peer>();
@@ -69,15 +69,18 @@ export class PeerRepository implements Contracts.P2P.PeerRepository {
 	}
 
 	public getPeersWithHigherBlock(): Contracts.P2P.Peer[] {
-		const height = this.state.getLastBlock().data.height;
-
-		return this.getPeers().filter((peer) => peer.state.height > height);
+		const header = this.headerService.getHeader();
+		return this.getPeers().filter((peer) => header.canDownloadBlocks(peer.state));
 	}
 
 	public getPeersWithProposal(): Contracts.P2P.Peer[] {
-		const height = this.state.getLastBlock().data.height;
+		const header = this.headerService.getHeader();
+		return this.getPeers().filter((peer) => header.canDownloadProposal(peer.state));
+	}
 
-		return this.getPeers().filter((peer) => peer.state.height === height + 1 && peer.state.proposedBlockId);
+	public getPeersWithMessages(): Contracts.P2P.Peer[] {
+		const header = this.headerService.getHeader();
+		return this.getPeers().filter((peer) => header.canDownloadMessages(peer.state));
 	}
 
 	public getSameSubnetPeers(ip: string): Contracts.P2P.Peer[] {

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -7,7 +7,7 @@ import { BlockDownloader } from "./block-downloader";
 import { Broadcaster } from "./broadcaster";
 import { ChunkCache } from "./chunk-cache";
 import { Downloader } from "./downloader";
-import { Header } from "./header";
+import { HeaderService } from "./header-service";
 import { NetworkMonitor } from "./network-monitor";
 import { Peer } from "./peer";
 import { PeerCommunicator } from "./peer-communicator";
@@ -96,7 +96,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		this.app.bind(Identifiers.PeerProcessor).to(PeerProcessor).inSingletonScope();
 
-		this.app.bind(Identifiers.PeerHeaderService).to(Header).inSingletonScope();
+		this.app.bind(Identifiers.PeerHeaderService).to(HeaderService).inSingletonScope();
 
 		this.app.bind(Identifiers.PeerChunkCache).to(ChunkCache).inSingletonScope();
 

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -7,6 +7,7 @@ import { BlockDownloader } from "./block-downloader";
 import { Broadcaster } from "./broadcaster";
 import { ChunkCache } from "./chunk-cache";
 import { Downloader } from "./downloader";
+import { Header } from "./header";
 import { HeaderService } from "./header-service";
 import { NetworkMonitor } from "./network-monitor";
 import { Peer } from "./peer";
@@ -85,6 +86,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 			return this.app.resolve(Peer).init(sanitizedIp, Number(this.config().getRequired<number>("server.port")));
 		});
+
+		this.app
+			.bind(Identifiers.PeerHeaderFactory)
+			.toFactory<Contracts.P2P.IHeader>(() => () => this.app.resolve(Header));
 	}
 
 	#registerServices(): void {

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -96,7 +96,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		this.app.bind(Identifiers.PeerProcessor).to(PeerProcessor).inSingletonScope();
 
-		this.app.bind(Identifiers.PeerHeader).to(Header).inSingletonScope();
+		this.app.bind(Identifiers.PeerHeaderService).to(Header).inSingletonScope();
 
 		this.app.bind(Identifiers.PeerChunkCache).to(ChunkCache).inSingletonScope();
 

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -6,6 +6,7 @@ import { ValidateAndAcceptPeerAction } from "./actions";
 import { BlockDownloader } from "./block-downloader";
 import { Broadcaster } from "./broadcaster";
 import { ChunkCache } from "./chunk-cache";
+import { Downloader } from "./downloader";
 import { Header } from "./header";
 import { NetworkMonitor } from "./network-monitor";
 import { Peer } from "./peer";
@@ -100,6 +101,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		this.app.bind(Identifiers.PeerChunkCache).to(ChunkCache).inSingletonScope();
 
 		this.app.bind(Identifiers.PeerBlockDownloader).to(BlockDownloader).inSingletonScope();
+
+		this.app.bind(Identifiers.PeerDownloader).to(Downloader).inSingletonScope();
 
 		this.app.bind(Identifiers.PeerNetworkMonitor).to(NetworkMonitor).inSingletonScope();
 

--- a/packages/p2p/source/socket-server/plugins/header-handle.ts
+++ b/packages/p2p/source/socket-server/plugins/header-handle.ts
@@ -9,7 +9,7 @@ export class HeaderHandlePlugin {
 	protected readonly app!: Contracts.Kernel.Application;
 
 	@inject(Identifiers.PeerHeader)
-	private readonly header!: Contracts.P2P.IHeader;
+	private readonly header!: Contracts.P2P.IHeaderService;
 
 	@inject(Identifiers.PeerRepository)
 	private readonly peerRepository!: Contracts.P2P.PeerRepository;

--- a/packages/p2p/source/socket-server/plugins/header-handle.ts
+++ b/packages/p2p/source/socket-server/plugins/header-handle.ts
@@ -15,7 +15,7 @@ export class HeaderHandlePlugin {
 	private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
 	public register(server) {
-		const header = this.headerService;
+		const headerService = this.headerService;
 		const peerRepository = this.peerRepository;
 
 		server.ext({
@@ -25,7 +25,7 @@ export class HeaderHandlePlugin {
 				if (peerRepository.hasPeer(peerIp)) {
 					const peer = peerRepository.getPeer(peerIp);
 
-					void header.handle(peer, request.payload.headers);
+					void headerService.handle(peer, request.payload.headers);
 				}
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/plugins/header-handle.ts
+++ b/packages/p2p/source/socket-server/plugins/header-handle.ts
@@ -8,14 +8,14 @@ export class HeaderHandlePlugin {
 	@inject(Identifiers.Application)
 	protected readonly app!: Contracts.Kernel.Application;
 
-	@inject(Identifiers.PeerHeader)
-	private readonly header!: Contracts.P2P.IHeaderService;
+	@inject(Identifiers.PeerHeaderService)
+	private readonly headerService!: Contracts.P2P.IHeaderService;
 
 	@inject(Identifiers.PeerRepository)
 	private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
 	public register(server) {
-		const header = this.header;
+		const header = this.headerService;
 		const peerRepository = this.peerRepository;
 
 		server.ext({

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -17,7 +17,7 @@ export class HeaderIncludePlugin {
 			async method(request, h: ResponseToolkit) {
 				request.response.source = {
 					...request.response.source,
-					headers: headerService.getHeader(),
+					headers: headerService.getHeader().toData(),
 				};
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -7,17 +7,17 @@ export class HeaderIncludePlugin {
 	@inject(Identifiers.Application)
 	protected readonly app!: Contracts.Kernel.Application;
 
-	@inject(Identifiers.PeerHeaderService)
-	private readonly headerService!: Contracts.P2P.IHeaderService;
+	@inject(Identifiers.PeerHeaderFactory)
+	private readonly headerFactory!: Contracts.P2P.HeaderFactory;
 
 	public register(server) {
-		const headerService = this.headerService;
+		const headerFactory = this.headerFactory;
 
 		server.ext({
 			async method(request, h: ResponseToolkit) {
 				request.response.source = {
 					...request.response.source,
-					headers: headerService.getHeader().toData(),
+					headers: headerFactory().toData(),
 				};
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -8,7 +8,7 @@ export class HeaderIncludePlugin {
 	protected readonly app!: Contracts.Kernel.Application;
 
 	@inject(Identifiers.PeerHeader)
-	private readonly header!: Contracts.P2P.IHeader;
+	private readonly header!: Contracts.P2P.IHeaderService;
 
 	public register(server) {
 		const header = this.header;

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -7,11 +7,11 @@ export class HeaderIncludePlugin {
 	@inject(Identifiers.Application)
 	protected readonly app!: Contracts.Kernel.Application;
 
-	@inject(Identifiers.PeerHeader)
-	private readonly header!: Contracts.P2P.IHeaderService;
+	@inject(Identifiers.PeerHeaderService)
+	private readonly headerService!: Contracts.P2P.IHeaderService;
 
 	public register(server) {
-		const header = this.header;
+		const header = this.headerService;
 
 		server.ext({
 			async method(request, h: ResponseToolkit) {

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -11,13 +11,13 @@ export class HeaderIncludePlugin {
 	private readonly headerService!: Contracts.P2P.IHeaderService;
 
 	public register(server) {
-		const header = this.headerService;
+		const headerService = this.headerService;
 
 		server.ext({
 			async method(request, h: ResponseToolkit) {
 				request.response.source = {
 					...request.response.source,
-					headers: header.getHeader(),
+					headers: headerService.getHeader(),
 				};
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/server.test.ts
+++ b/packages/p2p/source/socket-server/server.test.ts
@@ -55,7 +55,8 @@ describe<{ sandbox: Sandbox; server: Server }>("Server", ({ it, assert, beforeEa
 		context.sandbox.app.bind(Identifiers.Consensus.Handler).toConstantValue({});
 		context.sandbox.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue({});
 		context.sandbox.app.bind(Identifiers.Cryptography.Message.Serializer).toConstantValue({});
-		context.sandbox.app.bind(Identifiers.PeerHeader).toConstantValue({});
+		context.sandbox.app.bind(Identifiers.PeerHeaderService).toConstantValue({});
+		context.sandbox.app.bind(Identifiers.PeerHeaderFactory).toConstantValue({});
 
 		context.server = context.sandbox.app.resolve(ServerProxy);
 	});


### PR DESCRIPTION
## Summary

- Temporary limit the download to one concurrent download per time. Prevote & precommit downloading will be improved in the future.
- Check peer header after delay, because new headers are expected in short time for precommit and prevote messages. 
- Skip header check if one is already pending for a peer. 



## Checklist

- [x] Ready to be merged
