### PR TITLE
fix(crypto): multipayment bignumber conversion

### DIFF
--- a/packages/crypto-transaction-multi-payment/source/versions/1.ts
+++ b/packages/crypto-transaction-multi-payment/source/versions/1.ts
@@ -1,8 +1,8 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { extendSchema, Transaction, transactionBaseSchema } from "@mainsail/crypto-transaction";
-import { BigNumber, ByteBuffer } from "@mainsail/utils";
 import { Utils } from "@mainsail/kernel";
+import { BigNumber, ByteBuffer } from "@mainsail/utils";
 
 @injectable()
 export class MultiPaymentTransaction extends Transaction {
@@ -55,9 +55,9 @@ export class MultiPaymentTransaction extends Transaction {
 
 		Utils.assert.defined<Contracts.Crypto.IMultiPaymentItem[]>(data.asset?.payments);
 
-		data.asset.payments.forEach(payment => {
+		for (const payment of data.asset.payments) {
 			payment.amount = BigNumber.make(payment.amount);
-		});
+		}
 
 		return data;
 	}
@@ -68,8 +68,8 @@ export class MultiPaymentTransaction extends Transaction {
 		if (data.asset && data.asset.payments) {
 			const buff: ByteBuffer = ByteBuffer.fromSize(
 				2 +
-				data.asset.payments.length * this.app.get<number>(Identifiers.Cryptography.Size.Address) +
-				data.asset.payments.length * 8,
+					data.asset.payments.length * this.app.get<number>(Identifiers.Cryptography.Size.Address) +
+					data.asset.payments.length * 8,
 			);
 			buff.writeUint16(data.asset.payments.length);
 

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -30,8 +30,10 @@ export class TransactionFactory implements Contracts.Crypto.ITransactionFactory 
 	}
 
 	public async fromJson(json: Contracts.Crypto.ITransactionJson): Promise<Contracts.Crypto.ITransaction> {
-		const data: Contracts.Crypto.ITransactionData = { ...json } as unknown as Contracts.Crypto.ITransactionData;
-		return this.fromData(data);
+		return this.fromData(
+			this.transactionTypeFactory.get(json.type, json.typeGroup, json.version)
+				.getData(json)
+		);
 	}
 
 	public async fromData(

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -1,6 +1,5 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
-import { BigNumber } from "@mainsail/utils";
 
 @injectable()
 export class TransactionFactory implements Contracts.Crypto.ITransactionFactory {
@@ -32,10 +31,6 @@ export class TransactionFactory implements Contracts.Crypto.ITransactionFactory 
 
 	public async fromJson(json: Contracts.Crypto.ITransactionJson): Promise<Contracts.Crypto.ITransaction> {
 		const data: Contracts.Crypto.ITransactionData = { ...json } as unknown as Contracts.Crypto.ITransactionData;
-		data.amount = BigNumber.make(data.amount);
-		data.fee = BigNumber.make(data.fee);
-		data.nonce = BigNumber.make(data.nonce);
-
 		return this.fromData(data);
 	}
 

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -30,10 +30,7 @@ export class TransactionFactory implements Contracts.Crypto.ITransactionFactory 
 	}
 
 	public async fromJson(json: Contracts.Crypto.ITransactionJson): Promise<Contracts.Crypto.ITransaction> {
-		return this.fromData(
-			this.transactionTypeFactory.get(json.type, json.typeGroup, json.version)
-				.getData(json)
-		);
+		return this.fromData(this.transactionTypeFactory.get(json.type, json.typeGroup, json.version).getData(json));
 	}
 
 	public async fromData(

--- a/packages/crypto-transaction/source/types/transaction.ts
+++ b/packages/crypto-transaction/source/types/transaction.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
-import { ByteBuffer } from "@mainsail/utils";
+import { ByteBuffer, BigNumber } from "@mainsail/utils";
 
 @injectable()
 export abstract class Transaction implements Contracts.Crypto.ITransaction {
@@ -36,6 +36,14 @@ export abstract class Transaction implements Contracts.Crypto.ITransaction {
 
 	public static getSchema(): Contracts.Crypto.ITransactionSchema {
 		throw new Exceptions.NotImplemented(this.constructor.name, "getSchema");
+	}
+
+	public static getData(json: Contracts.Crypto.ITransactionJson): Contracts.Crypto.ITransactionData {
+		const data: Contracts.Crypto.ITransactionData = { ...json } as unknown as Contracts.Crypto.ITransactionData;
+		data.amount = BigNumber.make(data.amount);
+		data.fee = BigNumber.make(data.fee);
+		data.nonce = BigNumber.make(data.nonce);
+		return data;
 	}
 
 	public hasVendorField(): boolean {

--- a/packages/crypto-transaction/source/types/transaction.ts
+++ b/packages/crypto-transaction/source/types/transaction.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
-import { ByteBuffer, BigNumber } from "@mainsail/utils";
+import { BigNumber, ByteBuffer } from "@mainsail/utils";
 
 @injectable()
 export abstract class Transaction implements Contracts.Crypto.ITransaction {

--- a/packages/crypto-validation/source/keywords.test.ts
+++ b/packages/crypto-validation/source/keywords.test.ts
@@ -234,7 +234,7 @@ describe<{
 		);
 	});
 
-	it("keyword bignumber should be able to modify parent", (context) => {
+	it("keyword bignumber should not modify parent", (context) => {
 		const schema = {
 			$id: "test",
 			properties: {
@@ -248,24 +248,8 @@ describe<{
 		const object: any = { id: "test", amount: "12" };
 		assert.false(object.amount instanceof BigNumber);
 		assert.undefined(context.validator.validate("test", object).error);
-		assert.true(object.amount instanceof BigNumber);
-		assert.equal(object.amount, BigNumber.make(12));
+		assert.false(object.amount instanceof BigNumber);
+		assert.equal(object.amount, "12");
 	});
 
-	it("keyword bignumber should not modify parent on error", (context) => {
-		const schema = {
-			$id: "test",
-			properties: {
-				id: { type: "string" },
-				amount: { bignumber: { minimum: 1 } },
-			},
-			type: "object",
-		};
-		context.validator.addSchema(schema);
-
-		const object: any = { id: "test", amount: "notanumber" };
-		assert.false(object.amount instanceof BigNumber);
-		assert.defined(context.validator.validate("test", object).error);
-		assert.false(object.amount instanceof BigNumber);
-	});
 });

--- a/packages/crypto-validation/source/keywords.test.ts
+++ b/packages/crypto-validation/source/keywords.test.ts
@@ -233,4 +233,39 @@ describe<{
 			}).error,
 		);
 	});
+
+	it("keyword bignumber should be able to modify parent", (context) => {
+		const schema = {
+			$id: "test",
+			properties: {
+				id: { type: "string" },
+				amount: { bignumber: { minimum: 1 } },
+			},
+			type: "object",
+		};
+		context.validator.addSchema(schema);
+
+		const object: any = { id: "test", amount: "12" };
+		assert.false(object.amount instanceof BigNumber);
+		assert.undefined(context.validator.validate("test", object).error);
+		assert.true(object.amount instanceof BigNumber);
+		assert.equal(object.amount, BigNumber.make(12));
+	});
+
+	it("keyword bignumber should not modify parent on error", (context) => {
+		const schema = {
+			$id: "test",
+			properties: {
+				id: { type: "string" },
+				amount: { bignumber: { minimum: 15 } },
+			},
+			type: "object",
+		};
+		context.validator.addSchema(schema);
+
+		const object: any = { id: "test", amount: "12" };
+		assert.false(object.amount instanceof BigNumber);
+		assert.defined(context.validator.validate("test", object).error);
+		assert.false(object.amount instanceof BigNumber);
+	});
 });

--- a/packages/crypto-validation/source/keywords.test.ts
+++ b/packages/crypto-validation/source/keywords.test.ts
@@ -257,13 +257,13 @@ describe<{
 			$id: "test",
 			properties: {
 				id: { type: "string" },
-				amount: { bignumber: { minimum: 15 } },
+				amount: { bignumber: { minimum: 1 } },
 			},
 			type: "object",
 		};
 		context.validator.addSchema(schema);
 
-		const object: any = { id: "test", amount: "12" };
+		const object: any = { id: "test", amount: "notanumber" };
 		assert.false(object.amount instanceof BigNumber);
 		assert.defined(context.validator.validate("test", object).error);
 		assert.false(object.amount instanceof BigNumber);

--- a/packages/crypto-validation/source/keywords.test.ts
+++ b/packages/crypto-validation/source/keywords.test.ts
@@ -251,5 +251,4 @@ describe<{
 		assert.false(object.amount instanceof BigNumber);
 		assert.equal(object.amount, "12");
 	});
-
 });

