### PR TITLE
fix(consensus): rerun all roundStates on bootstrap & process block on handle

### DIFF
--- a/packages/consensus/source/committed-block-state.ts
+++ b/packages/consensus/source/committed-block-state.ts
@@ -50,8 +50,16 @@ export class CommittedBlockState implements Contracts.BlockProcessor.IProcessabl
 		this.#processorResult = processorResult;
 	}
 
+	public hasProcessorResult(): boolean {
+		return this.#processorResult !== undefined;
+	}
+
 	public getProcessorResult(): boolean {
-		return !!this.#processorResult;
+		if (this.#processorResult == undefined) {
+			throw new Error("Processor result is undefined.");
+		}
+
+		return this.#processorResult;
 	}
 
 	public async getProposedCommitBlock(): Promise<Contracts.Crypto.ICommittedBlock> {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -103,6 +103,10 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		await this.startRound(this.#round);
 
 		await this.handle(this.roundStateRepository.getRoundState(this.#height, this.#round));
+
+		for (let index = 0; index < this.#round; index++) {
+			await this.handle(this.roundStateRepository.getRoundState(this.#height, index));
+		}
 	}
 
 	async handle(roundState: Contracts.Consensus.IRoundState): Promise<void> {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -309,9 +309,12 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		const block = roundState.getBlock();
 
 		if (!roundState.getProcessorResult()) {
-			this.logger.info(`Block ${block.data.id} on height ${this.#height} received +2/3 precommit but is invalid`);
+			this.logger.info(
+				`Block ${block.data.id} on height ${this.#height} received +2/3 precommits but is invalid`,
+			);
 			return;
 		}
+
 		this.logger.info(`Received +2/3 precommits for ${this.#height}/${roundState.round} blockId: ${block.data.id}`);
 
 		await this.processor.commit(roundState);

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -104,6 +104,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 
 		await this.handle(this.roundStateRepository.getRoundState(this.#height, this.#round));
 
+		// Rerun previous rounds, in case proposal & +2/3 precommits were received
 		for (let index = 0; index < this.#round; index++) {
 			await this.handle(this.roundStateRepository.getRoundState(this.#height, index));
 		}

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -231,7 +231,8 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.#step = Contracts.Consensus.Step.Prevote;
 
 		const lockedRound = this.getLockedRound();
-		if (!lockedRound || (lockedRound <= proposal.validRound && roundState.getProcessorResult())) {
+
+		if ((!lockedRound || lockedRound <= proposal.validRound) && roundState.getProcessorResult()) {
 			await this.#prevote(block.data.id);
 		} else {
 			await this.#prevote();

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -310,14 +310,13 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		}
 
 		this.#didMajorityPrecommit = true;
-		// TODO: Check if block can be missing
 		const block = roundState.getBlock();
 
 		if (!roundState.getProcessorResult()) {
 			this.logger.info(`Block ${block.data.id} on height ${this.#height} received +2/3 precommit but is invalid`);
 			return;
 		}
-		this.logger.info(`Received +2/3 precommits for ${this.#height}/${this.#round} blockId: ${block.data.id}`);
+		this.logger.info(`Received +2/3 precommits for ${this.#height}/${roundState.round} blockId: ${block.data.id}`);
 
 		await this.processor.commit(roundState);
 

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -231,17 +231,11 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 		this.#step = Contracts.Consensus.Step.Prevote;
 
 		const lockedRound = this.getLockedRound();
-		if (!lockedRound || lockedRound <= proposal.validRound) {
-			const result = await this.processor.process(roundState);
-			roundState.setProcessorResult(result);
-
-			if (result) {
-				await this.#prevote(block.data.id);
-				return;
-			}
+		if (!lockedRound || (lockedRound <= proposal.validRound && roundState.getProcessorResult())) {
+			await this.#prevote(block.data.id);
+		} else {
+			await this.#prevote();
 		}
-
-		await this.#prevote();
 	}
 
 	protected async onMajorityPrevote(roundState: Contracts.Consensus.IRoundState): Promise<void> {

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -112,8 +112,16 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		this.#processorResult = processorResult;
 	}
 
+	public hasProcessorResult(): boolean {
+		return this.#processorResult !== undefined;
+	}
+
 	public getProcessorResult(): boolean {
-		return !!this.#processorResult;
+		if (this.#processorResult === undefined) {
+			throw new Error("Processor result is undefined.");
+		}
+
+		return this.#processorResult;
 	}
 
 	public hasPrevote(validatorIndex: number): boolean {

--- a/packages/contracts/source/contracts/block-processor.ts
+++ b/packages/contracts/source/contracts/block-processor.ts
@@ -5,6 +5,7 @@ export interface IProcessableUnit {
 	readonly height: number;
 	readonly round: number;
 	getWalletRepository(): WalletRepositoryClone;
+	hasProcessorResult(): boolean;
 	getProcessorResult(): boolean;
 	setProcessorResult(processorResult: boolean): void;
 	getBlock(): IBlock;


### PR DESCRIPTION
## Summary

Rerun all round states on bootstrap after the last one. There is a case where +2/3 precommits are received and that can be for the any round.  

Additionally block processor is called  from the handle method, so consensus methods always work with the checked block. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged