### PR TITLE
refactor(p2p): remove `setMaxPayload` method form websocket client

### DIFF
--- a/packages/contracts/source/contracts/p2p/peer-connector.ts
+++ b/packages/contracts/source/contracts/p2p/peer-connector.ts
@@ -6,7 +6,7 @@ export interface PeerConnector {
 
 	connection(peer: Peer): Client | undefined;
 
-	connect(peer: Peer, maxPayload?: number): Promise<Client>;
+	connect(peer: Peer): Promise<Client>;
 
 	disconnect(peer: Peer): void;
 

--- a/packages/p2p/source/hapi-nes/client.ts
+++ b/packages/p2p/source/hapi-nes/client.ts
@@ -203,12 +203,6 @@ export class Client {
 		return this._ws && this._ws.readyState === WebSocket.OPEN;
 	}
 
-	public setMaxPayload(maxPayload: number) {
-		if (this._ws?._receiver) {
-			this._ws._receiver._maxPayload = maxPayload;
-		}
-	}
-
 	public setTimeout(timeout: number) {
 		this._settings.timeout = timeout;
 	}
@@ -465,10 +459,6 @@ export class Client {
 		return this._send(request, true);
 	}
 
-	private _resetMaxPayload() {
-		this.setMaxPayload(this._settings.ws.maxPayload);
-	}
-
 	private _onMessage(message) {
 		this._beat();
 
@@ -507,8 +497,6 @@ export class Client {
 			this._lastPinged = Date.now();
 			return this._send({ type: "ping" }, false).catch(ignore); // Ignore errors
 		}
-
-		this._resetMaxPayload();
 
 		// Lookup request (message must include an id from this point)
 		const request = this._requests[update.id];

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -252,7 +252,7 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 			const timeBeforeSocketCall: number = Date.now();
 
 			maxPayload = maxPayload || constants.DEFAULT_MAX_PAYLOAD_CLIENT;
-			await this.connector.connect(peer, maxPayload);
+			await this.connector.connect(peer);
 
 			response = await this.connector.emit(
 				peer,

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -178,8 +178,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 		peer: Contracts.P2P.Peer,
 		{ fromHeight, limit = constants.MAX_DOWNLOAD_BLOCKS }: { fromHeight: number; limit?: number },
 	): Promise<Contracts.P2P.IGetBlocksResponse> {
-		const maxPayload = constants.DEFAULT_MAX_PAYLOAD;
-
 		const result = await this.emit(
 			peer,
 			Routes.GetBlocks,
@@ -188,7 +186,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 				limit,
 			},
 			this.configuration.getRequired<number>("getBlocksTimeout"),
-			maxPayload,
 			false, //TODO: check why this is false
 		);
 
@@ -237,7 +234,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 		event: Routes,
 		payload: any,
 		timeout?: number,
-		maxPayload?: number,
 		disconnectOnError = true,
 	) {
 		await this.throttle(peer, event);
@@ -251,7 +247,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 
 			const timeBeforeSocketCall: number = Date.now();
 
-			maxPayload = maxPayload || constants.DEFAULT_MAX_PAYLOAD_CLIENT;
 			await this.connector.connect(peer);
 
 			response = await this.connector.emit(

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -34,11 +34,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 				await delay(TEN_SECONDS_IN_MILLISECONDS - timeSinceLastConnectionCreate);
 			}
 		}
-		const connection = this.connection(peer) || (await this.create(peer));
-		if (maxPayload) {
-			connection.setMaxPayload(maxPayload);
-		}
-		return connection;
+		return this.connection(peer) || (await this.create(peer));
 	}
 
 	public disconnect(peer: Contracts.P2P.Peer): void {

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -26,7 +26,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		return connection;
 	}
 
-	public async connect(peer: Contracts.P2P.Peer, maxPayload?: number): Promise<Client> {
+	public async connect(peer: Contracts.P2P.Peer): Promise<Client> {
 		if (!this.connection(peer)) {
 			// delay a bit if last connection create was less than 10 sec ago to prevent possible abuse of reconnection
 			const timeSinceLastConnectionCreate = Date.now() - (this.#lastConnectionCreate.get(peer.ip) ?? 0);


### PR DESCRIPTION
## Summary

Remove setMaxPayload method, because it is overwritten on request and it doesn't handle payload restrictions properly. This results in server disconnection when, because payload is exceeded, when lover value is set by another request. The collision is more often when the number of peer is low and traffic is high. 

## Checklist

- [x] Ready to be merged

