### PR TITLE
fix(p2p): getBlocks limit parameter

### DIFF
--- a/packages/p2p/source/block-downloader.ts
+++ b/packages/p2p/source/block-downloader.ts
@@ -77,7 +77,7 @@ export class BlockDownloader implements Contracts.P2P.BlockDownloader {
 
 			const result = await this.communicator.getBlocks(job.peer, {
 				fromHeight: job.heightFrom,
-				limit: job.heightTo - job.heightFrom,
+				limit: job.heightTo - job.heightFrom + 1,
 			});
 
 			job.blocks = result.blocks;

--- a/packages/p2p/source/socket-server/controllers/get-blocks.test.ts
+++ b/packages/p2p/source/socket-server/controllers/get-blocks.test.ts
@@ -40,6 +40,6 @@ describe<{
 
 		assert.equal(response, { blocks: mockBlocks });
 		spyGetBlocksForDownload.calledOnce();
-		spyGetBlocksForDownload.calledWith(payload.fromHeight, payload.fromHeight + payload.limit);
+		spyGetBlocksForDownload.calledWith(payload.fromHeight, payload.fromHeight + payload.limit - 1);
 	});
 });

--- a/packages/p2p/source/socket-server/controllers/get-blocks.ts
+++ b/packages/p2p/source/socket-server/controllers/get-blocks.ts
@@ -31,7 +31,7 @@ export class GetBlocksController implements Contracts.P2P.Controller {
 
 		const committedBlocks: Buffer[] = await this.database.findCommittedBlocks(
 			requestBlockHeight,
-			requestBlockHeight + requestBlockLimit,
+			requestBlockHeight + requestBlockLimit - 1,
 		);
 
 		// Only return the blocks fetched while we are below the p2p maxPayload limit

--- a/packages/p2p/source/socket-server/routes/route.ts
+++ b/packages/p2p/source/socket-server/routes/route.ts
@@ -45,6 +45,9 @@ export abstract class Route {
 					payload: {
 						maxBytes: config.maxBytes,
 					},
+					validate: {
+						payload: config.validation,
+					},
 				},
 				path,
 			});

--- a/packages/p2p/source/socket-server/schemas/get-blocks.ts
+++ b/packages/p2p/source/socket-server/schemas/get-blocks.ts
@@ -5,5 +5,5 @@ import { headers } from "./shared";
 export const getBlocks = Joi.object({
 	fromHeight: Joi.number().integer().min(1),
 	headers,
-	limit: Joi.number().integer().min(1).max(400),
-});
+	limit: Joi.number().integer().min(1).max(400).required(),
+}).required();

--- a/packages/p2p/source/socket-server/schemas/get-blocks.ts
+++ b/packages/p2p/source/socket-server/schemas/get-blocks.ts
@@ -3,7 +3,7 @@ import Joi from "joi";
 import { headers } from "./shared";
 
 export const getBlocks = Joi.object({
-	fromHeight: Joi.number().integer().min(1),
+	fromHeight: Joi.number().integer().min(1).required(),
 	headers,
 	limit: Joi.number().integer().min(1).max(400).required(),
 }).required();

--- a/packages/p2p/source/utils/build-rate-limiter.ts
+++ b/packages/p2p/source/utils/build-rate-limiter.ts
@@ -6,9 +6,8 @@ export const buildRateLimiter = (options) =>
 		configurations: {
 			endpoints: [
 				{
-					duration: 2,
 					endpoint: Routes.GetBlocks,
-					rateLimit: 1,
+					rateLimit: 5,
 				},
 				{
 					endpoint: Routes.GetPeers,


### PR DESCRIPTION
## Summary

- use correct limit values
- improve getBlocks validation schema
- validate route payload

## Checklist

- [x] Ready to be merged