--- a/packages/crypto-validation/source/keywords.ts
+++ b/packages/crypto-validation/source/keywords.ts
@@ -60,6 +60,11 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 				return false;
 			}
 
+			const { parentData, parentDataProperty } = parentSchema;
+			if (parentData && parentDataProperty) {
+				parentData[parentDataProperty] = bignum;
+			}
+
 			return true;
 		},
 		errors: false,

--- a/packages/crypto-validation/source/keywords.ts
+++ b/packages/crypto-validation/source/keywords.ts
@@ -48,6 +48,11 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 				return false;
 			}
 
+			const { parentData, parentDataProperty } = parentSchema;
+			if (parentData && parentDataProperty) {
+				parentData[parentDataProperty] = bignum;
+			}
+
 			if (bignum.isLessThan(minimum)) {
 				if (bignum.isZero() && schema.bypassGenesis && parentSchema.parentData?.id) {
 					return isGenesisTransaction(configuration, parentSchema.parentData.id);
@@ -58,11 +63,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 
 			if (bignum.isGreaterThan(maximum)) {
 				return false;
-			}
-
-			const { parentData, parentDataProperty } = parentSchema;
-			if (parentData && parentDataProperty) {
-				parentData[parentDataProperty] = bignum;
 			}
 
 			return true;

--- a/packages/crypto-validation/source/keywords.ts
+++ b/packages/crypto-validation/source/keywords.ts
@@ -48,11 +48,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 				return false;
 			}
 
-			const { parentData, parentDataProperty } = parentSchema;
-			if (parentData && parentDataProperty) {
-				parentData[parentDataProperty] = bignum;
-			}
-
 			if (bignum.isLessThan(minimum)) {
 				if (bignum.isZero() && schema.bypassGenesis && parentSchema.parentData?.id) {
 					return isGenesisTransaction(configuration, parentSchema.parentData.id);
@@ -78,7 +73,6 @@ export const makeKeywords = (configuration: Contracts.Crypto.IConfiguration) => 
 			},
 			type: "object",
 		},
-		modifying: true,
 	};
 
 	return { bignum, maxBytes };

