### PR TITLE
refactor(p2p): discover peers and ping ports when new peer is accepted 

### DIFF
--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -19,6 +19,9 @@ export class Bootstrapper {
 	@inject(Identifiers.TransactionPoolService)
 	private readonly transactionPool!: Contracts.TransactionPool.Service;
 
+	@inject(Identifiers.P2PServer)
+	private readonly p2pServer!: Contracts.P2P.Server;
+
 	@inject(Identifiers.P2P.Service)
 	private readonly p2pService!: Contracts.P2P.Service;
 
@@ -67,6 +70,7 @@ export class Bootstrapper {
 
 			void this.consensus.run();
 
+			await this.p2pServer.boot();
 			await this.p2pService.boot();
 		} catch (error) {
 			this.logger.error(error.stack);

--- a/packages/contracts/source/contracts/p2p/peer-discoverer.ts
+++ b/packages/contracts/source/contracts/p2p/peer-discoverer.ts
@@ -1,4 +1,7 @@
+import { Peer } from "./peer";
+
 export interface PeerDiscoverer {
-	discoverPeers(pingAll?: boolean): Promise<boolean>;
+	discoverPeers(): Promise<void>;
+	discoverPeersByPeer(peer: Peer): Promise<void>;
 	populateSeedPeers(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/peer-discoverer.ts
+++ b/packages/contracts/source/contracts/p2p/peer-discoverer.ts
@@ -1,7 +1,6 @@
 import { Peer } from "./peer";
 
 export interface PeerDiscoverer {
-	discoverPeers(): Promise<void>;
-	discoverPeersByPeer(peer: Peer): Promise<void>;
+	discoverPeers(peer: Peer): Promise<void>;
 	populateSeedPeers(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/p2p/server.ts
+++ b/packages/contracts/source/contracts/p2p/server.ts
@@ -1,5 +1,14 @@
-import Hapi from "@hapi/hapi";
+import { Request, ResponseToolkit, ServerInjectOptions, ServerInjectResponse, ServerRoute } from "@hapi/hapi";
 
 export interface Controller {
-	handle(request: Hapi.Request, h: Hapi.ResponseToolkit): Promise<any>;
+	handle(request: Request, h: ResponseToolkit): Promise<any>;
+}
+
+export interface Server {
+	initialize(name: string, optionsServer: { hostname: string; port: number }): Promise<void>;
+	boot(): Promise<void>;
+	dispose(): Promise<void>;
+	register(plugins: any | any[]): Promise<void>; // TODO: Add proper types
+	route(routes: ServerRoute | ServerRoute[]): Promise<void>;
+	inject(options: string | ServerInjectOptions): Promise<ServerInjectResponse>;
 }

--- a/packages/p2p/source/peer-discoverer.ts
+++ b/packages/p2p/source/peer-discoverer.ts
@@ -10,9 +10,6 @@ export class PeerDiscoverer implements Contracts.P2P.PeerDiscoverer {
 	@inject(Identifiers.PeerFactory)
 	private readonly peerFactory!: Contracts.P2P.PeerFactory;
 
-	@inject(Identifiers.PeerRepository)
-	private readonly repository!: Contracts.P2P.PeerRepository;
-
 	@inject(Identifiers.PeerCommunicator)
 	private readonly communicator!: Contracts.P2P.PeerCommunicator;
 
@@ -22,19 +19,7 @@ export class PeerDiscoverer implements Contracts.P2P.PeerDiscoverer {
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;
 
-	public async discoverPeers(pingAll?: boolean): Promise<void> {
-		await Promise.all(
-			Utils.shuffle(this.repository.getPeers())
-				.slice(0, 8)
-				.map(async (peer: Contracts.P2P.Peer) => {
-					await this.discoverPeersByPeer(peer);
-				}),
-		);
-
-		void this.#pingPeerPorts();
-	}
-
-	async discoverPeersByPeer(peer: Contracts.P2P.Peer): Promise<void> {
+	async discoverPeers(peer: Contracts.P2P.Peer): Promise<void> {
 		try {
 			const { peers } = await this.communicator.getPeers(peer);
 
@@ -100,16 +85,5 @@ export class PeerDiscoverer implements Contracts.P2P.PeerDiscoverer {
 		}
 
 		return [];
-	}
-
-	async #pingPeerPorts(pingAll?: boolean): Promise<void> {
-		let peers = this.repository.getPeers();
-		if (!pingAll) {
-			peers = Utils.shuffle(peers).slice(0, Math.floor(peers.length / 2));
-		}
-
-		this.logger.debug(`Checking ports of ${Utils.pluralize("peer", peers.length, true)}.`);
-
-		await Promise.all(peers.map((peer) => this.communicator.pingPorts(peer)));
 	}
 }

--- a/packages/p2p/source/peer-processor.ts
+++ b/packages/p2p/source/peer-processor.ts
@@ -23,6 +23,9 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
 	@inject(Identifiers.PeerDisposer)
 	private readonly peerDisposer!: Contracts.P2P.PeerDisposer;
 
+	@inject(Identifiers.PeerDiscoverer)
+	private readonly peerDiscoverer!: Contracts.P2P.PeerDiscoverer;
+
 	@inject(Identifiers.EventDispatcherService)
 	private readonly events!: Contracts.Kernel.EventDispatcher;
 
@@ -96,6 +99,8 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
 			this.logger.debugExtra(`Accepted new peer ${peer.ip}:${peer.port} (v${peer.version})`);
 
 			void this.events.dispatch(Enums.PeerEvent.Added, peer);
+
+			await this.peerDiscoverer.discoverPeers(peer);
 		}
 
 		this.repository.forgetPendingPeer(peer);

--- a/packages/p2p/source/peer-processor.ts
+++ b/packages/p2p/source/peer-processor.ts
@@ -23,6 +23,9 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
 	@inject(Identifiers.PeerDisposer)
 	private readonly peerDisposer!: Contracts.P2P.PeerDisposer;
 
+	@inject(Identifiers.PeerCommunicator)
+	private readonly peerCommunicator!: Contracts.P2P.PeerCommunicator;
+
 	@inject(Identifiers.PeerDiscoverer)
 	private readonly peerDiscoverer!: Contracts.P2P.PeerDiscoverer;
 
@@ -99,6 +102,8 @@ export class PeerProcessor implements Contracts.P2P.PeerProcessor {
 			this.logger.debugExtra(`Accepted new peer ${peer.ip}:${peer.port} (v${peer.version})`);
 
 			void this.events.dispatch(Enums.PeerEvent.Added, peer);
+
+			await this.peerCommunicator.pingPorts(peer);
 
 			await this.peerDiscoverer.discoverPeers(peer);
 		}

--- a/packages/p2p/source/service-provider.test.ts
+++ b/packages/p2p/source/service-provider.test.ts
@@ -28,20 +28,7 @@ describe<{
 		await assert.resolves(() => serviceProvider.register());
 	});
 
-	it("#bootWhen - should return false when process.env.DISABLE_P2P_SERVER", async ({ serviceProvider }) => {
-		process.env.DISABLE_P2P_SERVER = "true";
-		assert.false(await serviceProvider.bootWhen());
-
-		delete process.env.DISABLE_P2P_SERVER;
-	});
-
-	it("#bootWhen - should return true when !process.env.DISABLE_P2P_SERVER", async ({ serviceProvider }) => {
-		assert.true(await serviceProvider.bootWhen());
-	});
-
-	it("#boot - should call the server boot method", async ({ sandbox, serviceProvider }) => {
-		const peerEventListener = { initialize: () => {} };
-
+	it("#boot - should call the server initialize", async ({ sandbox, serviceProvider }) => {
 		const spyServerInitialize = stub(server, "initialize");
 		const spyServerBoot = stub(server, "boot");
 
@@ -53,34 +40,16 @@ describe<{
 		await serviceProvider.boot();
 
 		spyServerInitialize.calledOnce();
-		spyServerBoot.calledOnce();
+		spyServerBoot.neverCalled();
 	});
 
-	it("#dispose - should call the server dispose method when process.env.DISABLE_P2P_SERVER is undefined", async ({
-		sandbox,
-		serviceProvider,
-	}) => {
+	it("#dispose - should call the server dispose", async ({ sandbox, serviceProvider }) => {
 		const spyServerDispose = stub(server, "dispose");
 		sandbox.app.bind(Identifiers.P2PServer).toConstantValue(server);
 
 		await serviceProvider.dispose();
 
 		spyServerDispose.calledOnce();
-	});
-
-	it("#dispose - should not call the server dispose method when process.env.DISABLE_P2P_SERVER = true", async ({
-		sandbox,
-		serviceProvider,
-	}) => {
-		const spyServerDispose = stub(server, "dispose");
-		sandbox.app.bind(Identifiers.P2PServer).toConstantValue(server);
-
-		process.env.DISABLE_P2P_SERVER = "true";
-		await serviceProvider.dispose();
-
-		spyServerDispose.neverCalled();
-
-		delete process.env.DISABLE_P2P_SERVER; // reset to initial undefined value
 	});
 
 	it("#required - should return true", async ({ serviceProvider }) => {

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { Constants, Contracts, Identifiers } from "@mainsail/contracts";
+import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers, Services, Utils } from "@mainsail/kernel";
 import Joi from "joi";
 
@@ -35,20 +35,12 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		this.#registerActions();
 	}
 
-	public async bootWhen(): Promise<boolean> {
-		return !process.env[Constants.Flags.DISABLE_P2P_SERVER];
-	}
-
 	public async boot(): Promise<void> {
 		await this.#buildServer();
-
-		await this.app.get<Server>(Identifiers.P2PServer).boot();
 	}
 
 	public async dispose(): Promise<void> {
-		if (!process.env[Constants.Flags.DISABLE_P2P_SERVER]) {
-			await this.app.get<Server>(Identifiers.P2PServer).dispose();
-		}
+		await this.app.get<Contracts.P2P.Server>(Identifiers.P2PServer).dispose();
 	}
 
 	public async required(): Promise<boolean> {
@@ -140,7 +132,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 	}
 
 	async #buildServer(): Promise<void> {
-		const server: Server = this.app.get<Server>(Identifiers.P2PServer);
+		const server = this.app.get<Contracts.P2P.Server>(Identifiers.P2PServer);
 		const serverConfig = this.config().getRequired<{ hostname: string; port: number }>("server");
 		Utils.assert.defined(serverConfig);
 

--- a/packages/p2p/source/service.ts
+++ b/packages/p2p/source/service.ts
@@ -38,7 +38,7 @@ export class Service implements Contracts.P2P.Service {
 		}
 
 		await this.peerDiscoverer.populateSeedPeers();
-		await this.peerDiscoverer.discoverPeers(true);
+		await this.peerDiscoverer.discoverPeers();
 
 		for (const [version, peers] of Object.entries(
 			Utils.groupBy(this.repository.getPeers(), (peer) => peer.version),
@@ -69,7 +69,7 @@ export class Service implements Contracts.P2P.Service {
 			this.logger.info(`Couldn't find enough peers. Falling back to seed peers.`);
 
 			await this.peerDiscoverer.populateSeedPeers();
-			await this.peerDiscoverer.discoverPeers(true);
+			await this.peerDiscoverer.discoverPeers();
 		}
 	}
 

--- a/packages/p2p/source/service.ts
+++ b/packages/p2p/source/service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Constants, Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers, Utils } from "@mainsail/kernel";
+import { shuffle } from "@mainsail/utils";
 import dayjs from "dayjs";
 import delay from "delay";
 
@@ -68,6 +69,10 @@ export class Service implements Contracts.P2P.Service {
 			this.logger.info(`Couldn't find enough peers. Falling back to seed peers.`);
 
 			await this.peerDiscoverer.populateSeedPeers();
+
+			for (const peer of shuffle(this.repository.getPeers()).slice(0, 8)) {
+				await this.peerDiscoverer.discoverPeers(peer);
+			}
 		}
 	}
 

--- a/packages/p2p/source/service.ts
+++ b/packages/p2p/source/service.ts
@@ -38,7 +38,6 @@ export class Service implements Contracts.P2P.Service {
 		}
 
 		await this.peerDiscoverer.populateSeedPeers();
-		await this.peerDiscoverer.discoverPeers();
 
 		for (const [version, peers] of Object.entries(
 			Utils.groupBy(this.repository.getPeers(), (peer) => peer.version),
@@ -69,7 +68,6 @@ export class Service implements Contracts.P2P.Service {
 			this.logger.info(`Couldn't find enough peers. Falling back to seed peers.`);
 
 			await this.peerDiscoverer.populateSeedPeers();
-			await this.peerDiscoverer.discoverPeers();
 		}
 	}
 

--- a/packages/p2p/source/socket-server/server.ts
+++ b/packages/p2p/source/socket-server/server.ts
@@ -25,7 +25,7 @@ import {
 
 // todo: review the implementation
 @injectable()
-export class Server {
+export class Server implements Contracts.P2P.Server {
 	@inject(Identifiers.Application)
 	private readonly app!: Contracts.Kernel.Application;
 


### PR DESCRIPTION
## Summary

Refactor PeerDiscoverer. Boot p2p server after the bootstrap process. Move peer discovery and ping peer ports into PeerProcessor.

## Checklist

- [x] Ready to be merged

