### PR TITLE
refactor(crypto): calculate tx buffer size

### DIFF
--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -13,7 +13,7 @@ export interface ITransaction {
 	serialized: Buffer;
 
 	assetSize(): number;
-	serialize(options?: ISerializeOptions): Promise<ByteBuffer | undefined>;
+	serialize(options?: ISerializeOptions): Promise<ByteBuffer>;
 	deserialize(buf: ByteBuffer): Promise<void>;
 
 	hasVendorField(): boolean;

--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -12,6 +12,7 @@ export interface ITransaction {
 	data: ITransactionData;
 	serialized: Buffer;
 
+	assetSize(): number;
 	serialize(options?: ISerializeOptions): Promise<ByteBuffer | undefined>;
 	deserialize(buf: ByteBuffer): Promise<void>;
 
@@ -114,6 +115,7 @@ export interface IVoteAsset {
 export interface ISerializeOptions {
 	excludeSignature?: boolean;
 	excludeMultiSignature?: boolean;
+	// TODO: consider passing pre-allocated buffer
 }
 
 export interface TransactionServiceProvider {

--- a/packages/crypto-signature-schnorr-legacy/source/index.ts
+++ b/packages/crypto-signature-schnorr-legacy/source/index.ts
@@ -8,7 +8,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {
 		this.app
 			.bind(Identifiers.Cryptography.Size.Signature)
-			.toConstantValue(65)
+			.toConstantValue(64)
 			.when(Selectors.anyAncestorOrTargetTaggedFirst("type", "wallet"));
 
 		this.app

--- a/packages/crypto-signature-schnorr/source/index.ts
+++ b/packages/crypto-signature-schnorr/source/index.ts
@@ -8,7 +8,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {
 		this.app
 			.bind(Identifiers.Cryptography.Size.Signature)
-			.toConstantValue(65)
+			.toConstantValue(64)
 			.when(Selectors.anyAncestorOrTargetTaggedFirst("type", "wallet"));
 
 		this.app

--- a/packages/crypto-transaction-multi-payment/source/versions/1.ts
+++ b/packages/crypto-transaction-multi-payment/source/versions/1.ts
@@ -70,9 +70,9 @@ export class MultiPaymentTransaction extends Transaction {
 
 		return (
 			2 + // number of payments
-			(payments.length * 8) + // amounts
-			(payments.length * this.addressSize) // recipients
-		)
+			payments.length * 8 + // amounts
+			payments.length * this.addressSize // recipients
+		);
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
@@ -81,11 +81,7 @@ export class MultiPaymentTransaction extends Transaction {
 		Utils.assert.defined<Contracts.Crypto.IMultiPaymentItem[]>(data.asset?.payments);
 		const { payments } = data.asset;
 
-		const buff: ByteBuffer = ByteBuffer.fromSize(
-			2 +
-			payments.length * 8 +
-			payments.length * this.addressSize
-		);
+		const buff: ByteBuffer = ByteBuffer.fromSize(2 + payments.length * 8 + payments.length * this.addressSize);
 
 		buff.writeUint16(payments.length);
 

--- a/packages/crypto-transaction-multi-payment/source/versions/1.ts
+++ b/packages/crypto-transaction-multi-payment/source/versions/1.ts
@@ -75,13 +75,13 @@ export class MultiPaymentTransaction extends Transaction {
 		);
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		const { data } = this;
 
 		Utils.assert.defined<Contracts.Crypto.IMultiPaymentItem[]>(data.asset?.payments);
 		const { payments } = data.asset;
 
-		const buff: ByteBuffer = ByteBuffer.fromSize(2 + payments.length * 8 + payments.length * this.addressSize);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 
 		buff.writeUint16(payments.length);
 

--- a/packages/crypto-transaction-multi-signature-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-multi-signature-registration/source/versions/1.ts
@@ -77,11 +77,11 @@ export class MultiSignatureRegistrationTransaction extends Transaction {
 		);
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		const { data } = this;
 		Utils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(data.asset?.multiSignature);
 		const { min, publicKeys } = data.asset.multiSignature;
-		const buff: ByteBuffer = ByteBuffer.fromSize(2 + publicKeys.length * this.publicKeySize);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 
 		buff.writeUint8(min);
 		buff.writeUint8(publicKeys.length);

--- a/packages/crypto-transaction-multi-signature-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-multi-signature-registration/source/versions/1.ts
@@ -74,18 +74,14 @@ export class MultiSignatureRegistrationTransaction extends Transaction {
 			1 + // min
 			1 + // number of public keys
 			publicKeys.length * this.publicKeySize // public keys
-		)
+		);
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
 		const { data } = this;
 		Utils.assert.defined<Contracts.Crypto.IMultiSignatureAsset>(data.asset?.multiSignature);
 		const { min, publicKeys } = data.asset.multiSignature;
-		const buff: ByteBuffer = ByteBuffer.fromSize(
-			2 +
-			publicKeys.length *
-			this.publicKeySize,
-		);
+		const buff: ByteBuffer = ByteBuffer.fromSize(2 + publicKeys.length * this.publicKeySize);
 
 		buff.writeUint8(min);
 		buff.writeUint8(publicKeys.length);

--- a/packages/crypto-transaction-transfer/source/versions/1.ts
+++ b/packages/crypto-transaction-transfer/source/versions/1.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "@mainsail/container";
-import { Utils } from "@mainsail/kernel";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { extendSchema, Transaction, transactionBaseSchema } from "@mainsail/crypto-transaction";
+import { Utils } from "@mainsail/kernel";
 import { BigNumber, ByteBuffer } from "@mainsail/utils";
 
 @injectable()
@@ -35,10 +35,10 @@ export class TransferTransaction extends Transaction {
 
 	public assetSize(): number {
 		return (
-			8 +  // amount
+			8 + // amount
 			4 + // expiration
 			this.addressSize // recipient
-		)
+		);
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {

--- a/packages/crypto-transaction-transfer/source/versions/1.ts
+++ b/packages/crypto-transaction-transfer/source/versions/1.ts
@@ -41,9 +41,9 @@ export class TransferTransaction extends Transaction {
 		);
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		const { data } = this;
-		const buff: ByteBuffer = ByteBuffer.fromSize(64);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 		buff.writeUint64(data.amount.toBigInt());
 		buff.writeUint32(data.expiration || 0);
 

--- a/packages/crypto-transaction-username-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-username-registration/source/versions/1.ts
@@ -41,14 +41,14 @@ export abstract class UsernameRegistrationTransaction extends Transaction {
 		);
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		const { data } = this;
 
 		Utils.assert.defined<Contracts.Crypto.ITransactionAsset>(data.asset);
 		Utils.assert.defined<string>(data.asset.username);
 
 		const usernameBytes: Buffer = Buffer.from(data.asset.username, "utf8");
-		const buff: ByteBuffer = ByteBuffer.fromSize(usernameBytes.length + 1);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 
 		buff.writeUint8(usernameBytes.length);
 		buff.writeBytes(usernameBytes);

--- a/packages/crypto-transaction-username-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-username-registration/source/versions/1.ts
@@ -29,6 +29,18 @@ export abstract class UsernameRegistrationTransaction extends Transaction {
 		});
 	}
 
+	public assetSize(): number {
+		const { data } = this;
+
+		Utils.assert.defined<Contracts.Crypto.ITransactionAsset>(data.asset);
+		Utils.assert.defined<string>(data.asset.username);
+
+		return (
+			1 + // length
+			Buffer.byteLength(data.asset.username, "utf-8")
+		)
+	}
+
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
 		const { data } = this;
 

--- a/packages/crypto-transaction-username-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-username-registration/source/versions/1.ts
@@ -38,7 +38,7 @@ export abstract class UsernameRegistrationTransaction extends Transaction {
 		return (
 			1 + // length
 			Buffer.byteLength(data.asset.username, "utf-8")
-		)
+		);
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {

--- a/packages/crypto-transaction-username-resignation/source/versions/1.ts
+++ b/packages/crypto-transaction-username-resignation/source/versions/1.ts
@@ -23,7 +23,7 @@ export class UsernameResignationTransaction extends Transaction {
 		return 0;
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		return ByteBuffer.fromSize(0);
 	}
 

--- a/packages/crypto-transaction-username-resignation/source/versions/1.ts
+++ b/packages/crypto-transaction-username-resignation/source/versions/1.ts
@@ -19,6 +19,10 @@ export class UsernameResignationTransaction extends Transaction {
 		});
 	}
 
+	public assetSize(): number {
+		return 0;
+	}
+
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
 		return ByteBuffer.fromSize(0);
 	}

--- a/packages/crypto-transaction-validator-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-registration/source/versions/1.ts
@@ -33,6 +33,12 @@ export abstract class ValidatorRegistrationTransaction extends Transaction {
 		});
 	}
 
+	public assetSize(): number {
+		return (
+			this.publicKeySize
+		);
+	}
+
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
 		const { data, publicKeySize } = this;
 

--- a/packages/crypto-transaction-validator-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-registration/source/versions/1.ts
@@ -34,9 +34,7 @@ export abstract class ValidatorRegistrationTransaction extends Transaction {
 	}
 
 	public assetSize(): number {
-		return (
-			this.publicKeySize
-		);
+		return this.publicKeySize;
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {

--- a/packages/crypto-transaction-validator-registration/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-registration/source/versions/1.ts
@@ -37,13 +37,13 @@ export abstract class ValidatorRegistrationTransaction extends Transaction {
 		return this.publicKeySize;
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
-		const { data, publicKeySize } = this;
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
+		const { data } = this;
 
 		Utils.assert.defined<Contracts.Crypto.ITransactionAsset>(data.asset);
 		Utils.assert.defined<string>(data.asset.validatorPublicKey);
 
-		const buff: ByteBuffer = ByteBuffer.fromSize(publicKeySize);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 		buff.writeBytes(Buffer.from(data.asset.validatorPublicKey, "hex"));
 
 		return buff;

--- a/packages/crypto-transaction-validator-resignation/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-resignation/source/versions/1.ts
@@ -23,7 +23,7 @@ export class ValidatorResignationTransaction extends Transaction {
 		return 0;
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		return ByteBuffer.fromSize(0);
 	}
 

--- a/packages/crypto-transaction-validator-resignation/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-resignation/source/versions/1.ts
@@ -19,6 +19,11 @@ export class ValidatorResignationTransaction extends Transaction {
 		});
 	}
 
+
+	public assetSize(): number {
+		return 0;
+	}
+
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
 		return ByteBuffer.fromSize(0);
 	}

--- a/packages/crypto-transaction-validator-resignation/source/versions/1.ts
+++ b/packages/crypto-transaction-validator-resignation/source/versions/1.ts
@@ -19,7 +19,6 @@ export class ValidatorResignationTransaction extends Transaction {
 		});
 	}
 
