### PR TITLE
fix(consensus): ProposerPicker seed calculation 

### DIFF
--- a/packages/consensus/source/proposer-picker.ts
+++ b/packages/consensus/source/proposer-picker.ts
@@ -17,8 +17,7 @@ export class ProposerPicker implements Contracts.Consensus.IProposerPicker {
 
 		const height = committedBlock.block.data.height;
 		if (this.validatorIndexMatrix.length === 0 || height % activeValidators === 0) {
-			const roundHeight = height - (height % activeValidators) + 1;
-			this.#updateValidatorMatrix(activeValidators, roundHeight);
+			this.#updateValidatorMatrix(activeValidators);
 		}
 	}
 
@@ -30,8 +29,8 @@ export class ProposerPicker implements Contracts.Consensus.IProposerPicker {
 		return this.validatorIndexMatrix[offset % activeValidators];
 	}
 
-	#updateValidatorMatrix(activeValidators: number, height: number): void {
-		const seed = this.#calculateSeed(height);
+	#updateValidatorMatrix(activeValidators: number): void {
+		const seed = this.#calculateSeed();
 		const rng = seedrandom(seed);
 
 		const matrix = [...Array.from({ length: activeValidators }).keys()];
@@ -45,8 +44,8 @@ export class ProposerPicker implements Contracts.Consensus.IProposerPicker {
 		this.validatorIndexMatrix = matrix;
 	}
 
-	#calculateSeed(round: number): string {
-		const totalRound = this.#getTotalRound(round);
+	#calculateSeed(): string {
+		const totalRound = this.state.getLastCommittedRound();
 
 		// TODO: take block id into account
 
@@ -55,6 +54,7 @@ export class ProposerPicker implements Contracts.Consensus.IProposerPicker {
 
 	#getTotalRound(round: number): number {
 		const committedRound = this.state.getLastCommittedRound();
+
 		return committedRound + round;
 	}
 }

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -61,17 +61,17 @@ export class BlockProcessor implements Contracts.BlockProcessor.Processor {
 		const committedBlock = await unit.getProposedCommitBlock();
 		await this.databaseService.saveBlocks([committedBlock]);
 
+		const committedRound = this.state.getLastCommittedRound();
+		this.state.setLastCommittedRound(committedRound + unit.round + 1);
+
+		this.state.setLastBlock(committedBlock.block);
+
 		await this.validatorSet.onCommit(committedBlock);
 		await this.proposerPicker.onCommit(committedBlock);
 
 		if (this.apiSync) {
 			await this.apiSync.onCommit(committedBlock);
 		}
-
-		const committedRound = this.state.getLastCommittedRound();
-		this.state.setLastCommittedRound(committedRound + unit.round + 1);
-
-		this.state.setLastBlock(committedBlock.block);
 
 		this.logger.info(
 			`Block ${committedBlock.block.header.height.toLocaleString()} with ${committedBlock.block.header.numberOfTransactions.toLocaleString()} tx(s) committed`,

--- a/packages/state/source/stores/state.ts
+++ b/packages/state/source/stores/state.ts
@@ -24,7 +24,6 @@ export class StateStore implements Contracts.State.StateStore {
 	#genesisBlock?: Contracts.Crypto.ICommittedBlock;
 
 	// The last committed round
-	// Use -1 for genesis block. First round value is 0.
 	#committedRound = 0;
 
 	// Stores the last n blocks in ascending height. The amount of last blocks


### PR DESCRIPTION
## Summary

Don't use current round, but only last committed round to calculate seed.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

