### PR TITLE
fix(p2p): await consensus handler on block download 

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -325,12 +325,12 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 				await this.app.terminate("Failed to commit block", error);
 			}
 
+			await this.storage.clear();
+			this.roundStateRepository.clear();
+
 			this.#height++;
 			this.#lockedValue = undefined;
 			this.#validValue = undefined;
-
-			this.roundStateRepository.clear();
-			await this.storage.clear();
 
 			await this.startRound(0);
 		});

--- a/packages/contracts/source/contracts/consensus/consensus.ts
+++ b/packages/contracts/source/contracts/consensus/consensus.ts
@@ -1,7 +1,7 @@
 import { IAggregatedSignature, ICommittedBlock, IPrecommit, IPrevote, IProposal } from "../crypto";
 import { IProcessableUnit } from "../processor";
 import { IValidatorWallet } from "../state";
-import { ProcessorResult, Step } from "./enums";
+import { Step } from "./enums";
 
 export interface IRoundState extends IProcessableUnit {
 	readonly validators: string[];
@@ -97,20 +97,4 @@ export interface IScheduler {
 	scheduleTimeoutPrevote(height: number, round: number): void;
 	scheduleTimeoutPrecommit(height: number, round: number): void;
 	clear(): void;
-}
-
-export interface IProposalProcessor {
-	process(proposal: IProposal, broadcast?: boolean): Promise<ProcessorResult>;
-}
-
-export interface IPrevoteProcessor {
-	process(prevote: IPrevote, broadcast?: boolean): Promise<ProcessorResult>;
-}
-
-export interface IPrecommitProcessor {
-	process(prevote: IPrecommit, broadcast?: boolean): Promise<ProcessorResult>;
-}
-
-export interface ICommittedBlockProcessor {
-	process(committedBlock: ICommittedBlock, broadcast?: boolean): Promise<ProcessorResult>;
 }

--- a/packages/contracts/source/contracts/consensus/index.ts
+++ b/packages/contracts/source/contracts/consensus/index.ts
@@ -1,2 +1,3 @@
 export * from "./consensus";
 export * from "./enums";
+export * from "./processor";

--- a/packages/contracts/source/contracts/consensus/processor.ts
+++ b/packages/contracts/source/contracts/consensus/processor.ts
@@ -1,0 +1,18 @@
+import { ICommittedBlock, IPrecommit, IPrevote, IProposal } from "../crypto";
+import { ProcessorResult } from "./enums";
+
+export interface IProposalProcessor {
+	process(proposal: IProposal, broadcast?: boolean): Promise<ProcessorResult>;
+}
+
+export interface IPrevoteProcessor {
+	process(prevote: IPrevote, broadcast?: boolean): Promise<ProcessorResult>;
+}
+
+export interface IPrecommitProcessor {
+	process(prevote: IPrecommit, broadcast?: boolean): Promise<ProcessorResult>;
+}
+
+export interface ICommittedBlockProcessor {
+	process(committedBlock: ICommittedBlock, broadcast?: boolean): Promise<ProcessorResult>;
+}


### PR DESCRIPTION
## Summary

Await consensus handler to process block before checking if new block can be downloaded. Fixes the issue with multiple downloads for same block, which occurred because promise was resolved before height was increased. 

Consensus height and round are increased atomically, without intermediate awaits. 

## Checklist

- [x] Ready to be merged