-
 	public assetSize(): number {
 		return 0;
 	}

--- a/packages/crypto-transaction-vote/source/versions/1.ts
+++ b/packages/crypto-transaction-vote/source/versions/1.ts
@@ -56,9 +56,9 @@ export class VoteTransaction extends Transaction {
 		return (
 			1 + // number of votes
 			1 + // number of unvotes
-			(this.publicKeySize * data.asset.votes.length) +// size of votes
-			(this.publicKeySize * data.asset.unvotes.length)// size of unvotes
-		)
+			this.publicKeySize * data.asset.votes.length + // size of votes
+			this.publicKeySize * data.asset.unvotes.length // size of unvotes
+		);
 	}
 
 	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {

--- a/packages/crypto-transaction-vote/source/versions/1.ts
+++ b/packages/crypto-transaction-vote/source/versions/1.ts
@@ -61,12 +61,10 @@ export class VoteTransaction extends Transaction {
 		);
 	}
 
-	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer | undefined> {
+	public async serialize(options?: Contracts.Crypto.ISerializeOptions): Promise<ByteBuffer> {
 		const { data } = this;
 		Utils.assert.defined<Contracts.Crypto.IVoteAsset>(data.asset);
-		const buff: ByteBuffer = ByteBuffer.fromSize(
-			1 + 1 + this.publicKeySize * data.asset.votes.length + this.publicKeySize * data.asset.unvotes.length,
-		);
+		const buff: ByteBuffer = ByteBuffer.fromSize(this.assetSize());
 
 		// TODO: Check asset
 

--- a/packages/crypto-transaction/source/serializer.ts
+++ b/packages/crypto-transaction/source/serializer.ts
@@ -57,7 +57,7 @@ export class Serializer implements Contracts.Crypto.ITransactionSerializer {
 
 	public signaturesSize(
 		transaction: Contracts.Crypto.ITransaction,
-		options: Contracts.Crypto.ISerializeOptions = {}
+		options: Contracts.Crypto.ISerializeOptions = {},
 	): number {
 		let size = 0;
 
@@ -67,14 +67,16 @@ export class Serializer implements Contracts.Crypto.ITransactionSerializer {
 		}
 
 		if (data.signatures && !options.excludeMultiSignature) {
-			size += (data.signatures.length * (1 + this.signatureSize) /* 1 additional byte for index */);
+			size += data.signatures.length * (1 + this.signatureSize) /* 1 additional byte for index */;
 		}
 
 		return size;
 	}
 
-	public totalSize(transaction: Contracts.Crypto.ITransaction,
-		options: Contracts.Crypto.ISerializeOptions = {}): number {
+	public totalSize(
+		transaction: Contracts.Crypto.ITransaction,
+		options: Contracts.Crypto.ISerializeOptions = {},
+	): number {
 		return (
 			this.commonSize(transaction) +
 			this.vendorFieldSize(transaction) +
@@ -105,7 +107,9 @@ export class Serializer implements Contracts.Crypto.ITransactionSerializer {
 
 		const bufferBuffer = buff.getResult();
 		if (bufferBuffer.length !== bufferSize) {
-			throw new Exceptions.InvalidTransactionBytesError(`expected size ${bufferSize} actual size: ${bufferBuffer.length}`);
+			throw new Exceptions.InvalidTransactionBytesError(
+				`expected size ${bufferSize} actual size: ${bufferBuffer.length}`,
+			);
 		}
 
 		transaction.serialized = bufferBuffer;

--- a/packages/crypto-transaction/source/types/transaction.ts
+++ b/packages/crypto-transaction/source/types/transaction.ts
@@ -50,6 +50,7 @@ export abstract class Transaction implements Contracts.Crypto.ITransaction {
 		return false;
 	}
 
+	public abstract assetSize(): number;
 	public abstract serialize(): Promise<ByteBuffer | undefined>;
 	public abstract deserialize(buf: ByteBuffer): Promise<void>;
 }

--- a/packages/crypto-transaction/source/types/transaction.ts
+++ b/packages/crypto-transaction/source/types/transaction.ts
@@ -51,6 +51,6 @@ export abstract class Transaction implements Contracts.Crypto.ITransaction {
 	}
 
 	public abstract assetSize(): number;
-	public abstract serialize(): Promise<ByteBuffer | undefined>;
+	public abstract serialize(): Promise<ByteBuffer>;
 	public abstract deserialize(buf: ByteBuffer): Promise<void>;
 }

--- a/packages/transactions/source/handlers/handler-registry.test.ts
+++ b/packages/transactions/source/handlers/handler-registry.test.ts
@@ -46,7 +46,7 @@ abstract class TestTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "test";
 
-	async deserialize(buf: ByteBuffer): Promise<void> {}
+	async deserialize(buf: ByteBuffer): Promise<void> { }
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -64,7 +64,7 @@ abstract class TestDeactivatedTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "deactivated_test";
 
-	async deserialize(buf: ByteBuffer): Promise<void> {}
+	async deserialize(buf: ByteBuffer): Promise<void> { }
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -82,7 +82,7 @@ abstract class TestWithDependencyTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "test_with_dependency";
 
-	async deserialize(buf: ByteBuffer): Promise<void> {}
+	async deserialize(buf: ByteBuffer): Promise<void> { }
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -116,9 +116,9 @@ class TestTransactionHandler extends TransactionHandler {
 		return true;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 }
 
 class TestDeactivatedTransactionHandler extends TransactionHandler {
@@ -142,9 +142,9 @@ class TestDeactivatedTransactionHandler extends TransactionHandler {
 		return false;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 }
 
 class TestWithDependencyTransactionHandler extends TransactionHandler {
@@ -168,9 +168,9 @@ class TestWithDependencyTransactionHandler extends TransactionHandler {
 		return false;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
 }
 
 describe<{
@@ -200,6 +200,8 @@ describe<{
 		app.bind(Identifiers.Cryptography.Transaction.Utils).to(Utils);
 		app.bind(Identifiers.Cryptography.Transaction.Serializer).to(Serializer);
 		app.bind(Identifiers.Cryptography.HashFactory).to(HashFactory);
+		app.bind(Identifiers.Cryptography.Size.PublicKey).toConstantValue(32);
+		app.bind(Identifiers.Cryptography.Size.Signature).toConstantValue(64);
 
 		app.bind(Identifiers.TransactionHandler).to(TransferTransactionHandler);
 		app.bind(Identifiers.TransactionHandler).to(ValidatorRegistrationTransactionHandler);

--- a/packages/transactions/source/handlers/handler-registry.test.ts
+++ b/packages/transactions/source/handlers/handler-registry.test.ts
@@ -46,7 +46,7 @@ abstract class TestTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "test";
 
-	async deserialize(buf: ByteBuffer): Promise<void> { }
+	async deserialize(buf: ByteBuffer): Promise<void> {}
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -64,7 +64,7 @@ abstract class TestDeactivatedTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "deactivated_test";
 
-	async deserialize(buf: ByteBuffer): Promise<void> { }
+	async deserialize(buf: ByteBuffer): Promise<void> {}
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -82,7 +82,7 @@ abstract class TestWithDependencyTransaction extends Transaction {
 	public static typeGroup: number = Contracts.Crypto.TransactionTypeGroup.Test;
 	public static key = "test_with_dependency";
 
-	async deserialize(buf: ByteBuffer): Promise<void> { }
+	async deserialize(buf: ByteBuffer): Promise<void> {}
 
 	async serialize(): Promise<ByteBuffer | undefined> {
 		return undefined;
@@ -116,9 +116,9 @@ class TestTransactionHandler extends TransactionHandler {
 		return true;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 }
 
 class TestDeactivatedTransactionHandler extends TransactionHandler {
@@ -142,9 +142,9 @@ class TestDeactivatedTransactionHandler extends TransactionHandler {
 		return false;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 }
 
 class TestWithDependencyTransactionHandler extends TransactionHandler {
@@ -168,9 +168,9 @@ class TestWithDependencyTransactionHandler extends TransactionHandler {
 		return false;
 	}
 
-	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async applyToRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 
-	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> { }
+	async revertForRecipient(transaction: Contracts.Crypto.ITransaction): Promise<void> {}
 }
 
 describe<{


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Instead of allocating a way too large buffer when serializing transactions, we can precisely determine how big the buffer needs to be.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
