### PR TITLE
fix(api-common): register plugin only if block repository is bound to container

### DIFF
--- a/packages/api-common/source/index.ts
+++ b/packages/api-common/source/index.ts
@@ -1,6 +1,6 @@
 export * as Contracts from "./contracts";
 export * from "./controller";
-export * as Schemas from "./schemas";
 export * as Plugins from "./plugins";
+export * as Schemas from "./schemas";
 export * from "./server";
 export * from "./service-provider";

--- a/packages/api-common/source/index.ts
+++ b/packages/api-common/source/index.ts
@@ -1,5 +1,6 @@
 export * as Contracts from "./contracts";
 export * from "./controller";
 export * as Schemas from "./schemas";
+export * as Plugins from "./plugins";
 export * from "./server";
 export * from "./service-provider";

--- a/packages/api-common/source/plugins/index.ts
+++ b/packages/api-common/source/plugins/index.ts
@@ -1,38 +1,7 @@
-import { commaArrayQuery } from "./comma-separated-query";
-import { dotSeparatedQuery } from "./dot-separated-query";
-import { hapiAjv } from "./hapi-ajv";
-import { pagination } from "./pagination";
-import { rateLimit } from "./rate-limit";
-import { responseHeaders } from "./response-headers";
-import { whitelist } from "./whitelist";
-
-export const preparePlugins: any = (config) => [
-	{
-		options: {
-			trustProxy: config.trustProxy,
-			whitelist: config.whitelist,
-		},
-		plugin: whitelist,
-	},
-	{ plugin: hapiAjv },
-	{
-		options: {
-			...config.rateLimit,
-			trustProxy: config.trustProxy,
-		},
-		plugin: rateLimit,
-	},
-	{ plugin: commaArrayQuery },
-	{ plugin: dotSeparatedQuery },
-	{
-		options: {
-			query: {
-				limit: {
-					default: config.pagination.limit,
-				},
-			},
-		},
-		plugin: pagination,
-	},
-	{ plugin: responseHeaders },
-];
+export { commaArrayQuery } from "./comma-separated-query";
+export { dotSeparatedQuery } from "./dot-separated-query";
+export { hapiAjv } from "./hapi-ajv";
+export { pagination } from "./pagination";
+export { rateLimit } from "./rate-limit";
+export { responseHeaders } from "./response-headers";
+export { whitelist } from "./whitelist";

