### PR TITLE
fix(api-database): use explicit names for unique constraints instead of generated ones

### DIFF
--- a/packages/api-database/source/models/block.ts
+++ b/packages/api-database/source/models/block.ts
@@ -1,8 +1,11 @@
-import { Column, Entity } from "typeorm";
+import { Column, Entity, Unique } from "typeorm";
 
 @Entity({
 	name: "blocks",
 })
+@Unique("unique_block_height", ["height"])
+@Unique("unique_block_timestamp", ["timestamp"])
+@Unique("unique_previous_block", ["previousBlock"])
 export class Block {
 	@Column({
 		primary: true,
@@ -20,13 +23,11 @@ export class Block {
 	@Column({
 		nullable: false,
 		type: "bigint",
-		unique: true,
 	})
 	public readonly timestamp!: string;
 
 	@Column({
 		type: "varchar",
-		unique: true,
 		// TODO: length depends on hash size...
 		// length: 64,
 	})
@@ -35,7 +36,6 @@ export class Block {
 	@Column({
 		nullable: false,
 		type: "bigint",
-		unique: true,
 	})
 	public readonly height!: string;
 

--- a/packages/api-database/source/models/validator-round.ts
+++ b/packages/api-database/source/models/validator-round.ts
@@ -1,8 +1,9 @@
-import { Column, Entity } from "typeorm";
+import { Column, Entity, Unique } from "typeorm";
 
 @Entity({
 	name: "validator_rounds",
 })
+@Unique("unique_validator_round_height", ["roundHeight"])
 export class ValidatorRound {
 	@Column({
 		primary: true,

--- a/packages/api-database/source/models/wallet.ts
+++ b/packages/api-database/source/models/wallet.ts
@@ -1,8 +1,9 @@
-import { Column, Entity } from "typeorm";
+import { Column, Entity, Unique } from "typeorm";
 
 @Entity({
 	name: "wallets",
 })
+@Unique("unique_wallet_public_key", ["publicKey"])
 export class Wallet {
 	@Column({
 		primary: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Before:
```
duplicate key value violates unique constraint "UQ_905a98dead19fbbf16aabdbe121"
```

After:
```
duplicate key value violates unique constraint "unique_previous_block"
```

This way you can tell right away what the actual problem is.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
