### PR TITLE
refactor(crypto-transaction-username-registration): stricter username regex

### DIFF
--- a/packages/crypto-transaction-username-registration/source/validation/schemas.test.ts
+++ b/packages/crypto-transaction-username-registration/source/validation/schemas.test.ts
@@ -34,7 +34,7 @@ describe<{
 		assert.undefined(validator.validate("username", "0".repeat(1)).error);
 		assert.undefined(validator.validate("username", "0".repeat(20)).error);
 
-		const validChars = "0123456789abcdefghijklmnopqrstuvwxyz!@$&_.";
+		const validChars = "0123456789abcdefghijklmnopqrstuvwxyz_";
 
 		for (const char of validChars) {
 			assert.undefined(validator.validate("username", char.repeat(20)).error);
@@ -43,12 +43,13 @@ describe<{
 
 	it("username - should not be ok", ({ validator }) => {
 		assert.defined(validator.validate("username", "0".repeat(21)).error);
+		assert.defined(validator.validate("username", "").error);
 		assert.defined(validator.validate("username", 123).error);
 		assert.defined(validator.validate("username", null).error);
 		assert.defined(validator.validate("username").error);
 		assert.defined(validator.validate("username", {}).error);
 
-		const invalidChars = "ABCDEFGHJKLMNPQRSTUVWXYZ+-?";
+		const invalidChars = "ABCDEFGHJKLMNPQRSTUVWXYZ+-?!@$&.";
 
 		for (const char of invalidChars) {
 			assert.defined(validator.validate("username", char.repeat(20)).error);

--- a/packages/crypto-transaction-username-registration/source/validation/schemas.test.ts
+++ b/packages/crypto-transaction-username-registration/source/validation/schemas.test.ts
@@ -33,8 +33,9 @@ describe<{
 	it("username - should be ok", ({ validator }) => {
 		assert.undefined(validator.validate("username", "0".repeat(1)).error);
 		assert.undefined(validator.validate("username", "0".repeat(20)).error);
+		assert.undefined(validator.validate("username", "a_a").error);
 
-		const validChars = "0123456789abcdefghijklmnopqrstuvwxyz_";
+		const validChars = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 		for (const char of validChars) {
 			assert.undefined(validator.validate("username", char.repeat(20)).error);
@@ -48,6 +49,10 @@ describe<{
 		assert.defined(validator.validate("username", null).error);
 		assert.defined(validator.validate("username").error);
 		assert.defined(validator.validate("username", {}).error);
+
+		assert.defined(validator.validate("username", "_a").error);
+		assert.defined(validator.validate("username", "a_").error);
+		assert.defined(validator.validate("username", "a__a").error);
 
 		const invalidChars = "ABCDEFGHJKLMNPQRSTUVWXYZ+-?!@$&.";
 

--- a/packages/crypto-transaction-username-registration/source/validation/schemas.ts
+++ b/packages/crypto-transaction-username-registration/source/validation/schemas.ts
@@ -2,7 +2,7 @@ export const schemas = {
 	username: {
 		$id: "username",
 		allOf: [
-			{ pattern: "^[a-z0-9_]+$", type: "string" },
+			{ pattern: "^(?!_)(?!.*_$)(?!.*__)[a-z0-9_]+$", type: "string" }, // Allow only lowercase letters, numbers and underscores, underscores can be used only once in a row and not at the beginning or end of the string
 			{ maxLength: 20, minLength: 1 },
 		],
 		type: "string",

--- a/packages/crypto-transaction-username-registration/source/validation/schemas.ts
+++ b/packages/crypto-transaction-username-registration/source/validation/schemas.ts
@@ -2,9 +2,8 @@ export const schemas = {
 	username: {
 		$id: "username",
 		allOf: [
-			{ pattern: "^[a-z0-9!@$&_.]+$", type: "string" },
+			{ pattern: "^[a-z0-9_]+$", type: "string" },
 			{ maxLength: 20, minLength: 1 },
-			{ transform: ["toLowerCase"] },
 		],
 		type: "string",
 	},


### PR DESCRIPTION
## Summary

Allow only lowercase letters, numbers and underscores, underscores can be used only once in a row and not at the beginning or end of the string.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged