### PR TITLE
refactor(consensus): store messages by validator and round

### DIFF
--- a/packages/consensus/source/consensus.test.ts
+++ b/packages/consensus/source/consensus.test.ts
@@ -29,72 +29,73 @@ type Context = {
 describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each }) => {
 	beforeEach((context) => {
 		context.blockProcessor = {
-			commit: () => {},
-			process: () => {},
+			commit: () => { },
+			process: () => { },
 		};
 
 		context.state = {
-			getLastBlock: () => {},
+			getLastBlock: () => { },
 		};
 
 		context.proposalProcessor = {
-			process: () => {},
+			process: () => { },
 		};
 
 		context.prevoteProcessor = {
-			process: () => {},
+			process: () => { },
 		};
 
 		context.precommitProcessor = {
-			process: () => {},
+			process: () => { },
 		};
 
 		context.scheduler = {
-			clear: () => {},
-			scheduleTimeoutPrecommit: () => {},
-			scheduleTimeoutPrevote: () => {},
-			scheduleTimeoutPropose: () => {},
-			scheduleTimeoutStartRound: () => {},
+			clear: () => { },
+			scheduleTimeoutPrecommit: () => { },
+			scheduleTimeoutPrevote: () => { },
+			scheduleTimeoutPropose: () => { },
+			scheduleTimeoutStartRound: () => { },
 		};
 
 		context.storage = {
-			clear: () => {},
-			getPrecommits: () => {},
-			getPrevotes: () => {},
-			getProposals: () => {},
-			getState: () => {},
-			savePrecommit: () => {},
-			savePrevote: () => {},
-			saveProposal: () => {},
-			saveState: () => {},
+			clear: () => { },
+			getPrecommits: () => { },
+			getPrevotes: () => { },
+			getProposals: () => { },
+			getState: () => { },
+			savePrecommit: () => { },
+			savePrevote: () => { },
+			saveProposal: () => { },
+			saveState: () => { },
 		};
 
 		context.bootstrapper = {
-			run: () => {},
+			run: () => { },
 		};
 
 		context.aggregator = {};
 
 		context.validatorsRepository = {
-			getValidator: () => {},
-			getValidators: () => {},
+			getValidator: () => { },
+			getValidators: () => { },
 		};
 
 		context.roundStateRepository = {
-			getRoundState: () => {},
+			getRoundState: () => context.roundState,
+			clear: () => { },
 		};
 
 		context.validatorSet = {
-			getActiveValidators: () => {},
+			getActiveValidators: () => { },
 			getValidatorIndexByPublicKey: () => "",
 		};
 
 		context.proposerPicker = {
-			getValidatorIndex: () => {},
+			getValidatorIndex: () => { },
 		};
 
 		context.logger = {
-			info: () => {},
+			info: () => { },
 		};
 
 		context.block = {
@@ -115,24 +116,16 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 			validatorPublicKey: "validatorPublicKey",
 		};
 
-		context.roundStateRepository = {
-			getRoundState: () => {},
-		};
-
 		context.roundState = {
-			getBlock: () => {},
+			getBlock: () => { },
 			getProposal: () => context.proposal,
 			hasPrecommit: () => false,
 			hasPrevote: () => false,
 			hasProposal: () => false,
 			height: 2,
 			round: 0,
-			setProcessorResult: () => {},
+			setProcessorResult: () => { },
 		} as unknown as Contracts.Consensus.IRoundState;
-
-		context.roundStateRepository = {
-			getRoundState: () => context.roundState,
-		};
 
 		context.verifier = {
 			hasValidProposalLockProof: () => true,

--- a/packages/consensus/source/consensus.test.ts
+++ b/packages/consensus/source/consensus.test.ts
@@ -29,73 +29,73 @@ type Context = {
 describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each }) => {
 	beforeEach((context) => {
 		context.blockProcessor = {
-			commit: () => { },
-			process: () => { },
+			commit: () => {},
+			process: () => {},
 		};
 
 		context.state = {
-			getLastBlock: () => { },
+			getLastBlock: () => {},
 		};
 
 		context.proposalProcessor = {
-			process: () => { },
+			process: () => {},
 		};
 
 		context.prevoteProcessor = {
-			process: () => { },
+			process: () => {},
 		};
 
 		context.precommitProcessor = {
-			process: () => { },
+			process: () => {},
 		};
 
 		context.scheduler = {
-			clear: () => { },
-			scheduleTimeoutPrecommit: () => { },
-			scheduleTimeoutPrevote: () => { },
-			scheduleTimeoutPropose: () => { },
-			scheduleTimeoutStartRound: () => { },
+			clear: () => {},
+			scheduleTimeoutPrecommit: () => {},
+			scheduleTimeoutPrevote: () => {},
+			scheduleTimeoutPropose: () => {},
+			scheduleTimeoutStartRound: () => {},
 		};
 
 		context.storage = {
-			clear: () => { },
-			getPrecommits: () => { },
-			getPrevotes: () => { },
-			getProposals: () => { },
-			getState: () => { },
-			savePrecommit: () => { },
-			savePrevote: () => { },
-			saveProposal: () => { },
-			saveState: () => { },
+			clear: () => {},
+			getPrecommits: () => {},
+			getPrevotes: () => {},
+			getProposals: () => {},
+			getState: () => {},
+			savePrecommit: () => {},
+			savePrevote: () => {},
+			saveProposal: () => {},
+			saveState: () => {},
 		};
 
 		context.bootstrapper = {
-			run: () => { },
+			run: () => {},
 		};
 
 		context.aggregator = {};
 
 		context.validatorsRepository = {
-			getValidator: () => { },
-			getValidators: () => { },
+			getValidator: () => {},
+			getValidators: () => {},
 		};
 
 		context.roundStateRepository = {
 			getRoundState: () => context.roundState,
-			clear: () => { },
+			clear: () => {},
 		};
 
 		context.validatorSet = {
-			getActiveValidators: () => { },
+			getActiveValidators: () => {},
 			getValidatorIndexByPublicKey: () => "",
 		};
 
 		context.proposerPicker = {
-			getValidatorIndex: () => { },
+			getValidatorIndex: () => {},
 		};
 
 		context.logger = {
-			info: () => { },
+			info: () => {},
 		};
 
 		context.block = {
@@ -117,14 +117,14 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		};
 
 		context.roundState = {
-			getBlock: () => { },
+			getBlock: () => {},
 			getProposal: () => context.proposal,
 			hasPrecommit: () => false,
 			hasPrevote: () => false,
 			hasProposal: () => false,
 			height: 2,
 			round: 0,
-			setProcessorResult: () => { },
+			setProcessorResult: () => {},
 		} as unknown as Contracts.Consensus.IRoundState;
 
 		context.verifier = {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -152,9 +152,11 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.scheduler.clear();
 
 		if (round === 0) {
-			// Remove persisted state, because new heigh is reached
+			// Remove persisted state, because new height is reached
 			await this.storage.clear();
+			this.roundStateRepository.clear();
 		}
+
 		await this.#saveState();
 
 		this.scheduler.scheduleTimeoutStartRound();

--- a/packages/consensus/source/round-state-repository.ts
+++ b/packages/consensus/source/round-state-repository.ts
@@ -20,6 +20,10 @@ export class RoundStateRepository implements Contracts.Consensus.IRoundStateRepo
 		return this.#roundStates.get(key)!;
 	}
 
+	public clear(): void {
+		this.#roundStates.clear();
+	}
+
 	#createRoundState(height: number, round: number): Contracts.Consensus.IRoundState {
 		return this.app.resolve(RoundState).configure(height, round);
 	}

--- a/packages/consensus/source/storage.ts
+++ b/packages/consensus/source/storage.ts
@@ -51,20 +51,19 @@ export class Storage implements Contracts.Consensus.IConsensusStorage {
 		await this.consensusStorage.put("consensus-state", data);
 	}
 
-	// TODO: Support multiple rounds
 	public async saveProposal(proposal: Contracts.Crypto.IProposal): Promise<void> {
 		const validatorPublicKey = this.validatorSet.getValidatorPublicKeyByIndex(proposal.validatorIndex);
-		await this.proposalStorage.put(validatorPublicKey, proposal.toData());
+		await this.proposalStorage.put(`${proposal.round}-${validatorPublicKey}`, proposal.toData());
 	}
 
 	public async savePrevote(prevote: Contracts.Crypto.IPrevote): Promise<void> {
 		const validatorPublicKey = this.validatorSet.getValidatorPublicKeyByIndex(prevote.validatorIndex);
-		await this.prevoteStorage.put(validatorPublicKey, prevote.toData());
+		await this.prevoteStorage.put(`${prevote.round}-${validatorPublicKey}`, prevote.toData());
 	}
 
 	public async savePrecommit(precommit: Contracts.Crypto.IPrecommit): Promise<void> {
 		const validatorPublicKey = this.validatorSet.getValidatorPublicKeyByIndex(precommit.validatorIndex);
-		await this.precommitStorage.put(validatorPublicKey, precommit.toData());
+		await this.precommitStorage.put(`${precommit.round}-${validatorPublicKey}`, precommit.toData());
 	}
 
 	public async getProposals(): Promise<Contracts.Crypto.IProposal[]> {

--- a/packages/contracts/source/contracts/consensus/consensus.ts
+++ b/packages/contracts/source/contracts/consensus/consensus.ts
@@ -59,6 +59,7 @@ export interface IConsensusStateData {
 
 export interface IRoundStateRepository {
 	getRoundState(height: number, round: number): IRoundState;
+	clear(): void;
 }
 
 export interface IConsensusService {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Support multiple messages per validator per height for different rounds to cover scenarios where network fragmentation may lead to a validator proposing multiple times per height.

Also fix a potential "memory leak" caused by the round state repository keeping old heights in memory.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
