### PR TITLE
fix(api-sync): enable listeners during service provider boot

### DIFF
--- a/packages/api-sync/source/service-provider.ts
+++ b/packages/api-sync/source/service-provider.ts
@@ -1,4 +1,4 @@
-import { interfaces, postConstruct } from "@mainsail/container";
+import { interfaces } from "@mainsail/container";
 import { Identifiers } from "@mainsail/contracts";
 import { Providers } from "@mainsail/kernel";
 
@@ -18,8 +18,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		await this.#registerListeners();
 	}
 
-	@postConstruct()
-	public async initialize(): Promise<void> {
+	public async boot(): Promise<void> {
 		await this.#bootListeners();
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix wrong initialization order and remove `postConstruct` in favour of service provider `boot`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
