### PR TITLE
fix(api): transform vendorfield when reading from database

### DIFF
--- a/packages/api-database/source/models/mempool-transaction.ts
+++ b/packages/api-database/source/models/mempool-transaction.ts
@@ -1,4 +1,5 @@
 import { Column, Entity } from "typeorm";
+
 import { vendorFieldTransformer } from "../transformers/vendor-field";
 
 @Entity({
@@ -56,8 +57,8 @@ export class MempoolTransaction {
 	@Column({
 		default: undefined,
 		nullable: true,
-		type: "bytea",
 		transformer: vendorFieldTransformer,
+		type: "bytea",
 	})
 	public vendorField: string | undefined;
 

--- a/packages/api-database/source/models/mempool-transaction.ts
+++ b/packages/api-database/source/models/mempool-transaction.ts
@@ -1,4 +1,5 @@
 import { Column, Entity } from "typeorm";
+import { vendorFieldTransformer } from "../transformers/vendor-field";
 
 @Entity({
 	name: "mempool_transactions",
@@ -56,6 +57,7 @@ export class MempoolTransaction {
 		default: undefined,
 		nullable: true,
 		type: "bytea",
+		transformer: vendorFieldTransformer,
 	})
 	public vendorField: string | undefined;
 

--- a/packages/api-database/source/models/transaction.ts
+++ b/packages/api-database/source/models/transaction.ts
@@ -1,4 +1,5 @@
 import { Column, Entity } from "typeorm";
+
 import { vendorFieldTransformer } from "../transformers/vendor-field";
 
 @Entity({
@@ -82,8 +83,8 @@ export class Transaction {
 	@Column({
 		default: undefined,
 		nullable: true,
-		type: "bytea",
 		transformer: vendorFieldTransformer,
+		type: "bytea",
 	})
 	public vendorField: string | undefined;
 

--- a/packages/api-database/source/models/transaction.ts
+++ b/packages/api-database/source/models/transaction.ts
@@ -1,4 +1,5 @@
 import { Column, Entity } from "typeorm";
+import { vendorFieldTransformer } from "../transformers/vendor-field";
 
 @Entity({
 	name: "transactions",
@@ -82,6 +83,7 @@ export class Transaction {
 		default: undefined,
 		nullable: true,
 		type: "bytea",
+		transformer: vendorFieldTransformer,
 	})
 	public vendorField: string | undefined;
 

--- a/packages/api-database/source/transformers/vendor-field.ts
+++ b/packages/api-database/source/transformers/vendor-field.ts
@@ -1,0 +1,12 @@
+export const vendorFieldTransformer = {
+    from: (value: Buffer | undefined | null): string | null => {
+        if (value !== undefined && value !== null) {
+            return value.toString("utf8");
+        }
+
+        return null;
+    },
+    to: (value: any): any => {
+        return value;
+    },
+};

--- a/packages/api-database/source/transformers/vendor-field.ts
+++ b/packages/api-database/source/transformers/vendor-field.ts
@@ -1,12 +1,10 @@
 export const vendorFieldTransformer = {
-    from: (value: Buffer | undefined | null): string | null => {
-        if (value !== undefined && value !== null) {
-            return value.toString("utf8");
-        }
+	from: (value: Buffer | undefined | null): string | null => {
+		if (value !== undefined && value !== null) {
+			return value.toString("utf8");
+		}
 
-        return null;
-    },
-    to: (value: any): any => {
-        return value;
-    },
+		return null;
+	},
+	to: (value: any): any => value,
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Fix vendor field being returned as a buffer object:

```
# Before
"vendorField": {"type":"Buffer","data":[100,102,115,102,100,115,102,115,100,102]}

# After
"vendorField": "dfsfdsfsdf"
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
