### PR TITLE
refactor(api-http): disable total count estimation for peers table

### DIFF
--- a/packages/api-http/source/controllers/peers.ts
+++ b/packages/api-http/source/controllers/peers.ts
@@ -6,6 +6,7 @@ import {
 	Search,
 } from "@mainsail/api-database";
 import { inject, injectable } from "@mainsail/container";
+import { Contracts } from "@mainsail/contracts";
 
 import { PeerResource } from "../resources/peer";
 import { Controller } from "./controller";
@@ -40,5 +41,11 @@ export class PeersController extends Controller {
 		}
 
 		return this.respondWithResource(peer, PeerResource, request.query.transform);
+	}
+
+	protected getListingOptions(): Contracts.Api.Options {
+		return {
+			estimateTotalCount: false
+		};
 	}
 }

--- a/packages/api-http/source/controllers/peers.ts
+++ b/packages/api-http/source/controllers/peers.ts
@@ -45,7 +45,7 @@ export class PeersController extends Controller {
 
 	protected getListingOptions(): Contracts.Api.Options {
 		return {
-			estimateTotalCount: false
+			estimateTotalCount: false,
 		};
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
We do not need total count estimation for the `peers` table. Other tables can grow quite large so we generally want to keep it for performance reasons.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
