### PR TITLE
fix(crypto-transactions): use correct signature size checks in deserializer

### DIFF
--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -69,12 +69,12 @@ export class Deserializer implements Contracts.Crypto.ITransactionDeserializer {
 	#deserializeSignatures(transaction: Contracts.Crypto.ITransactionData, buf: ByteBuffer): void {
 		// @TODO: take into account what the length of signatures is based on plugins
 		// Check the length of the reminder: if only one signature is left or if the length is not a multiple of multisignature length, it's a single signature
-		const canReadNonMultiSignature = () =>
+		const canReadSignature = () =>
 			buf.getRemainderLength() &&
 			(buf.getRemainderLength() % this.signatureSize === 0 ||
 				buf.getRemainderLength() % (this.signatureSize + 1) !== 0);
 
-		if (canReadNonMultiSignature()) {
+		if (canReadSignature()) {
 			transaction.signature = this.signatureSerializer.deserialize(buf).toString("hex");
 		}
 

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -76,13 +76,13 @@ export class Deserializer implements Contracts.Crypto.ITransactionDeserializer {
 		}
 
 		if (buf.getRemainderLength()) {
-			if (buf.getRemainderLength() % this.signatureSize === 0) {
+			if (buf.getRemainderLength() % (this.signatureSize + 1) === 0) {
 				transaction.signatures = [];
 
-				const count: number = buf.getRemainderLength() / 65;
+				const count: number = buf.getRemainderLength() / (this.signatureSize + 1);
 				const publicKeyIndexes: { [index: number]: boolean } = {};
 				for (let index = 0; index < count; index++) {
-					const multiSignaturePart: string = buf.readBytes(65).toString("hex");
+					const multiSignaturePart: string = buf.readBytes(this.signatureSize + 1).toString("hex");
 					const publicKeyIndex: number = Number.parseInt(multiSignaturePart.slice(0, 2), 16);
 
 					if (!publicKeyIndexes[publicKeyIndex]) {

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -68,8 +68,11 @@ export class Deserializer implements Contracts.Crypto.ITransactionDeserializer {
 
 	#deserializeSignatures(transaction: Contracts.Crypto.ITransactionData, buf: ByteBuffer): void {
 		// @TODO: take into account what the length of signatures is based on plugins
+		// Check the length of the reminder: if wonly one signature is left or if the length is not a multiple of multisignature length, it's a single signature
 		const canReadNonMultiSignature = () =>
-			buf.getRemainderLength() && (buf.getRemainderLength() % 64 === 0 || buf.getRemainderLength() % 65 !== 0);
+			buf.getRemainderLength() &&
+			(buf.getRemainderLength() % this.signatureSize === 0 ||
+				buf.getRemainderLength() % (this.signatureSize + 1) !== 0);
 
 		if (canReadNonMultiSignature()) {
 			transaction.signature = this.signatureSerializer.deserialize(buf).toString("hex");

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -69,12 +69,11 @@ export class Deserializer implements Contracts.Crypto.ITransactionDeserializer {
 	#deserializeSignatures(transaction: Contracts.Crypto.ITransactionData, buf: ByteBuffer): void {
 		// @TODO: take into account what the length of signatures is based on plugins
 		// Check the length of the reminder: if only one signature is left or if the length is not a multiple of multisignature length, it's a single signature
-		const canReadSignature = () =>
+		if (
 			buf.getRemainderLength() &&
 			(buf.getRemainderLength() % this.signatureSize === 0 ||
-				buf.getRemainderLength() % (this.signatureSize + 1) !== 0);
-
-		if (canReadSignature()) {
+				buf.getRemainderLength() % (this.signatureSize + 1) !== 0)
+		) {
 			transaction.signature = this.signatureSerializer.deserialize(buf).toString("hex");
 		}
 

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -68,7 +68,7 @@ export class Deserializer implements Contracts.Crypto.ITransactionDeserializer {
 
 	#deserializeSignatures(transaction: Contracts.Crypto.ITransactionData, buf: ByteBuffer): void {
 		// @TODO: take into account what the length of signatures is based on plugins
-		// Check the length of the reminder: if wonly one signature is left or if the length is not a multiple of multisignature length, it's a single signature
+		// Check the length of the reminder: if only one signature is left or if the length is not a multiple of multisignature length, it's a single signature
 		const canReadNonMultiSignature = () =>
 			buf.getRemainderLength() &&
 			(buf.getRemainderLength() % this.signatureSize === 0 ||


### PR DESCRIPTION
## Summary

Multisignaure check should use additional byte for musig index.

## Checklist

- [x] Ready to be merged
