### PR TITLE
refactor(crypto-messages): implements `limitToActiveValidators` keyword

### DIFF
--- a/packages/crypto-messages/source/keywords.test.ts
+++ b/packages/crypto-messages/source/keywords.test.ts
@@ -19,14 +19,14 @@ describe<{
 		context.sandbox.app.get<Configuration>(Identifiers.Cryptography.Configuration).setConfig(cryptoJson);
 
 		const keywords = makeKeywords(context.sandbox.app.get<Configuration>(Identifiers.Cryptography.Configuration));
-		context.validator.addKeyword(keywords.isValidatorBitmap);
+		context.validator.addKeyword(keywords.limitToActiveValidators);
 		context.validator.addKeyword(keywords.isValidatorIndex);
 	});
 
-	it("keyword isValidatorBitmap - should be ok", (context) => {
+	it("keyword limitToActiveValidators - should be ok", (context) => {
 		const schema = {
 			$id: "test",
-			isValidatorBitmap: {},
+			limitToActiveValidators: {},
 		};
 		context.validator.addSchema(schema);
 
@@ -41,23 +41,23 @@ describe<{
 		assert.undefined(context.validator.validate("test", matrix).error);
 
 		matrix = new Array(activeValidators).fill(1);
-		assert.defined(context.validator.validate("test", matrix).error);
+		assert.undefined(context.validator.validate("test", matrix).error);
 
 		matrix = new Array(activeValidators - 1).fill(false);
 		assert.defined(context.validator.validate("test", matrix).error);
 
 		assert.defined(context.validator.validate("test", {}).error);
-		assert.defined(context.validator.validate("test", undefined).error);
+		assert.defined(context.validator.validate("test").error);
 		assert.defined(context.validator.validate("test", null).error);
 		assert.defined(context.validator.validate("test", "12134354").error);
 		assert.defined(context.validator.validate("test", []).error);
 		assert.defined(context.validator.validate("test", 1).error);
 	});
 
-	it("keyword isValidatorBitmap - should be ok with minimum", (context) => {
+	it("keyword limitToActiveValidators - should be ok with minimum", (context) => {
 		const schema = {
 			$id: "test",
-			isValidatorBitmap: {
+			limitToActiveValidators: {
 				minimum: 0,
 			},
 		};
@@ -89,14 +89,14 @@ describe<{
 			.get<Contracts.Crypto.IConfiguration>(Identifiers.Cryptography.Configuration)
 			.getMilestone();
 
-		for (let i = 0; i < activeValidators; i++) {
-			assert.undefined(context.validator.validate("test", i).error);
+		for (let index = 0; index < activeValidators; index++) {
+			assert.undefined(context.validator.validate("test", index).error);
 		}
 
-		assert.defined(context.validator.validate("test", 50.00001).error);
+		assert.defined(context.validator.validate("test", 50.000_01).error);
 		assert.defined(context.validator.validate("test", activeValidators).error);
 		assert.defined(context.validator.validate("test", activeValidators + 1).error);
 		assert.defined(context.validator.validate("test", "a").error);
-		assert.defined(context.validator.validate("test", undefined).error);
+		assert.defined(context.validator.validate("test").error);
 	});
 });

--- a/packages/crypto-messages/source/keywords.ts
+++ b/packages/crypto-messages/source/keywords.ts
@@ -2,6 +2,33 @@ import { Contracts } from "@mainsail/contracts";
 import { FuncKeywordDefinition } from "ajv";
 
 export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => {
+	const limitToActiveValidators: FuncKeywordDefinition = {
+		compile(schema) {
+			return (data) => {
+				const { activeValidators } = configuration.getMilestone();
+				if (!Array.isArray(data)) {
+					return false;
+				}
+
+				const minimum = typeof schema.minimum !== "undefined" ? schema.minimum : activeValidators;
+
+				if (data.length < minimum || data.length > activeValidators) {
+					return false;
+				}
+
+				return true;
+			};
+		},
+		errors: false,
+		keyword: "limitToActiveValidators",
+		metaSchema: {
+			properties: {
+				minimum: { type: "integer" },
+			},
+			type: "object",
+		},
+	};
+
 	const isValidatorBitmap: FuncKeywordDefinition = {
 		compile(schema) {
 			return (data) => {
@@ -51,5 +78,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 	return {
 		isValidatorBitmap,
 		isValidatorIndex,
+		limitToActiveValidators,
 	};
 };

--- a/packages/crypto-messages/source/keywords.ts
+++ b/packages/crypto-messages/source/keywords.ts
@@ -29,33 +29,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 		},
 	};
 
-	const isValidatorBitmap: FuncKeywordDefinition = {
-		compile(schema) {
-			return (data) => {
-				const { activeValidators } = configuration.getMilestone();
-				if (!Array.isArray(data)) {
-					return false;
-				}
-
-				const minimum = typeof schema.minimum !== "undefined" ? schema.minimum : activeValidators;
-
-				if (data.length < minimum || data.length > activeValidators) {
-					return false;
-				}
-
-				return data.every((element: any) => typeof element === "boolean");
-			};
-		},
-		errors: false,
-		keyword: "isValidatorBitmap",
-		metaSchema: {
-			properties: {
-				minimum: { type: "integer" },
-			},
-			type: "object",
-		},
-	};
-
 	const isValidatorIndex: FuncKeywordDefinition = {
 		compile() {
 			return (data) => {
@@ -76,7 +49,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 	};
 
 	return {
-		isValidatorBitmap,
 		isValidatorIndex,
 		limitToActiveValidators,
 	};

--- a/packages/crypto-messages/source/schemas.test.ts
+++ b/packages/crypto-messages/source/schemas.test.ts
@@ -1,14 +1,12 @@
 import { Identifiers } from "@mainsail/contracts";
-import { Configuration } from "@mainsail/crypto-config";
-import { schemas as baseSchemas, makeKeywords as makeBaseKeywords } from "@mainsail/crypto-validation";
 import { schemas as blockSchemas } from "@mainsail/crypto-block";
+import { Configuration } from "@mainsail/crypto-config";
 import { schemas as consensusSchemas } from "@mainsail/crypto-consensus-bls12-381";
+import { makeKeywords as makeBaseKeywords, schemas as baseSchemas } from "@mainsail/crypto-validation";
 import { Validator } from "@mainsail/validation/source/validator";
 
 import cryptoJson from "../../core/bin/config/testnet/crypto.json";
 import { describe, Sandbox } from "../../test-framework";
-import { schemas } from "./schemas";
-import { makeKeywords as makeMessageKeywords } from "./keywords";
 import {
 	precommitData,
 	precommitDataNoBlock,
@@ -16,6 +14,8 @@ import {
 	prevoteDataNoBlock,
 	proposalData,
 } from "../test/fixtures/proposal";
+import { makeKeywords as makeMessageKeywords } from "./keywords";
+import { schemas } from "./schemas";
 
 describe<{
 	sandbox: Sandbox;

--- a/packages/crypto-messages/source/schemas.ts
+++ b/packages/crypto-messages/source/schemas.ts
@@ -63,6 +63,10 @@ export const schemas: Record<
 	},
 	validatorBitmap: {
 		$id: "validatorBitmap",
-		isValidatorBitmap: {},
+		items: {
+			buffer: {},
+		},
+		limitToActiveValidators: {},
+		type: "array",
 	},
 };

--- a/packages/p2p/source/reply-schemas/get-messages.test.ts
+++ b/packages/p2p/source/reply-schemas/get-messages.test.ts
@@ -2,8 +2,8 @@ import { Validator } from "@mainsail/validation/source/validator";
 
 import { describe, Sandbox } from "../../../test-framework/distribution";
 import { headers } from "../../test/fixtures/responses/headers";
-import { getMessages } from "./get-messages";
 import { prepareValidatorContext } from "../../test/helpers/prepare-validator-context";
+import { getMessages } from "./get-messages";
 
 type Context = {
 	sandbox: Sandbox;
@@ -49,10 +49,10 @@ describe<Context>("GetMessages Schema", ({ it, assert, beforeEach, each }) => {
 		assert.defined(result.error);
 	});
 
-	it("should not pass if precommits.len > 51", ({ validator }) => {
+	it("should not pass if precommits.len > activeValidators", ({ validator }) => {
 		const result = validator.validate(getMessages, {
 			...data,
-			precommits: Array.from({ length: 52 }).fill(Buffer.from("a")),
+			precommits: Array.from({ length: 55 }).fill(Buffer.from("a")),
 		});
 
 		assert.defined(result.error);
@@ -67,10 +67,10 @@ describe<Context>("GetMessages Schema", ({ it, assert, beforeEach, each }) => {
 		assert.defined(result.error);
 	});
 
-	it("should not pass if prevotes.len > 51", ({ validator }) => {
+	it("should not pass if prevotes.len > activeValidators", ({ validator }) => {
 		const result = validator.validate(getMessages, {
 			...data,
-			prevotes: Array.from({ length: 52 }).fill(Buffer.from("b")),
+			prevotes: Array.from({ length: 55 }).fill(Buffer.from("b")),
 		});
 
 		assert.defined(result.error);

--- a/packages/p2p/source/reply-schemas/get-messages.ts
+++ b/packages/p2p/source/reply-schemas/get-messages.ts
@@ -7,14 +7,14 @@ export const getMessages = {
 			items: {
 				buffer: {},
 			},
-			maxItems: 51, // TODO: Form milestones
+			limitToActiveValidators: { minimum: 0 },
 			type: "array",
 		},
 		prevotes: {
 			items: {
 				buffer: {},
 			},
-			maxItems: 51, // TODO: Form milestones
+			limitToActiveValidators: { minimum: 0 },
 			type: "array",
 		},
 	},

--- a/packages/p2p/source/reply-schemas/headers.ts
+++ b/packages/p2p/source/reply-schemas/headers.ts
@@ -18,10 +18,18 @@ export const headers = {
 			type: "integer",
 		},
 		validatorsSignedPrecommit: {
-			isValidatorBitmap: {},
+			items: {
+				typeof: "boolean",
+			},
+			limitToActiveValidators: {},
+			type: "array",
 		},
 		validatorsSignedPrevote: {
-			isValidatorBitmap: {},
+			items: {
+				typeof: "boolean",
+			},
+			limitToActiveValidators: {},
+			type: "array",
 		},
 		version: {
 			pattern: "^\\d+\\.\\d+\\.\\d+$",

--- a/packages/p2p/test/helpers/prepare-validator-context.ts
+++ b/packages/p2p/test/helpers/prepare-validator-context.ts
@@ -1,13 +1,14 @@
 import { Identifiers } from "@mainsail/contracts";
-import { Configuration } from "../../../crypto-config/distribution";
-import cryptoJson from "../../../core/bin/config/testnet/crypto.json";
-import { makeKeywords } from "../../source/validation/keywords";
-import { makeKeywords as makeMessageKeywords } from "../../../crypto-messages/distribution/keywords";
-import { schemas as cryptoBlockSchemas } from "../../../crypto-block/distribution";
-import { schemas as cryptoValidationSchemas } from "../../../crypto-validation/distribution";
-import { schemas as cryptoTransactionSchemas } from "../../../crypto-transaction/distribution";
-import { Sandbox } from "../../../test-framework/distribution";
 import { Validator } from "@mainsail/validation/source/validator";
+
+import cryptoJson from "../../../core/bin/config/testnet/crypto.json";
+import { schemas as cryptoBlockSchemas } from "../../../crypto-block/distribution";
+import { Configuration } from "../../../crypto-config/distribution";
+import { makeKeywords as makeMessageKeywords } from "../../../crypto-messages/distribution/keywords";
+import { schemas as cryptoTransactionSchemas } from "../../../crypto-transaction/distribution";
+import { schemas as cryptoValidationSchemas } from "../../../crypto-validation/distribution";
+import { Sandbox } from "../../../test-framework/distribution";
+import { makeKeywords } from "../../source/validation/keywords";
 
 type Context = {
 	sandbox: Sandbox;
@@ -23,7 +24,7 @@ export const prepareValidatorContext = (context: Context) => {
 
 	const configuration = context.sandbox.app.get<Configuration>(Identifiers.Cryptography.Configuration);
 	const messageKeywords = makeMessageKeywords(configuration);
-	context.validator.addKeyword(messageKeywords.isValidatorBitmap);
+	context.validator.addKeyword(messageKeywords.limitToActiveValidators);
 	context.validator.addKeyword(messageKeywords.isValidatorIndex);
 
 	context.validator.addSchema(cryptoValidationSchemas.hex);


### PR DESCRIPTION
## Summary

Implement and uses **limitToActiveValidators** keyword.  **isValidatorBitmap** is removed. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
