### PR TITLE
fix(core): make `token` / `network` command flags required

### DIFF
--- a/packages/core/source/commands/core-log.ts
+++ b/packages/core/source/commands/core-log.ts
@@ -10,7 +10,7 @@ export class Command extends Commands.Command {
 
 	public configure(): void {
 		this.definition
-			.setFlag("token", "The name of the token.", Joi.string())
+			.setFlag("token", "The name of the token.", Joi.string().required())
 			.setFlag("error", "Only display the error output.", Joi.boolean())
 			.setFlag("lines", "The number of lines to output.", Joi.number().default(15));
 	}

--- a/packages/core/source/commands/core-restart.test.ts
+++ b/packages/core/source/commands/core-restart.test.ts
@@ -16,7 +16,8 @@ describe<{
 		const missing = stub(processManager, "missing").returnValue(true);
 		const isStopped = stub(processManager, "isStopped").returnValue(false);
 
-		await assert.rejects(() => cli.execute(Command), 'The "ark-core" process does not exist.');
+		cli.flags = { network: "testnet", token: "arkdoesnotexist" };
+		await assert.rejects(() => cli.execute(Command), 'The "arkdoesnotexist-core" process does not exist.');
 	});
 
 	it("should throw if the process is stopped", async ({ processManager, cli }) => {

--- a/packages/core/source/commands/core-restart.ts
+++ b/packages/core/source/commands/core-restart.ts
@@ -9,7 +9,7 @@ export class Command extends Commands.Command {
 	public description = "Restart the Core process.";
 
 	public configure(): void {
-		this.definition.setFlag("token", "The name of the token.", Joi.string());
+		this.definition.setFlag("token", "The name of the token.", Joi.string().required());
 	}
 
 	public async execute(): Promise<void> {

--- a/packages/core/source/commands/core-run.ts
+++ b/packages/core/source/commands/core-run.ts
@@ -10,8 +10,8 @@ export class Command extends Commands.Command {
 
 	public configure(): void {
 		this.definition
-			.setFlag("token", "The name of the token.", Joi.string())
-			.setFlag("network", "The name of the network.", Joi.string())
+			.setFlag("token", "The name of the token.", Joi.string().required())
+			.setFlag("network", "The name of the network.", Joi.string().required())
 			.setFlag("env", "", Joi.string().default("production"))
 			.setFlag("disableDiscovery", "Permanently disable all peer discovery.", Joi.boolean())
 			.setFlag("skipDiscovery", "Skip the initial peer discovery.", Joi.boolean())

--- a/packages/core/source/commands/core-start.ts
+++ b/packages/core/source/commands/core-start.ts
@@ -11,8 +11,8 @@ export class Command extends Commands.Command {
 
 	public configure(): void {
 		this.definition
-			.setFlag("token", "The name of the token.", Joi.string())
-			.setFlag("network", "The name of the network.", Joi.string())
+			.setFlag("token", "The name of the token.", Joi.string().required())
+			.setFlag("network", "The name of the network.", Joi.string().required())
 			.setFlag("env", "", Joi.string().default("production"))
 			.setFlag("disableDiscovery", "Permanently disable all peer discovery.", Joi.boolean())
 			.setFlag("skipDiscovery", "Skip the initial peer discovery.", Joi.boolean())

--- a/packages/core/source/commands/core-status.test.ts
+++ b/packages/core/source/commands/core-status.test.ts
@@ -13,7 +13,8 @@ describe<{
 	});
 
 	it("should throw if the process does not exist", async ({ cli }) => {
-		await assert.rejects(() => cli.execute(Command), 'The "ark-core" process does not exist.');
+		cli.flags = { network: "testnet", token: "arkdoesnotexist" };
+		await assert.rejects(() => cli.execute(Command), 'The "arkdoesnotexist-core" process does not exist.');
 	});
 
 	it("should render a table with the process information", async ({ processManager, cli }) => {

--- a/packages/core/source/commands/core-status.ts
+++ b/packages/core/source/commands/core-status.ts
@@ -9,7 +9,7 @@ export class Command extends Commands.Command {
 	public description = "Display the status of the Core process.";
 
 	public configure(): void {
-		this.definition.setFlag("token", "The name of the token.", Joi.string());
+		this.definition.setFlag("token", "The name of the token.", Joi.string().required());
 	}
 
 	public async execute(): Promise<void> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Technically, `token` and `network` are required for all `core:*` commands, however the schema didn't enforce it which produced weird error messages when either was absent.

Before:
```shell
pnpm run mainsail core:run

[ERROR] Expected string, got undefined
 ELIFECYCLE  Command failed with exit code 1.
```

After:
```shell
pnpm run mainsail core:run

[ERROR] "token" is required
 ELIFECYCLE  Command failed with exit code 1.
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
