### PR TITLE
refactor(state): improve wallet indexing 

### DIFF
--- a/packages/contracts/source/contracts/state/wallets.ts
+++ b/packages/contracts/source/contracts/state/wallets.ts
@@ -132,8 +132,6 @@ export interface WalletRepository {
 }
 
 export interface WalletRepositoryClone extends WalletRepository {
-	reset(): void;
-
 	getDirtyWallets(): ReadonlyArray<Wallet>;
 	commitChanges(): void;
 }

--- a/packages/contracts/source/contracts/state/wallets.ts
+++ b/packages/contracts/source/contracts/state/wallets.ts
@@ -70,7 +70,7 @@ export interface Wallet {
 
 	getOriginal(): Wallet;
 
-	applyChanges(): void;
+	commitChanges(): void;
 }
 
 export interface IValidatorWallet {

--- a/packages/contracts/source/contracts/state/wallets.ts
+++ b/packages/contracts/source/contracts/state/wallets.ts
@@ -9,11 +9,9 @@ export interface WalletIndex {
 	get(key: string): Wallet | undefined;
 	set(key: string, wallet: Wallet): void;
 	forget(key: string): void;
-	forgetWallet(wallet: Wallet): void;
 	entries(): ReadonlyArray<[string, Wallet]>;
 	values(): ReadonlyArray<Wallet>;
 	keys(): string[];
-	walletKeys(wallet: Wallet): string[];
 	clear(): void;
 }
 

--- a/packages/state/source/wallets/wallet-index.test.ts
+++ b/packages/state/source/wallets/wallet-index.test.ts
@@ -37,14 +37,6 @@ describe<{
 		assert.true(context.walletIndex.keys().includes(context.wallet.getAddress()));
 	});
 
