### PR TITLE
fix(consenus): clean on commit

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -151,12 +151,6 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 		this.scheduler.clear();
 
-		if (round === 0) {
-			// Remove persisted state, because new height is reached
-			await this.storage.clear();
-			this.roundStateRepository.clear();
-		}
-
 		await this.#saveState();
 
 		this.scheduler.scheduleTimeoutStartRound();
@@ -324,6 +318,9 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.#height++;
 		this.#lockedValue = undefined;
 		this.#validValue = undefined;
+
+		this.roundStateRepository.clear();
+		await this.storage.clear();
 
 		await this.startRound(0);
 	}


### PR DESCRIPTION
## Summary

Clean roundStateRepository and storage only on commit instead when height is 0. This prevents unintended data loss, when bootstrapping round 0.  

## Checklist

- [x] Tests
- [x] Ready to be merged
