### PR TITLE
fix(api-database): make transaction recipientId nullable

### DIFF
--- a/packages/api-database/source/models/transaction.ts
+++ b/packages/api-database/source/models/transaction.ts
@@ -73,8 +73,10 @@ export class Transaction {
 
 	@Column({
 		default: undefined,
+		nullable: true,
+		type: "varchar",
 	})
-	public recipientId!: string;
+	public recipientId!: string | undefined;
 
 	@Column({
 		default: undefined,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Some transactions don't have a `recipientId` (e.g. validator registrations) and fail to insert. We can consider changing this in the future.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
