### PR TITLE
refactor(crypto-messages): add serialized field

### DIFF
--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -16,9 +16,9 @@ export interface ISignatureMessageData {
 export type HasBlockId = { blockId: string };
 export type WithoutBlockId<T> = Omit<T, "blockId">;
 export type WithOptionalBlockId<T extends HasBlockId> = WithoutBlockId<T> & Partial<Pick<T, "blockId">>;
-export interface ISignatureProposalData extends Omit<ISignatureMessageData, "type"> {}
-export interface ISignaturePrevoteData extends WithOptionalBlockId<ISignatureMessageData> {}
-export interface ISignaturePrecommitData extends WithOptionalBlockId<ISignatureMessageData> {}
+export interface ISignatureProposalData extends Omit<ISignatureMessageData, "type"> { }
+export interface ISignaturePrevoteData extends WithOptionalBlockId<ISignatureMessageData> { }
+export interface ISignaturePrecommitData extends WithOptionalBlockId<ISignatureMessageData> { }
 
 export interface IProposalData {
 	readonly height: number;
@@ -31,6 +31,7 @@ export interface IProposalData {
 
 export interface IProposal extends IProposalData {
 	readonly block: IProposedBlock;
+	readonly serialized: Buffer;
 
 	toSignatureData(): ISignatureProposalData;
 	toData(): IProposalData;
@@ -52,6 +53,8 @@ export interface IPrevoteData {
 }
 
 export interface IPrevote extends IPrevoteData {
+	readonly serialized: Buffer;
+
 	toSignatureData(): ISignaturePrevoteData;
 	toData(): IPrevoteData;
 	toString(): string;
@@ -67,6 +70,8 @@ export interface IPrecommitData {
 }
 
 export interface IPrecommit extends IPrecommitData {
+	readonly serialized: Buffer;
+
 	toSignatureData(): ISignaturePrecommitData;
 	toData(): IPrecommitData;
 	toString(): string;

--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -16,9 +16,9 @@ export interface ISignatureMessageData {
 export type HasBlockId = { blockId: string };
 export type WithoutBlockId<T> = Omit<T, "blockId">;
 export type WithOptionalBlockId<T extends HasBlockId> = WithoutBlockId<T> & Partial<Pick<T, "blockId">>;
-export interface ISignatureProposalData extends Omit<ISignatureMessageData, "type"> { }
-export interface ISignaturePrevoteData extends WithOptionalBlockId<ISignatureMessageData> { }
-export interface ISignaturePrecommitData extends WithOptionalBlockId<ISignatureMessageData> { }
+export interface ISignatureProposalData extends Omit<ISignatureMessageData, "type"> {}
+export interface ISignaturePrevoteData extends WithOptionalBlockId<ISignatureMessageData> {}
+export interface ISignaturePrecommitData extends WithOptionalBlockId<ISignatureMessageData> {}
 
 export interface IProposalData {
 	readonly height: number;

--- a/packages/crypto-messages/source/factory.ts
+++ b/packages/crypto-messages/source/factory.ts
@@ -42,7 +42,10 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 		return this.makeProposalFromData(data, bytes);
 	}
 
-	public async makeProposalFromData(data: Contracts.Crypto.IProposalData, serialized?: Buffer): Promise<Contracts.Crypto.IProposal> {
+	public async makeProposalFromData(
+		data: Contracts.Crypto.IProposalData,
+		serialized?: Buffer,
+	): Promise<Contracts.Crypto.IProposal> {
 		this.#applySchema("proposal", data);
 		const block = await this.blockFactory.fromProposedBytes(Buffer.from(data.block.serialized, "hex"));
 
@@ -73,7 +76,10 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 		return this.makePrevoteFromData(data, bytes);
 	}
 
-	public async makePrevoteFromData(data: Contracts.Crypto.IPrevoteData, serialized?: Buffer): Promise<Contracts.Crypto.IPrevote> {
+	public async makePrevoteFromData(
+		data: Contracts.Crypto.IPrevoteData,
+		serialized?: Buffer,
+	): Promise<Contracts.Crypto.IPrevote> {
 		this.#applySchema("prevote", data);
 
 		if (!serialized) {
@@ -104,7 +110,10 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 		return this.makePrecommitFromData(data, bytes);
 	}
 
-	public async makePrecommitFromData(data: Contracts.Crypto.IPrecommitData, serialized?: Buffer): Promise<Contracts.Crypto.IPrecommit> {
+	public async makePrecommitFromData(
+		data: Contracts.Crypto.IPrecommitData,
+		serialized?: Buffer,
+	): Promise<Contracts.Crypto.IPrecommit> {
 		this.#applySchema("precommit", data);
 
 		if (!serialized) {

--- a/packages/crypto-messages/source/factory.ts
+++ b/packages/crypto-messages/source/factory.ts
@@ -39,14 +39,18 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 
 	public async makeProposalFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IProposal> {
 		const data = await this.deserializer.deserializeProposal(bytes);
-		return this.makeProposalFromData(data);
+		return this.makeProposalFromData(data, bytes);
 	}
 
-	public async makeProposalFromData(data: Contracts.Crypto.IProposalData): Promise<Contracts.Crypto.IProposal> {
+	public async makeProposalFromData(data: Contracts.Crypto.IProposalData, serialized?: Buffer): Promise<Contracts.Crypto.IProposal> {
 		this.#applySchema("proposal", data);
 		const block = await this.blockFactory.fromProposedBytes(Buffer.from(data.block.serialized, "hex"));
 
-		return new Proposal({ ...data, block });
+		if (!serialized) {
+			serialized = await this.serializer.serializeProposal(data);
+		}
+
+		return new Proposal({ ...data, block, serialized });
 	}
 
 	public async makePrevote(
@@ -66,12 +70,17 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 
 	public async makePrevoteFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IPrecommit> {
 		const data = await this.deserializer.deserializePrevote(bytes);
-		return this.makePrevoteFromData(data);
+		return this.makePrevoteFromData(data, bytes);
 	}
 
-	public async makePrevoteFromData(data: Contracts.Crypto.IPrevoteData): Promise<Contracts.Crypto.IPrevote> {
+	public async makePrevoteFromData(data: Contracts.Crypto.IPrevoteData, serialized?: Buffer): Promise<Contracts.Crypto.IPrevote> {
 		this.#applySchema("prevote", data);
-		return new Prevote(data);
+
+		if (!serialized) {
+			serialized = await this.serializer.serializePrevote(data);
+		}
+
+		return new Prevote({ ...data, serialized });
 	}
 
 	public async makePrecommit(
@@ -92,13 +101,17 @@ export class MessageFactory implements Contracts.Crypto.IMessageFactory {
 
 	public async makePrecommitFromBytes(bytes: Buffer): Promise<Contracts.Crypto.IPrecommit> {
 		const data = await this.deserializer.deserializePrecommit(bytes);
-		this.#applySchema("precommit", data);
-		return new Precommit(data);
+		return this.makePrecommitFromData(data, bytes);
 	}
 
-	public async makePrecommitFromData(data: Contracts.Crypto.IPrecommitData): Promise<Contracts.Crypto.IPrecommit> {
+	public async makePrecommitFromData(data: Contracts.Crypto.IPrecommitData, serialized?: Buffer): Promise<Contracts.Crypto.IPrecommit> {
 		this.#applySchema("precommit", data);
-		return new Precommit(data);
+
+		if (!serialized) {
+			serialized = await this.serializer.serializePrecommit(data);
+		}
+
+		return new Precommit({ ...data, serialized });
 	}
 
 	#applySchema<T>(schema: string, data: T): T {

--- a/packages/crypto-messages/source/precommit.test.ts
+++ b/packages/crypto-messages/source/precommit.test.ts
@@ -1,4 +1,3 @@
-import { Contracts } from "@mainsail/contracts";
 import { describe, Sandbox } from "../../test-framework";
 import { Precommit } from "./precommit";
 import { precommitData } from "../test/fixtures/proposal";
@@ -6,7 +5,7 @@ import { precommitData } from "../test/fixtures/proposal";
 describe<{
 	sandbox: Sandbox;
 }>("Precommit", ({ it, assert }) => {
-	const precommit = new Precommit(precommitData);
+	const precommit = new Precommit({ ...precommitData, serialized: Buffer.from("dead", "hex") });
 
 	it("#height", async () => {
 		assert.equal(precommit.height, 1);
@@ -26,6 +25,10 @@ describe<{
 
 	it("#signature", async () => {
 		assert.equal(precommit.signature, precommitData.signature);
+	});
+
+	it("#signature", async () => {
+		assert.equal(precommit.serialized.toString("hex"), "dead");
 	});
 
 	it("#toString", async () => {

--- a/packages/crypto-messages/source/precommit.ts
+++ b/packages/crypto-messages/source/precommit.ts
@@ -8,7 +8,14 @@ export class Precommit implements Contracts.Crypto.IPrecommit {
 	#signature: string;
 	#serialized: Buffer;
 
-	constructor({ height, round, blockId, validatorIndex, signature, serialized }: Contracts.Crypto.IPrecommitData & { serialized: Buffer }) {
+	constructor({
+		height,
+		round,
+		blockId,
+		validatorIndex,
+		signature,
+		serialized,
+	}: Contracts.Crypto.IPrecommitData & { serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#blockId = blockId;

--- a/packages/crypto-messages/source/precommit.ts
+++ b/packages/crypto-messages/source/precommit.ts
@@ -6,13 +6,15 @@ export class Precommit implements Contracts.Crypto.IPrecommit {
 	#blockId: string | undefined;
 	#validatorIndex: number;
 	#signature: string;
+	#serialized: Buffer;
 
-	constructor({ height, round, blockId, validatorIndex, signature }: Contracts.Crypto.IPrecommitData) {
+	constructor({ height, round, blockId, validatorIndex, signature, serialized }: Contracts.Crypto.IPrecommitData & { serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#blockId = blockId;
 		this.#validatorIndex = validatorIndex;
 		this.#signature = signature;
+		this.#serialized = serialized;
 	}
 
 	get type(): Contracts.Crypto.MessageType {
@@ -37,6 +39,10 @@ export class Precommit implements Contracts.Crypto.IPrecommit {
 
 	get signature(): string {
 		return this.#signature;
+	}
+
+	get serialized(): Buffer {
+		return this.#serialized;
 	}
 
 	toString(): string {

--- a/packages/crypto-messages/source/prevote.test.ts
+++ b/packages/crypto-messages/source/prevote.test.ts
@@ -6,7 +6,7 @@ import { prevoteData } from "../test/fixtures/proposal";
 describe<{
 	sandbox: Sandbox;
 }>("Prevote", ({ it, assert }) => {
-	const prevote = new Prevote(prevoteData);
+	const prevote = new Prevote({ ...prevoteData, serialized: Buffer.from("dead", "hex") });
 
 	it("#height", async () => {
 		assert.equal(prevote.height, 1);
@@ -26,6 +26,10 @@ describe<{
 
 	it("#signature", async () => {
 		assert.equal(prevote.signature, prevoteData.signature);
+	});
+
+	it("#serialized", async () => {
+		assert.equal(prevote.serialized.toString("hex"), "dead");
 	});
 
 	it("#toString", async () => {

--- a/packages/crypto-messages/source/prevote.ts
+++ b/packages/crypto-messages/source/prevote.ts
@@ -8,7 +8,14 @@ export class Prevote implements Contracts.Crypto.IPrevote {
 	#signature: string;
 	#serialized: Buffer;
 
-	constructor({ height, round, blockId, validatorIndex, signature, serialized }: Contracts.Crypto.IPrevoteData & { serialized: Buffer }) {
+	constructor({
+		height,
+		round,
+		blockId,
+		validatorIndex,
+		signature,
+		serialized,
+	}: Contracts.Crypto.IPrevoteData & { serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#blockId = blockId;

--- a/packages/crypto-messages/source/prevote.ts
+++ b/packages/crypto-messages/source/prevote.ts
@@ -6,13 +6,15 @@ export class Prevote implements Contracts.Crypto.IPrevote {
 	#blockId: string | undefined;
 	#validatorIndex: number;
 	#signature: string;
+	#serialized: Buffer;
 
-	constructor({ height, round, blockId, validatorIndex, signature }: Contracts.Crypto.IPrevoteData) {
+	constructor({ height, round, blockId, validatorIndex, signature, serialized }: Contracts.Crypto.IPrevoteData & { serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#blockId = blockId;
 		this.#validatorIndex = validatorIndex;
 		this.#signature = signature;
+		this.#serialized = serialized;
 	}
 
 	get type(): Contracts.Crypto.MessageType {
@@ -37,6 +39,10 @@ export class Prevote implements Contracts.Crypto.IPrevote {
 
 	get signature(): string {
 		return this.#signature;
+	}
+
+	get serialized(): Buffer {
+		return this.#serialized;
 	}
 
 	toString(): string {

--- a/packages/crypto-messages/source/proposal.test.ts
+++ b/packages/crypto-messages/source/proposal.test.ts
@@ -16,7 +16,7 @@ describe<{
 		serialized: serializedBlock,
 	};
 
-	const proposal = new Proposal({ ...proposalData, block });
+	const proposal = new Proposal({ ...proposalData, block, serialized: Buffer.from("dead", "hex") });
 
 	it("#height", async () => {
 		assert.equal(proposal.height, 1);
@@ -40,6 +40,10 @@ describe<{
 
 	it("#signature", async () => {
 		assert.equal(proposal.signature, proposalData.signature);
+	});
+
+	it("#serialized", async () => {
+		assert.equal(proposal.serialized.toString("hex"), "dead");
 	});
 
 	it("#toString", async () => {

--- a/packages/crypto-messages/source/proposal.ts
+++ b/packages/crypto-messages/source/proposal.ts
@@ -17,7 +17,7 @@ export class Proposal implements Contracts.Crypto.IProposal {
 		validRound,
 		signature,
 		serialized,
-	}: Contracts.Crypto.IProposalData & { block: Contracts.Crypto.IProposedBlock, serialized: Buffer }) {
+	}: Contracts.Crypto.IProposalData & { block: Contracts.Crypto.IProposedBlock; serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#validRound = validRound;

--- a/packages/crypto-messages/source/proposal.ts
+++ b/packages/crypto-messages/source/proposal.ts
@@ -7,6 +7,7 @@ export class Proposal implements Contracts.Crypto.IProposal {
 	#block: Contracts.Crypto.IProposedBlock;
 	#validatorIndex: number;
 	#signature: string;
+	#serialized: Buffer;
 
 	constructor({
 		height,
@@ -15,13 +16,15 @@ export class Proposal implements Contracts.Crypto.IProposal {
 		block,
 		validRound,
 		signature,
-	}: Contracts.Crypto.IProposalData & { block: Contracts.Crypto.IProposedBlock }) {
+		serialized,
+	}: Contracts.Crypto.IProposalData & { block: Contracts.Crypto.IProposedBlock, serialized: Buffer }) {
 		this.#height = height;
 		this.#round = round;
 		this.#validRound = validRound;
 		this.#block = block;
 		this.#validatorIndex = validatorIndex;
 		this.#signature = signature;
+		this.#serialized = serialized;
 	}
 
 	get height(): number {
@@ -46,6 +49,10 @@ export class Proposal implements Contracts.Crypto.IProposal {
 
 	get signature(): string {
 		return this.#signature;
+	}
+
+	get serialized(): Buffer {
+		return this.#serialized;
 	}
 
 	toString(): string {

--- a/packages/p2p/source/broadcaster.ts
+++ b/packages/p2p/source/broadcaster.ts
@@ -20,9 +20,6 @@ export class Broadcaster implements Contracts.P2P.Broadcaster {
 	@inject(Identifiers.Cryptography.Transaction.Serializer)
 	private readonly serializer!: Contracts.Crypto.ITransactionSerializer;
 
-	@inject(Identifiers.Cryptography.Message.Serializer)
-	private readonly messageSerializer!: Contracts.Crypto.IMessageSerializer;
-
 	public async broadcastTransactions(transactions: Contracts.Crypto.ITransaction[]): Promise<void> {
 		if (transactions.length === 0) {
 			this.logger.warning("Broadcasting 0 transactions");
@@ -49,8 +46,7 @@ export class Broadcaster implements Contracts.P2P.Broadcaster {
 	}
 
 	async broadcastProposal(proposal: Contracts.Crypto.IProposal): Promise<void> {
-		// TODO: Remove once serialized field is on IProposal
-		const serialized = await this.messageSerializer.serializeProposal(proposal);
+		const { serialized } = proposal;
 
 		const promises = this.#getPeersForBroadcast().map((peer) => this.communicator.postProposal(peer, serialized));
 
@@ -58,8 +54,7 @@ export class Broadcaster implements Contracts.P2P.Broadcaster {
 	}
 
 	public async broadcastPrevote(prevote: Contracts.Crypto.IPrevote): Promise<void> {
-		// TODO: Remove once serialized field is on IPrevote
-		const serialized = await this.messageSerializer.serializePrevote(prevote);
+		const { serialized } = prevote;
 
 		const promises = this.#getPeersForBroadcast().map((peer) => this.communicator.postPrevote(peer, serialized));
 
@@ -67,8 +62,7 @@ export class Broadcaster implements Contracts.P2P.Broadcaster {
 	}
 
 	async broadcastPrecommit(precommit: Contracts.Crypto.IPrecommit): Promise<void> {
-		// TODO: Remove once serialized field is on IPrecommit
-		const serialized = await this.messageSerializer.serializePrecommit(precommit);
+		const { serialized } = precommit;
 
 		const promises = this.#getPeersForBroadcast().map((peer) => this.communicator.postPrecommit(peer, serialized));
 

--- a/packages/p2p/source/socket-server/controllers/get-messages.ts
+++ b/packages/p2p/source/socket-server/controllers/get-messages.ts
@@ -39,10 +39,7 @@ export class GetMessagesController implements Contracts.P2P.Controller {
 		};
 	}
 
-	private getPrevotes(
-		validatorsSignedPrevote: boolean[],
-		roundState: Contracts.Consensus.IRoundState,
-	): Buffer[] {
+	private getPrevotes(validatorsSignedPrevote: boolean[], roundState: Contracts.Consensus.IRoundState): Buffer[] {
 		const prevotes: Buffer[] = [];
 
 		for (const [index, voted] of validatorsSignedPrevote.entries()) {
@@ -60,10 +57,7 @@ export class GetMessagesController implements Contracts.P2P.Controller {
 		return prevotes;
 	}
 
-	private getPrecommits(
-		validatorsSignedPrecommit: boolean[],
-		roundState: Contracts.Consensus.IRoundState,
-	): Buffer[] {
+	private getPrecommits(validatorsSignedPrecommit: boolean[], roundState: Contracts.Consensus.IRoundState): Buffer[] {
 		const precommits: Buffer[] = [];
 
 		for (const [index, voted] of validatorsSignedPrecommit.entries()) {

--- a/packages/p2p/source/socket-server/controllers/get-proposal.ts
+++ b/packages/p2p/source/socket-server/controllers/get-proposal.ts
@@ -7,9 +7,6 @@ export class GetProposalController implements Contracts.P2P.Controller {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 
-	@inject(Identifiers.Cryptography.Message.Serializer)
-	private readonly serializer!: Contracts.Crypto.IMessageSerializer;
-
 	public async handle(
 		request: Contracts.P2P.IGetProposalRequest,
 		h: Hapi.ResponseToolkit,
@@ -41,7 +38,7 @@ export class GetProposalController implements Contracts.P2P.Controller {
 		}
 
 		return {
-			proposal: await this.serializer.serializeProposal(proposal),
+			proposal: proposal.serialized,
 		};
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Add a `serialized` field to the message objects to keep the original bytes around, so we don't have to serialize them again for p2p gossip.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