-	it("should return walletKeys", (context) => {
-		assert.equal(context.walletIndex.walletKeys(context.wallet), []);
-
-		context.walletIndex.set(context.wallet.getAddress(), context.wallet);
-
-		assert.equal(context.walletIndex.walletKeys(context.wallet), [context.wallet.getAddress()]);
-	});
-
 	it("set - should set and get addresses", (context) => {
 		assert.false(context.walletIndex.has(context.wallet.getAddress()));
 
@@ -84,17 +76,5 @@ describe<{
 
 	it("forget - should not throw if key is not indexed", (context) => {
 		context.walletIndex.forget(context.wallet.getAddress());
-	});
-
-	it("forgetWallet - should forget wallet", (context) => {
-		context.walletIndex.set(context.wallet.getAddress(), context.wallet);
-		assert.equal(context.walletIndex.get(context.wallet.getAddress()), context.wallet);
-
-		context.walletIndex.forgetWallet(context.wallet);
-		assert.false(context.walletIndex.has(context.wallet.getAddress()));
-	});
-
-	it("forgetWallet - should not throw if wallet is not indexed", (context) => {
-		context.walletIndex.forgetWallet(context.wallet);
 	});
 });

--- a/packages/state/source/wallets/wallet-index.ts
+++ b/packages/state/source/wallets/wallet-index.ts
@@ -3,11 +3,9 @@ import { Utils } from "@mainsail/kernel";
 
 export class WalletIndex implements Contracts.State.WalletIndex {
 	#walletByKey: Map<string, Contracts.State.Wallet>;
-	#keysByWallet: Map<Contracts.State.Wallet, Set<string>>;
 
 	public constructor() {
 		this.#walletByKey = new Map();
-		this.#keysByWallet = new Map();
 	}
 
 	public entries(): ReadonlyArray<[string, Contracts.State.Wallet]> {
@@ -16,12 +14,6 @@ export class WalletIndex implements Contracts.State.WalletIndex {
 
 	public keys(): string[] {
 		return [...this.#walletByKey.keys()];
-	}
-
-	public walletKeys(walletHolder: Contracts.State.Wallet): string[] {
-		const walletKeys = this.#keysByWallet.get(walletHolder);
-
-		return walletKeys ? [...walletKeys.keys()] : [];
 	}
 
 	public values(): ReadonlyArray<Contracts.State.Wallet> {
@@ -40,53 +32,14 @@ export class WalletIndex implements Contracts.State.WalletIndex {
 	}
 
 	public set(key: string, walletHolder: Contracts.State.Wallet): void {
-		const existingWallet = this.#walletByKey.get(key)!;
-
-		// Remove given key in case where key points to different wallet
-		if (existingWallet) {
-			const existingKeys = this.#keysByWallet.get(existingWallet)!;
-			existingKeys.delete(key);
-		}
-
 		this.#walletByKey.set(key, walletHolder);
-
-		if (this.#keysByWallet.has(walletHolder)) {
-			const existingKeys = this.#keysByWallet.get(walletHolder)!;
-			existingKeys.add(key);
-		} else {
-			const keys: Set<string> = new Set();
-			keys.add(key);
-
-			this.#keysByWallet.set(walletHolder, keys);
-		}
 	}
 
 	public forget(key: string): void {
-		const wallet = this.#walletByKey.get(key)!;
-
-		if (wallet) {
-			const existingKeys = this.#keysByWallet.get(wallet)!;
-
-			existingKeys.delete(key);
-
-			this.#walletByKey.delete(key);
-		}
-	}
-
-	public forgetWallet(wallet: Contracts.State.Wallet): void {
-		const keys = this.#keysByWallet.get(wallet)!;
-
-		if (keys) {
-			for (const key of keys) {
-				this.#walletByKey.delete(key);
-			}
-
-			this.#keysByWallet.delete(wallet);
-		}
+		this.#walletByKey.delete(key);
 	}
 
 	public clear(): void {
 		this.#walletByKey = new Map();
-		this.#keysByWallet = new Map();
 	}
 }

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -31,8 +31,8 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 		}
 
 		if (this.originalWalletRepository.hasByAddress(address)) {
-			const walletToClone = this.originalWalletRepository.findByAddress(address);
-			return this.cloneWallet(this.originalWalletRepository, walletToClone);
+			const clone = this.originalWalletRepository.findByAddress(address).clone();
+			this.getIndex(Contracts.State.WalletIndexes.Addresses).set(address, clone);
 		}
 
 		return this.findOrCreate(address);
@@ -53,8 +53,9 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 			return this.getIndex(index).get(key)!;
 		}
 
-		const walletToClone = this.originalWalletRepository.findByIndex(index, key);
-		return this.cloneWallet(this.originalWalletRepository, walletToClone);
+		const clone = this.originalWalletRepository.findByIndex(index, key).clone();
+		this.getIndex(Contracts.State.WalletIndexes.Addresses).set(clone.getAddress(), clone);
+		return clone;
 	}
 
 	public hasByIndex(indexName: string, key: string): boolean {

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -85,7 +85,7 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 	public commitChanges(): void {
 		// Merge clones to originals
 		for (const wallet of this.getDirtyWallets()) {
-			wallet.applyChanges();
+			wallet.commitChanges();
 		}
 
 		for (const indexName of this.indexSet.all()) {

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -76,13 +76,6 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 		}
 	}
 
-	public reset(): void {
-		super.reset();
-		for (const walletIndex of Object.values(this.#forgetIndexes)) {
-			walletIndex.clear();
-		}
-	}
-
 	public getDirtyWallets(): ReadonlyArray<Contracts.State.Wallet> {
 		return this.getIndex(Contracts.State.WalletIndexes.Addresses)
 			.values()

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -88,22 +88,19 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 			wallet.applyChanges();
 		}
 
-		// Update indexes
 		for (const indexName of this.indexSet.all()) {
-			const localIndex = this.getIndex(indexName);
-			const originalIndex = this.originalWalletRepository.getIndex(indexName);
-
-			for (const [key, wallet] of localIndex.entries()) {
-				originalIndex.set(key, wallet.isClone() ? wallet.getOriginal() : wallet);
+			// Update indexes
+			for (const [key, wallet] of this.getIndex(indexName).entries()) {
+				this.originalWalletRepository.setOnIndex(
+					indexName,
+					key,
+					wallet.isClone() ? wallet.getOriginal() : wallet,
+				);
 			}
-		}
 
-		// Remove from forget indexes
-		for (const indexName of this.indexSet.all()) {
-			const originalIndex = this.originalWalletRepository.getIndex(indexName);
-
+			// Remove from forget indexes
 			for (const key of this.#getForgetSet(indexName).values()) {
-				originalIndex.forget(key);
+				this.originalWalletRepository.forgetOnIndex(indexName, key);
 			}
 		}
 	}

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -64,6 +64,11 @@ export class WalletRepositoryClone extends WalletRepository implements Contracts
 		);
 	}
 
+	public setOnIndex(index: string, key: string, wallet: Contracts.State.Wallet): void {
+		this.getIndex(index).set(key, wallet);
+		this.#getForgetSet(index).delete(key);
+	}
+
 	public forgetOnIndex(index: string, key: string): void {
 		if (this.getIndex(index).has(key) || this.originalWalletRepository.getIndex(index).has(key)) {
 			this.getIndex(index).forget(key);

--- a/packages/state/source/wallets/wallet-repository-copy-on-write.ts
+++ b/packages/state/source/wallets/wallet-repository-copy-on-write.ts
@@ -59,7 +59,7 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
 
 	#cloneWallet(address: string): Contracts.State.Wallet {
 		const clone = this.blockchainWalletRepository.findByAddress(address).clone();
-		this.getIndex(Contracts.State.WalletIndexes.Addresses).set(clone.getAddress(), clone);
+		this.getIndex(Contracts.State.WalletIndexes.Addresses).set(address, clone);
 		return clone;
 	}
 }

--- a/packages/state/source/wallets/wallet-repository-copy-on-write.ts
+++ b/packages/state/source/wallets/wallet-repository-copy-on-write.ts
@@ -14,20 +14,27 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
 	private readonly blockchainWalletRepository!: WalletRepository;
 
 	public async findByPublicKey(publicKey: string): Promise<Contracts.State.Wallet> {
-		if (publicKey && !this.hasByPublicKey(publicKey)) {
-			this.cloneWallet(
-				this.blockchainWalletRepository,
-				await this.blockchainWalletRepository.findByPublicKey(publicKey),
-			);
+		if (super.hasByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey)) {
+			return super.findByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey);
 		}
-		return this.findByIndex(Contracts.State.WalletIndexes.PublicKeys, publicKey)!;
+
+		const wallet = this.findByAddress(await this.addressFactory.fromPublicKey(publicKey));
+		wallet.setPublicKey(publicKey);
+		this.getIndex(Contracts.State.WalletIndexes.PublicKeys).set(publicKey, wallet);
+
+		return wallet;
 	}
 
 	public findByAddress(address: string): Contracts.State.Wallet {
-		if (address && !this.hasByAddress(address)) {
-			this.cloneWallet(this.blockchainWalletRepository, this.blockchainWalletRepository.findByAddress(address));
+		if (this.hasByAddress(address)) {
+			return super.findByAddress(address);
 		}
-		return this.findByIndex(Contracts.State.WalletIndexes.Addresses, address)!;
+
+		if (this.blockchainWalletRepository.hasByAddress(address)) {
+			return this.#cloneWallet(address);
+		}
+
+		return this.findOrCreate(address);
 	}
 
 	public hasByIndex(index: string, key: string): boolean {
@@ -38,16 +45,21 @@ export class WalletRepositoryCopyOnWrite extends WalletRepository {
 			return false;
 		}
 
-		this.cloneWallet(this.blockchainWalletRepository, this.blockchainWalletRepository.findByIndex(index, key));
 		return true;
 	}
 
 	public allByUsername(): ReadonlyArray<Contracts.State.Wallet> {
 		for (const wallet of this.blockchainWalletRepository.allByUsername()) {
 			if (!super.hasByAddress(wallet.getAddress())) {
-				this.cloneWallet(this.blockchainWalletRepository, wallet);
+				this.#cloneWallet(wallet.getAddress());
 			}
 		}
 		return super.allByUsername();
+	}
+
+	#cloneWallet(address: string): Contracts.State.Wallet {
+		const clone = this.blockchainWalletRepository.findByAddress(address).clone();
+		this.getIndex(Contracts.State.WalletIndexes.Addresses).set(clone.getAddress(), clone);
+		return clone;
 	}
 }

