### PR TITLE
feat(consensus): implements `commit` lock

### DIFF
--- a/packages/consensus/source/consensus.test.ts
+++ b/packages/consensus/source/consensus.test.ts
@@ -1,5 +1,6 @@
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { describe, Sandbox } from "@mainsail/test-framework";
+import { Utils } from "@mainsail/kernel";
 
 import { Consensus } from "./consensus";
 
@@ -145,6 +146,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		context.sandbox.app.bind(Identifiers.Consensus.Bootstrapper).toConstantValue(context.bootstrapper);
 		context.sandbox.app.bind(Identifiers.Consensus.Scheduler).toConstantValue(context.scheduler);
 		context.sandbox.app.bind(Identifiers.Consensus.Storage).toConstantValue(context.storage);
+		context.sandbox.app.bind(Identifiers.Consensus.CommitLock).toConstantValue(new Utils.Lock());
 		+context.sandbox.app
 			.bind(Identifiers.Consensus.ValidatorRepository)
 			.toConstantValue(context.validatorsRepository);

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -53,6 +53,7 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	#didMajorityPrevote = false;
 	#didMajorityPrecommit = false;
 
+	// Handler lock is different than commit lock. It is used to prevent parallel processing and it is similar to queue.
 	readonly #handlerLock = new Utils.Lock();
 
 	public getHeight(): number {

--- a/packages/consensus/source/index.ts
+++ b/packages/consensus/source/index.ts
@@ -1,5 +1,5 @@
 import { Identifiers } from "@mainsail/contracts";
-import { Providers } from "@mainsail/kernel";
+import { Providers, Utils } from "@mainsail/kernel";
 import { RootDatabase } from "lmdb";
 
 import { Aggregator } from "./aggregator";
@@ -21,6 +21,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		this.app.bind(Identifiers.Consensus.PrecommitProcessor).to(PrecommitProcessor).inSingletonScope();
 		this.app.bind(Identifiers.Consensus.CommittedBlockProcessor).to(CommittedBlockProcessor).inSingletonScope();
 		this.app.bind(Identifiers.Consensus.ProposerPicker).to(ProposerPicker).inSingletonScope();
+		this.app.bind(Identifiers.Consensus.CommitLock).toConstantValue(new Utils.Lock());
 
 		// Storage for uncommitted blocks
 		const consensusStorage = this.app.get<RootDatabase>(Identifiers.Database.ConsensusStorage);

--- a/packages/consensus/source/processors/abstract-processor.ts
+++ b/packages/consensus/source/processors/abstract-processor.ts
@@ -6,6 +6,9 @@ export abstract class AbstractProcessor implements Contracts.Consensus.IProcesso
 	@inject(Identifiers.Application)
 	protected readonly app!: Contracts.Kernel.Application;
 
+	@inject(Identifiers.Consensus.CommitLock)
+	protected readonly commitLock!: Contracts.Kernel.ILock;
+
 	public abstract process(data: Buffer): Promise<Contracts.Consensus.ProcessorResult>;
 
 	protected hasValidHeightOrRound(message: { height: number; round: number }): boolean {

--- a/packages/contracts/source/contracts/kernel/index.ts
+++ b/packages/contracts/source/contracts/kernel/index.ts
@@ -4,6 +4,7 @@ export * from "./config";
 export * from "./container";
 export * from "./events";
 export * from "./filesystem";
+export * from "./lock";
 export * from "./log";
 export * from "./pipeline";
 export * from "./process-actions";

--- a/packages/contracts/source/contracts/kernel/lock.ts
+++ b/packages/contracts/source/contracts/kernel/lock.ts
@@ -1,0 +1,4 @@
+export interface ILock {
+	runExclusive<T>(callback: () => Promise<T>): Promise<T>;
+	runNonExclusive<T>(callback: () => Promise<T>): Promise<T>;
+}

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -21,6 +21,7 @@ export const Identifiers = {
 	Consensus: {
 		Aggregator: Symbol.for("Aggregator<Consensus>"),
 		Bootstrapper: Symbol.for("Bootstrapper<Consensus>"),
+		CommitLock: Symbol.for("CommitLock<Consensus>"),
 		CommittedBlockProcessor: Symbol.for("Consensus<CommittedBlock.Processor>"),
 		PrecommitProcessor: Symbol.for("Consensus<Precommit.Processor>"),
 		PrevoteProcessor: Symbol.for("Consensus<Prevote.Processor>"),

--- a/packages/kernel/source/utils/lock.ts
+++ b/packages/kernel/source/utils/lock.ts
@@ -1,4 +1,6 @@
-export class Lock {
+import { Contracts } from "@mainsail/contracts";
+
+export class Lock implements Contracts.Kernel.ILock {
 	#exclusivePromise?: Promise<unknown>;
 
 	readonly #nonExclusivePromises: Set<Promise<unknown>> = new Set<Promise<unknown>>();


### PR DESCRIPTION
## Summary

Commit lock is used by the message processors. It is there to ensure data consistency, meaning that processing should be atomic and executed between the commits. 

We must ensure that all commit changes are executed before we process, otherwise we can get into the situation when height is increased, but the validator set is not updated yet. This can lead to the invalid check in the processors. 

## Checklist

- [x] Ready to be merged

