### PR TITLE
fix(api-sync): use `insert().orIgnore()` instead of calling `save()`

### DIFF
--- a/packages/api-sync/source/sync.ts
+++ b/packages/api-sync/source/sync.ts
@@ -141,14 +141,14 @@ export class Sync implements Contracts.ApiSync.ISync {
 
 			...(Utils.roundCalculator.isNewRound(header.height, this.configuration)
 				? {
-						validatorRound: {
-							round,
-							roundHeight,
-							validators: this.validatorSet
-								.getActiveValidators()
-								.map((validator) => validator.getWalletPublicKey()),
-						},
-				  }
+					validatorRound: {
+						round,
+						roundHeight,
+						validators: this.validatorSet
+							.getActiveValidators()
+							.map((validator) => validator.getWalletPublicKey()),
+					},
+				}
 				: {}),
 		};
 
@@ -252,7 +252,12 @@ export class Sync implements Contracts.ApiSync.ISync {
 			const validatorRoundRepository = this.validatorRoundRepositoryFactory(entityManager);
 			const walletRepository = this.walletRepositoryFactory(entityManager);
 
-			await blockRepository.save(deferred.block);
+			await blockRepository
+				.createQueryBuilder()
+				.insert()
+				.orIgnore()
+				.values(deferred.block)
+				.execute();
 
 			await stateRepository
 				.createQueryBuilder()
@@ -268,7 +273,12 @@ export class Sync implements Contracts.ApiSync.ISync {
 				})
 				.execute();
 
-			await transactionRepository.save(deferred.transactions);
+			await transactionRepository
+				.createQueryBuilder()
+				.insert()
+				.orIgnore()
+				.values(deferred.transactions)
+				.execute();
 
 			if (deferred.validatorRound) {
 				await validatorRoundRepository

--- a/packages/api-sync/source/sync.ts
+++ b/packages/api-sync/source/sync.ts
@@ -141,14 +141,14 @@ export class Sync implements Contracts.ApiSync.ISync {
 
 			...(Utils.roundCalculator.isNewRound(header.height, this.configuration)
 				? {
-					validatorRound: {
-						round,
-						roundHeight,
-						validators: this.validatorSet
-							.getActiveValidators()
-							.map((validator) => validator.getWalletPublicKey()),
-					},
-				}
+						validatorRound: {
+							round,
+							roundHeight,
+							validators: this.validatorSet
+								.getActiveValidators()
+								.map((validator) => validator.getWalletPublicKey()),
+						},
+				  }
 				: {}),
 		};
 
@@ -252,12 +252,7 @@ export class Sync implements Contracts.ApiSync.ISync {
 			const validatorRoundRepository = this.validatorRoundRepositoryFactory(entityManager);
 			const walletRepository = this.walletRepositoryFactory(entityManager);
 
-			await blockRepository
-				.createQueryBuilder()
-				.insert()
-				.orIgnore()
-				.values(deferred.block)
-				.execute();
+			await blockRepository.createQueryBuilder().insert().orIgnore().values(deferred.block).execute();
 
 			await stateRepository
 				.createQueryBuilder()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Replace usages of `save()` with `insert().orIgnore()` for blocks and transactions.

It makes local development easier since one doesn't have to reset the postgres database all the time, another added benefit is that it removes unnecessary database round trips because each `save()` always selects first before inserting.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
