### PR TITLE
refactor(logger): use `string` instead of `any`

### DIFF
--- a/packages/contracts/source/contracts/kernel/log.ts
+++ b/packages/contracts/source/contracts/kernel/log.ts
@@ -1,21 +1,21 @@
 export interface Logger {
 	make(options?: any): Promise<Logger>;
 
-	emergency(message: any): void;
+	emergency(message: string): void;
 
-	alert(message: any): void;
+	alert(message: string): void;
 
-	critical(message: any): void;
+	critical(message: string): void;
 
-	error(message: any): void;
+	error(message: string): void;
 
-	warning(message: any): void;
+	warning(message: string): void;
 
-	notice(message: any): void;
+	notice(message: string): void;
 
-	info(message: any): void;
+	info(message: string): void;
 
-	debug(message: any): void;
+	debug(message: string): void;
 
 	suppressConsoleOutput(suppress: boolean): void;
 

--- a/packages/kernel/source/application.ts
+++ b/packages/kernel/source/application.ts
@@ -189,7 +189,7 @@ export class Application implements Contracts.Kernel.Application {
 		}
 
 		if (error) {
-			this.get<Contracts.Kernel.Logger>(Identifiers.LogService).error(error.stack);
+			this.get<Contracts.Kernel.Logger>(Identifiers.LogService).error(error.stack ?? error.message);
 		}
 
 		await this.#disposeServiceProviders();

--- a/packages/kernel/source/services/log/drivers/memory.ts
+++ b/packages/kernel/source/services/log/drivers/memory.ts
@@ -67,7 +67,7 @@ export class MemoryLogger implements Contracts.Kernel.Logger {
 		this.#silentConsole = suppress;
 	}
 
-	public async dispose(): Promise<void> { }
+	public async dispose(): Promise<void> {}
 
 	#log(level: string, message: string): void {
 		if (this.#silentConsole) {

--- a/packages/kernel/source/services/log/drivers/memory.ts
+++ b/packages/kernel/source/services/log/drivers/memory.ts
@@ -31,35 +31,35 @@ export class MemoryLogger implements Contracts.Kernel.Logger {
 		return this;
 	}
 
-	public emergency(message: any): void {
+	public emergency(message: string): void {
 		this.#log("emergency", message);
 	}
 
-	public alert(message: any): void {
+	public alert(message: string): void {
 		this.#log("alert", message);
 	}
 
-	public critical(message: any): void {
+	public critical(message: string): void {
 		this.#log("critical", message);
 	}
 
-	public error(message: any): void {
+	public error(message: string): void {
 		this.#log("error", message);
 	}
 
-	public warning(message: any): void {
+	public warning(message: string): void {
 		this.#log("warning", message);
 	}
 
-	public notice(message: any): void {
+	public notice(message: string): void {
 		this.#log("notice", message);
 	}
 
-	public info(message: any): void {
+	public info(message: string): void {
 		this.#log("info", message);
 	}
 
-	public debug(message: any): void {
+	public debug(message: string): void {
 		this.#log("debug", message);
 	}
 
@@ -67,9 +67,9 @@ export class MemoryLogger implements Contracts.Kernel.Logger {
 		this.#silentConsole = suppress;
 	}
 
-	public async dispose(): Promise<void> {}
+	public async dispose(): Promise<void> { }
 
-	#log(level: any, message: any): void {
+	#log(level: string, message: string): void {
 		if (this.#silentConsole) {
 			return;
 		}

--- a/packages/logger-pino/source/driver.ts
+++ b/packages/logger-pino/source/driver.ts
@@ -188,7 +188,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
 							return callback(undefined, line.replace("USERLVL", formatLevel(json.level)));
 						}
 					}
-				} catch { }
+				} catch {}
 
 				return callback();
 			},

--- a/packages/logger-pino/source/driver.ts
+++ b/packages/logger-pino/source/driver.ts
@@ -97,35 +97,35 @@ export class PinoLogger implements Contracts.Kernel.Logger {
 		return this;
 	}
 
-	public emergency(message: any): void {
+	public emergency(message: string): void {
 		this.#log("emergency", message);
 	}
 
-	public alert(message: any): void {
+	public alert(message: string): void {
 		this.#log("alert", message);
 	}
 
-	public critical(message: any): void {
+	public critical(message: string): void {
 		this.#log("critical", message);
 	}
 
-	public error(message: any): void {
+	public error(message: string): void {
 		this.#log("error", message);
 	}
 
-	public warning(message: any): void {
+	public warning(message: string): void {
 		this.#log("warning", message);
 	}
 
-	public notice(message: any): void {
+	public notice(message: string): void {
 		this.#log("notice", message);
 	}
 
-	public info(message: any): void {
+	public info(message: string): void {
 		this.#log("info", message);
 	}
 
-	public debug(message: any): void {
+	public debug(message: string): void {
 		this.#log("debug", message);
 	}
 
@@ -150,7 +150,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
 		}
 	}
 
-	#log(level: string, message: any): void {
+	#log(level: string, message: string): void {
 		if (this.#silentConsole) {
 			return;
 		}
@@ -188,7 +188,7 @@ export class PinoLogger implements Contracts.Kernel.Logger {
 							return callback(undefined, line.replace("USERLVL", formatLevel(json.level)));
 						}
 					}
-				} catch {}
+				} catch { }
 
 				return callback();
 			},


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Use `string` instead of `any` in logger interface and class.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