--- a/packages/state/source/wallets/wallet-repository.test.ts
+++ b/packages/state/source/wallets/wallet-repository.test.ts
@@ -6,19 +6,11 @@ import { Wallet, WalletIndex, WalletRepository } from ".";
 
 describe<{
 	walletRepo: WalletRepository;
-}>("Wallet Repository", ({ it, assert, afterEach, beforeAll }) => {
-	beforeAll(async (context) => {
+}>("Wallet Repository", ({ it, assert, afterEach, beforeEach }) => {
+	beforeEach(async (context) => {
 		const environment = await setUp();
 
 		context.walletRepo = environment.sandbox.app.getTagged(Identifiers.WalletRepository, "state", "blockchain");
-	});
-
-	afterEach((context) => {
-		context.walletRepo.reset();
-	});
-
-	it("#initialize - should throw if indexers are already registered", ({ walletRepo }) => {
-		assert.throws(() => walletRepo.initialize(), "The wallet index is already registered: addresses");
 	});
 
 	it("#findByAddress - should create a wallet", ({ walletRepo }) => {
@@ -59,7 +51,7 @@ describe<{
 		assert.instance(walletRepo.findByAddress("iDontExist"), Wallet);
 		assert.true(walletRepo.hasByAddress("iDontExist"));
 
-		const errorMessage = "Wallet iAlsoDontExist doesn't exist in index addresses";
+		const errorMessage = "Wallet iAlsoDontExist doesn't exist on index addresses";
 		assert.throws(() => walletRepo.findByIndex("addresses", "iAlsoDontExist"), errorMessage);
 	});
 
@@ -109,12 +101,12 @@ describe<{
 	it("should throw when looking up a username which doesn't exist", ({ walletRepo }) => {
 		assert.throws(
 			() => walletRepo.findByUsername("iDontExist"),
-			"Wallet iDontExist doesn't exist in index usernames",
+			"Wallet iDontExist doesn't exist on index usernames",
 		);
 
 		assert.throws(
 			() => walletRepo.findByIndex("usernames", "iDontExist"),
-			"Wallet iDontExist doesn't exist in index usernames",
+			"Wallet iDontExist doesn't exist on index usernames",
 		);
 	});
 

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -70,7 +70,7 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 
 	public findByIndex(index: string, key: string): Contracts.State.Wallet {
 		if (!this.hasByIndex(index, key)) {
-			throw new Error(`Wallet ${key} doesn't exist in index ${index}`);
+			throw new Error(`Wallet ${key} doesn't exist on index ${index}`);
 		}
 		return this.getIndex(index).get(key)!;
 	}

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -106,18 +106,17 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 	}
 
 	protected cloneWallet(origin: WalletRepository, wallet: Contracts.State.Wallet): Contracts.State.Wallet {
-		const walletClone = wallet.clone();
+		return wallet.clone();
 
-		for (const indexName of origin.indexSet.all()) {
-			const walletKeys = origin.getIndex(indexName).walletKeys(wallet);
+		// TODO: Clone indexes
+		// for (const indexName of origin.indexSet.all()) {
+		// 	const walletKeys = origin.getIndex(indexName).walletKeys(wallet);
 
-			const index = this.getIndex(indexName);
-			for (const key of walletKeys) {
-				index.set(key, walletClone);
-			}
-		}
-
-		return walletClone;
+		// 	const index = this.getIndex(indexName);
+		// 	for (const key of walletKeys) {
+		// 		index.set(key, walletClone);
+		// 	}
+		// }
 	}
 
 	protected findOrCreate(address: string): Contracts.State.Wallet {

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -99,10 +99,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 		this.getIndex(index).forget(key);
 	}
 
-	protected cloneWallet(origin: WalletRepository, wallet: Contracts.State.Wallet): Contracts.State.Wallet {
-		return wallet.clone();
-	}
-
 	protected findOrCreate(address: string): Contracts.State.Wallet {
 		const index = this.getIndex(Contracts.State.WalletIndexes.Addresses);
 		if (!index.has(address)) {

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -99,12 +99,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 		this.getIndex(index).forget(key);
 	}
 
-	public reset(): void {
-		for (const walletIndex of Object.values(this.indexes)) {
-			walletIndex.clear();
-		}
-	}
-
 	protected cloneWallet(origin: WalletRepository, wallet: Contracts.State.Wallet): Contracts.State.Wallet {
 		return wallet.clone();
 

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -56,7 +56,7 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 
 	public async findByPublicKey(publicKey: string): Promise<Contracts.State.Wallet> {
 		const index = this.getIndex(Contracts.State.WalletIndexes.PublicKeys);
-		if (publicKey && !index.has(publicKey)) {
+		if (!index.has(publicKey)) {
 			const wallet = this.findOrCreate(await this.addressFactory.fromPublicKey(publicKey));
 			wallet.setPublicKey(publicKey);
 			index.set(publicKey, wallet);

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -3,7 +3,6 @@ import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
 
 import { WalletIndex } from "./wallet-index";
 
-// @TODO review the implementation
 @injectable()
 export class WalletRepository implements Contracts.State.WalletRepository {
 	@inject(Identifiers.WalletRepositoryIndexSet)
@@ -20,9 +19,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 	@postConstruct()
 	public initialize(): void {
 		for (const name of this.indexSet.all()) {
-			if (this.indexes[name]) {
-				throw new Exceptions.WalletIndexAlreadyRegisteredError(name);
-			}
 			this.indexes[name] = new WalletIndex();
 		}
 	}

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -101,16 +101,6 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 
 	protected cloneWallet(origin: WalletRepository, wallet: Contracts.State.Wallet): Contracts.State.Wallet {
 		return wallet.clone();
-
-		// TODO: Clone indexes
-		// for (const indexName of origin.indexSet.all()) {
-		// 	const walletKeys = origin.getIndex(indexName).walletKeys(wallet);
-
-		// 	const index = this.getIndex(indexName);
-		// 	for (const key of walletKeys) {
-		// 		index.set(key, walletClone);
-		// 	}
-		// }
 	}
 
 	protected findOrCreate(address: string): Contracts.State.Wallet {

--- a/packages/state/source/wallets/wallet.ts
+++ b/packages/state/source/wallets/wallet.ts
@@ -199,7 +199,7 @@ export class Wallet implements Contracts.State.Wallet {
 		throw new Error("This is not a clone wallet");
 	}
 
-	public applyChanges(): void {
+	public commitChanges(): void {
 		if (this.originalWallet) {
 			for (const attributeName of this.#forgetAttributes) {
 				this.originalWallet.forgetAttribute(attributeName);


### PR DESCRIPTION
## Summary

Don't clone all the indexes on wallet clone. Only difference between original index and clone index are calculated. If wallet by index exists only on original wallet repository then wallet is cloned and set to the address index. Only new sets and forgets on indexes are stored. 

Indexes are now KV (key-value) objects and doesn't store keysByWallet attributes anymore.
ForgetWallet and reset methods are removed. 

## Checklist

- [x] Ready to be merged
