### PR TITLE
fix(p2p): disconnect peer even if it is not in repository

### DIFF
--- a/packages/contracts/source/contracts/p2p/peer-connector.ts
+++ b/packages/contracts/source/contracts/p2p/peer-connector.ts
@@ -3,8 +3,7 @@ import { Peer } from "./peer";
 
 export interface PeerConnector {
 	connect(peer: Peer): Promise<Client>;
-
-	disconnect(peer: Peer): Promise<void>;
+	disconnect(ip: string): Promise<void>;
 
 	emit(peer: Peer, event: string, payload: any, timeout?: number): Promise<any>;
 }

--- a/packages/contracts/source/contracts/p2p/peer-connector.ts
+++ b/packages/contracts/source/contracts/p2p/peer-connector.ts
@@ -2,10 +2,6 @@ import { Client } from "./nes";
 import { Peer } from "./peer";
 
 export interface PeerConnector {
-	all(): Client[];
-
-	connection(peer: Peer): Client | undefined;
-
 	connect(peer: Peer): Promise<Client>;
 
 	disconnect(peer: Peer): Promise<void>;

--- a/packages/contracts/source/contracts/p2p/peer-connector.ts
+++ b/packages/contracts/source/contracts/p2p/peer-connector.ts
@@ -8,7 +8,7 @@ export interface PeerConnector {
 
 	connect(peer: Peer): Promise<Client>;
 
-	disconnect(peer: Peer): void;
+	disconnect(peer: Peer): Promise<void>;
 
 	emit(peer: Peer, event: string, payload: any, timeout?: number): Promise<any>;
 }

--- a/packages/contracts/source/contracts/p2p/peer-connector.ts
+++ b/packages/contracts/source/contracts/p2p/peer-connector.ts
@@ -11,12 +11,4 @@ export interface PeerConnector {
 	disconnect(peer: Peer): void;
 
 	emit(peer: Peer, event: string, payload: any, timeout?: number): Promise<any>;
-
-	getError(peer: Peer): string | undefined;
-
-	setError(peer: Peer, error: string): void;
-
-	hasError(peer: Peer, error: string): boolean;
-
-	forgetError(peer: Peer): void;
 }

--- a/packages/p2p/source/peer-communicator.ts
+++ b/packages/p2p/source/peer-communicator.ts
@@ -171,8 +171,6 @@ export class PeerCommunicator implements Contracts.P2P.PeerCommunicator {
 
 		const codec = Codecs[event];
 
-		this.connector.forgetError(peer);
-
 		const timeBeforeSocketCall: number = Date.now();
 
 		await this.connector.connect(peer);

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -36,13 +36,11 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		return this.connection(peer) || (await this.create(peer));
 	}
 
-	public disconnect(peer: Contracts.P2P.Peer): void {
+	public async disconnect(peer: Contracts.P2P.Peer): Promise<void> {
 		const connection = this.connection(peer);
 
 		if (connection) {
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			connection.terminate();
-
+			await connection.terminate();
 			this.connections.delete(`${peer.ip}`);
 		}
 

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -60,7 +60,7 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 			this.app.get<Contracts.P2P.PeerDisposer>(Identifiers.PeerDisposer).banPeer(peer.ip, error);
 		};
 
-		await connection.connect({ retries: 1, timeout: 5000 });
+		await connection.connect({ reconnect: false });
 
 		return connection;
 	}

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -16,11 +16,11 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 	readonly #lastConnectionCreate: Map<string, number> = new Map<string, number>();
 
 	public async connect(peer: Contracts.P2P.Peer): Promise<Client> {
-		return this.connection(peer) || (await this.create(peer));
+		return this.#connection(peer) || (await this.#create(peer));
 	}
 
 	public async disconnect(peer: Contracts.P2P.Peer): Promise<void> {
-		const connection = this.connection(peer);
+		const connection = this.#connection(peer);
 
 		if (connection) {
 			await connection.terminate();
@@ -45,13 +45,13 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		return connection.request(options);
 	}
 
-	private connection(peer: Contracts.P2P.Peer): Client | undefined {
+	#connection(peer: Contracts.P2P.Peer): Client | undefined {
 		const connection: Client | undefined = this.connections.get(`${peer.ip}`);
 
 		return connection;
 	}
 
-	private async create(peer: Contracts.P2P.Peer): Promise<Client> {
+	async #create(peer: Contracts.P2P.Peer): Promise<Client> {
 		// delay a bit if last connection create was less than 10 sec ago to prevent possible abuse of reconnection
 		const timeSinceLastConnectionCreate = Date.now() - (this.#lastConnectionCreate.get(peer.ip) ?? 0);
 		await delay(Math.max(0, TEN_SECONDS_IN_MILLISECONDS - timeSinceLastConnectionCreate));

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -16,15 +16,15 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 	readonly #lastConnectionCreate: Map<string, number> = new Map<string, number>();
 
 	public async connect(peer: Contracts.P2P.Peer): Promise<Client> {
-		return this.#connection(peer) || (await this.#create(peer));
+		return this.connections.get(peer.ip) || (await this.#create(peer));
 	}
 
-	public async disconnect(peer: Contracts.P2P.Peer): Promise<void> {
-		const connection = this.#connection(peer);
+	public async disconnect(ip: string): Promise<void> {
+		const connection = this.connections.get(ip);
 
 		if (connection) {
 			await connection.terminate();
-			this.connections.delete(`${peer.ip}`);
+			this.connections.delete(ip);
 		}
 	}
 
@@ -43,12 +43,6 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		};
 
 		return connection.request(options);
-	}
-
-	#connection(peer: Contracts.P2P.Peer): Client | undefined {
-		const connection: Client | undefined = this.connections.get(`${peer.ip}`);
-
-		return connection;
 	}
 
 	async #create(peer: Contracts.P2P.Peer): Promise<Client> {

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -15,16 +15,6 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 	private readonly connections: Map<string, Client> = new Map<string, Client>();
 	readonly #lastConnectionCreate: Map<string, number> = new Map<string, number>();
 
-	public all(): Client[] {
-		return [...this.connections].map(([key, value]) => value);
-	}
-
-	public connection(peer: Contracts.P2P.Peer): Client | undefined {
-		const connection: Client | undefined = this.connections.get(`${peer.ip}`);
-
-		return connection;
-	}
-
 	public async connect(peer: Contracts.P2P.Peer): Promise<Client> {
 		return this.connection(peer) || (await this.create(peer));
 	}
@@ -53,6 +43,12 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		};
 
 		return connection.request(options);
+	}
+
+	private connection(peer: Contracts.P2P.Peer): Client | undefined {
+		const connection: Client | undefined = this.connections.get(`${peer.ip}`);
+
+		return connection;
 	}
 
 	private async create(peer: Contracts.P2P.Peer): Promise<Client> {

--- a/packages/p2p/source/peer-connector.ts
+++ b/packages/p2p/source/peer-connector.ts
@@ -13,7 +13,6 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 	private readonly app!: Contracts.Kernel.Application;
 
 	private readonly connections: Map<string, Client> = new Map<string, Client>();
-	readonly #errors: Map<string, string> = new Map<string, string>();
 	readonly #lastConnectionCreate: Map<string, number> = new Map<string, number>();
 
 	public all(): Client[] {
@@ -73,22 +72,6 @@ export class PeerConnector implements Contracts.P2P.PeerConnector {
 		};
 
 		return connection.request(options);
-	}
-
-	public getError(peer: Contracts.P2P.Peer): string | undefined {
-		return this.#errors.get(peer.ip);
-	}
-
-	public setError(peer: Contracts.P2P.Peer, error: string): void {
-		this.#errors.set(peer.ip, error);
-	}
-
-	public hasError(peer: Contracts.P2P.Peer, error: string): boolean {
-		return this.getError(peer) === error;
-	}
-
-	public forgetError(peer: Contracts.P2P.Peer): void {
-		this.#errors.delete(peer.ip);
 	}
 
 	private async create(peer: Contracts.P2P.Peer): Promise<Client> {

--- a/packages/p2p/source/peer-disposer.ts
+++ b/packages/p2p/source/peer-disposer.ts
@@ -51,11 +51,12 @@ export class PeerDisposer implements Contracts.P2P.PeerDisposer {
 	}
 
 	public disposePeer(ip: string): void {
+		void this.connector.disconnect(ip);
+
 		if (this.repository.hasPeer(ip)) {
 			const peer = this.repository.getPeer(ip);
 
 			this.repository.forgetPeer(peer);
-			this.connector.disconnect(peer);
 			peer.dispose();
 
 			void this.events.dispatch(Enums.PeerEvent.Removed, peer);


### PR DESCRIPTION
## Summary

Disconnect peers that are not verified and are not yet in the peers repository. Remove errors from connector and refactor. 

## Checklist

- [x] Ready to be merged