--- a/packages/transactions/source/handlers/transaction.ts
+++ b/packages/transactions/source/handlers/transaction.ts
@@ -126,12 +126,12 @@ export abstract class TransactionHandler implements Contracts.Transactions.ITran
 		sender.setBalance(newBalance);
 	}
 
-	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {}
+	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void { }
 
 	public async throwIfCannotEnterPool(
 		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
-	): Promise<void> {}
+	): Promise<void> { }
 
 	public async verifySignatures(
 		wallet: Contracts.State.Wallet,

--- a/packages/transactions/source/handlers/transaction.ts
+++ b/packages/transactions/source/handlers/transaction.ts
@@ -126,12 +126,12 @@ export abstract class TransactionHandler implements Contracts.Transactions.ITran
 		sender.setBalance(newBalance);
 	}
 
-	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void { }
+	public emitEvents(transaction: Contracts.Crypto.ITransaction, emitter: Contracts.Kernel.EventDispatcher): void {}
 
 	public async throwIfCannotEnterPool(
 		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.ITransaction,
-	): Promise<void> { }
+	): Promise<void> {}
 
 	public async verifySignatures(
 		wallet: Contracts.State.Wallet,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Add missing bignumber conversion for multi payments.

The original behavior does so via the bignumber schema:
https://github.com/ArkEcosystem/core/blob/d7aa24a93495663940ccd6f05f2d67c5270d79a7/packages/crypto/src/validation/keywords.ts#L92-L93

But it has drawbacks since it modifies the data and hence was removed from mainsail.

Now `fromJson()` can be reimplemented by transaction classes to cast the respective fields.


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
