### PR TITLE
fix(crypto-address-base58): checksum calculation

### DIFF
--- a/packages/crypto-address-base58/source/address.factory.test.ts
+++ b/packages/crypto-address-base58/source/address.factory.test.ts
@@ -9,8 +9,7 @@ import { ServiceProvider as CoreValidation } from "@mainsail/validation";
 import { describe } from "../../test-framework";
 import { AddressFactory } from "./address.factory";
 
-const mnemonic =
-	"this is a top secret passphrase";
+const mnemonic = "this is a top secret passphrase";
 
 describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) => {
 	beforeEach(async (context) => {

--- a/packages/crypto-address-base58/source/address.factory.test.ts
+++ b/packages/crypto-address-base58/source/address.factory.test.ts
@@ -10,7 +10,7 @@ import { describe } from "../../test-framework";
 import { AddressFactory } from "./address.factory";
 
 const mnemonic =
-	"program fragile industry scare sun visit race erase daughter empty anxiety cereal cycle hunt airport educate giggle picture sunset apart jewel similar pulp moment";
+	"this is a top secret passphrase";
 
 describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) => {
 	beforeEach(async (context) => {
@@ -20,7 +20,7 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 			milestones: [
 				{
 					address: {
-						base58: 23,
+						base58: 30,
 					},
 				},
 			],
@@ -34,7 +34,7 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 
 		assert.is(
 			await context.app.resolve(AddressFactory).fromMnemonic(mnemonic),
-			"AcYBXbtvzjYhRnNoJEC7E4ybnbkjrezbX8",
+			"D5jdQXLMgL2TumzdJ8B1zVAGtYWc43VQSx",
 		);
 	});
 
@@ -43,7 +43,7 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 
 		assert.is(
 			await context.app.resolve(AddressFactory).fromMnemonic(mnemonic),
-			"AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu",
+			"D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 		);
 	});
 
@@ -54,7 +54,7 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 			await context.app
 				.resolve(AddressFactory)
 				.fromPublicKey("e84093c072af70004a38dd95e34def119d2348d5261228175d032e5f2070e19f"),
-			"AcYBXbtvzjYhRnNoJEC7E4ybnbkjrezbX8",
+			"DRuQRMywxznq9pMQUAXLcwt7C8ZLs8NDBv",
 		);
 	});
 
@@ -64,16 +64,15 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 		assert.is(
 			await context.app
 				.resolve(AddressFactory)
-				.fromPublicKey("03e84093c072af70004a38dd95e34def119d2348d5261228175d032e5f2070e19f"),
-			"AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu",
+				.fromPublicKey("034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192"),
+			"D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 		);
 	});
 
 	it("should validate addresses", async (context) => {
 		await context.app.resolve<ECDSA>(ECDSA).register();
 
-		assert.true(await context.app.resolve(AddressFactory).validate("AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu"));
-		assert.true(await context.app.resolve(AddressFactory).validate("AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu"));
+		assert.true(await context.app.resolve(AddressFactory).validate("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"));
 		assert.false(
 			await context.app
 				.resolve(AddressFactory)
@@ -87,8 +86,8 @@ describe<{ app: Application }>("AddressFactory", ({ assert, beforeEach, it }) =>
 		const addressFactory = context.app.resolve(AddressFactory);
 
 		assert.equal(
-			await addressFactory.fromBuffer(await addressFactory.toBuffer("AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu")),
-			"AFsmMfUo2MrcwPnoF3Liqu36dSd3o8yYVu",
+			await addressFactory.fromBuffer(await addressFactory.toBuffer("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")),
+			"D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 		);
 	});
 });

--- a/packages/crypto-address-base58/source/address.factory.ts
+++ b/packages/crypto-address-base58/source/address.factory.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { RIPEMD160, SHA256 } from "bcrypto";
+import { RIPEMD160, Hash256 } from "bcrypto";
 import { base58 } from "bstring";
 
 @injectable()
@@ -67,7 +67,7 @@ export class AddressFactory implements Contracts.Crypto.IAddressFactory {
 	}
 
 	#encodeCheck(buffer: Buffer): string {
-		const checksum: Buffer = SHA256.digest(buffer);
+		const checksum = Hash256.digest(buffer);
 
 		return base58.encode(Buffer.concat([buffer, checksum], buffer.length + 4));
 	}
@@ -75,7 +75,7 @@ export class AddressFactory implements Contracts.Crypto.IAddressFactory {
 	#decodeCheck(address: string): Buffer {
 		const buffer: Buffer = base58.decode(address);
 		const payload: Buffer = buffer.subarray(0, -4);
-		const checksum: Buffer = SHA256.digest(payload);
+		const checksum: Buffer = Hash256.digest(payload);
 
 		if (checksum.readUInt32LE(0) !== buffer.subarray(-4).readUInt32LE(0)) {
 			throw new Error("Invalid checksum for base58 string.");

--- a/packages/crypto-address-base58/source/address.factory.ts
+++ b/packages/crypto-address-base58/source/address.factory.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { RIPEMD160, Hash256 } from "bcrypto";
+import { Hash256, RIPEMD160 } from "bcrypto";
 import { base58 } from "bstring";
 
 @injectable()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Needs to be the double sha256 while it was doing a single sha256.
https://en.bitcoin.it/wiki/Base58Check_encoding

For this we should use the `hash256` function which does exactly that.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
