### PR TITLE
fix(p2p): await response before accessing array item in verifier 

### DIFF
--- a/packages/p2p/source/peer-verifier.ts
+++ b/packages/p2p/source/peer-verifier.ts
@@ -88,7 +88,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
 		const blockToCompare =
 			block.data.height === heightToRequest
 				? block
-				: await this.database.findBlockByHeights([heightToRequest])[0];
+				: (await this.database.findBlockByHeights([heightToRequest]))[0];
 
 		if (receivedCommittedBlock.block.data.height !== blockToCompare.data.height) {
 			throw new Error("Received block does not match the requested height");


### PR DESCRIPTION
## Summary

Fix verifier. Await response before accessing array item.

## Checklist

- [x] Ready to be merged