--- a/packages/api-common/source/plugins/response-headers.ts
+++ b/packages/api-common/source/plugins/response-headers.ts
@@ -22,7 +22,9 @@ export const responseHeaders = {
 	name: "response-headers",
 
 	register(server: ApiServer): void {
-		server.ext("onPreResponse", this.getOnPreResponseHandler(server.app.app));
+		if (server.app.app.isBound(ApiDatabaseIdentifiers.BlockRepositoryFactory)) {
+			server.ext("onPreResponse", this.getOnPreResponseHandler(server.app.app));
+		}
 	},
 
 	version: "1.0.0",

--- a/packages/api-common/source/plugins/response-headers.ts
+++ b/packages/api-common/source/plugins/response-headers.ts
@@ -22,9 +22,7 @@ export const responseHeaders = {
 	name: "response-headers",
 
 	register(server: ApiServer): void {
-		if (server.app.app.isBound(ApiDatabaseIdentifiers.BlockRepositoryFactory)) {
-			server.ext("onPreResponse", this.getOnPreResponseHandler(server.app.app));
-		}
+		server.ext("onPreResponse", this.getOnPreResponseHandler(server.app.app));
 	},
 
 	version: "1.0.0",

--- a/packages/api-common/source/service-provider.ts
+++ b/packages/api-common/source/service-provider.ts
@@ -2,7 +2,6 @@ import { Providers } from "@mainsail/kernel";
 import Joi from "joi";
 
 import { ServerType } from "./contracts";
-import { preparePlugins } from "./plugins";
 import { AbstractServer } from "./server";
 
 export type ServerConstructor<T extends AbstractServer> = new (...arguments_: any[]) => T;
@@ -11,6 +10,7 @@ export abstract class AbstractServiceProvider<T extends AbstractServer> extends 
 	protected abstract httpsIdentifier(): symbol;
 	protected abstract getServerConstructor(): ServerConstructor<T>;
 	protected abstract getHandlers(): any | any[];
+	protected abstract getPlugins(): any[];
 
 	public async register(): Promise<void> {
 		if (this.config().get("server.http.enabled")) {
@@ -85,7 +85,7 @@ export abstract class AbstractServiceProvider<T extends AbstractServer> extends 
 			},
 		});
 
-		await server.register(preparePlugins(this.config().get("plugins")));
+		await server.register(this.getPlugins());
 
 		await server.register({
 			plugin: this.getHandlers(),

--- a/packages/api-http/source/service-provider.ts
+++ b/packages/api-http/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { AbstractServiceProvider, ServerConstructor, Plugins } from "@mainsail/api-common";
+import { AbstractServiceProvider, Plugins, ServerConstructor } from "@mainsail/api-common";
 import Joi from "joi";
 
 import Handlers from "./handlers";

--- a/packages/api-http/source/service-provider.ts
+++ b/packages/api-http/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { AbstractServiceProvider, ServerConstructor } from "@mainsail/api-common";
+import { AbstractServiceProvider, ServerConstructor, Plugins } from "@mainsail/api-common";
 import Joi from "joi";
 
 import Handlers from "./handlers";
@@ -20,6 +20,41 @@ export class ServiceProvider extends AbstractServiceProvider<Server> {
 
 	protected getHandlers(): any | any[] {
 		return Handlers;
+	}
+
+	protected getPlugins(): any[] {
+		const config = this.config().get<any>("plugins");
+
+		return [
+			{
+				options: {
+					trustProxy: config.trustProxy,
+					whitelist: config.whitelist,
+				},
+				plugin: Plugins.whitelist,
+			},
+			{ plugin: Plugins.hapiAjv },
+			{
+				options: {
+					...config.rateLimit,
+					trustProxy: config.trustProxy,
+				},
+				plugin: Plugins.rateLimit,
+			},
+			{ plugin: Plugins.commaArrayQuery },
+			{ plugin: Plugins.dotSeparatedQuery },
+			{
+				options: {
+					query: {
+						limit: {
+							default: config.pagination.limit,
+						},
+					},
+				},
+				plugin: Plugins.pagination,
+			},
+			{ plugin: Plugins.responseHeaders },
+		];
 	}
 
 	public configSchema(): Joi.ObjectSchema {

--- a/packages/api-transaction-pool/source/service-provider.ts
+++ b/packages/api-transaction-pool/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { AbstractServiceProvider, ServerConstructor, Plugins } from "@mainsail/api-common";
+import { AbstractServiceProvider, Plugins, ServerConstructor } from "@mainsail/api-common";
 
 import Handlers from "./handlers";
 import { Identifiers as ApiTransactionPoolIdentifiers } from "./identifiers";

--- a/packages/api-transaction-pool/source/service-provider.ts
+++ b/packages/api-transaction-pool/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { AbstractServiceProvider, ServerConstructor } from "@mainsail/api-common";
+import { AbstractServiceProvider, ServerConstructor, Plugins } from "@mainsail/api-common";
 
 import Handlers from "./handlers";
 import { Identifiers as ApiTransactionPoolIdentifiers } from "./identifiers";
@@ -19,5 +19,27 @@ export class ServiceProvider extends AbstractServiceProvider<Server> {
 
 	protected getHandlers(): any | any[] {
 		return Handlers;
+	}
+
+	protected getPlugins(): any[] {
+		const config = this.config().get<any>("plugins");
+
+		return [
+			{
+				options: {
+					trustProxy: config.trustProxy,
+					whitelist: config.whitelist,
+				},
+				plugin: Plugins.whitelist,
+			},
+			{ plugin: Plugins.hapiAjv },
+			{
+				options: {
+					...config.rateLimit,
+					trustProxy: config.trustProxy,
+				},
+				plugin: Plugins.rateLimit,
+			},
+		];
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Allows the main process to run the `api-transaction-pool` without `api-sync` and `api-database`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
