### PR TITLE
perf: get rid of unnecessary transaction serializations

### DIFF
--- a/packages/api-sync/source/listeners/abstract-listener.ts
+++ b/packages/api-sync/source/listeners/abstract-listener.ts
@@ -110,7 +110,8 @@ export abstract class AbstractListener<TEventData, TEntity extends { [key: strin
 			const entityRepository = this.makeEntityRepository(entityManager);
 
 			this.logger.debug(
-				`syncing ${entityRepository.metadata.tableNameWithoutPrefix} to database (added: ${this.#addedEvents.size
+				`syncing ${entityRepository.metadata.tableNameWithoutPrefix} to database (added: ${
+					this.#addedEvents.size
 				} removed: ${this.#removedEvents.size}))`,
 			);
 
@@ -138,14 +139,14 @@ export abstract class AbstractListener<TEventData, TEntity extends { [key: strin
 	async #truncate(): Promise<void> {
 		try {
 			await this.makeEntityRepository(this.dataSource).clear();
-		} catch (ex) {
-			if (ex.code === '42P01') {
+		} catch (error) {
+			if (error.code === "42P01") {
 				// ignore 'relation "xxx" does not exist' errors when
 				// starting with an empty database.
 				return;
 			}
 
-			throw ex;
+			throw error;
 		}
 	}
 }

--- a/packages/api-sync/source/listeners/abstract-listener.ts
+++ b/packages/api-sync/source/listeners/abstract-listener.ts
@@ -137,6 +137,16 @@ export abstract class AbstractListener<TEventData, TEntity extends { [key: strin
 	}
 
 	async #truncate(): Promise<void> {
-		await this.makeEntityRepository(this.dataSource).clear();
+		try {
+			await this.makeEntityRepository(this.dataSource).clear();
+		} catch (ex) {
+			if (ex.code === '42P01') {
+				// ignore 'relation "xxx" does not exist' errors when
+				// starting with an empty database.
+				return;
+			}
+
+			throw ex;
+		}
 	}
 }

--- a/packages/api-sync/source/listeners/abstract-listener.ts
+++ b/packages/api-sync/source/listeners/abstract-listener.ts
@@ -110,8 +110,7 @@ export abstract class AbstractListener<TEventData, TEntity extends { [key: strin
 			const entityRepository = this.makeEntityRepository(entityManager);
 
 			this.logger.debug(
-				`syncing ${entityRepository.metadata.tableNameWithoutPrefix} to database (added: ${
-					this.#addedEvents.size
+				`syncing ${entityRepository.metadata.tableNameWithoutPrefix} to database (added: ${this.#addedEvents.size
 				} removed: ${this.#removedEvents.size}))`,
 			);
 

--- a/packages/api-sync/source/listeners/abstract-listener.ts
+++ b/packages/api-sync/source/listeners/abstract-listener.ts
@@ -137,16 +137,6 @@ export abstract class AbstractListener<TEventData, TEntity extends { [key: strin
 	}
 
 	async #truncate(): Promise<void> {
-		try {
-			await this.makeEntityRepository(this.dataSource).clear();
-		} catch (error) {
-			if (error.code === "42P01") {
-				// ignore 'relation "xxx" does not exist' errors when
-				// starting with an empty database.
-				return;
-			}
-
-			throw error;
-		}
+		await this.makeEntityRepository(this.dataSource).clear();
 	}
 }

--- a/packages/api-transaction-pool/source/controllers/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/controllers/transaction-pool.ts
@@ -9,8 +9,8 @@ export class TransactionsController extends AbstractController {
 	private readonly processor!: Contracts.TransactionPool.Processor;
 
 	public async store(request: Hapi.Request) {
-		// @ts-ignore
 		const result = await this.processor.process(
+			// @ts-ignore
 			request.payload.transactions.map((transaction: string) => Buffer.from(transaction, "hex")),
 		);
 		return {

--- a/packages/api-transaction-pool/source/controllers/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/controllers/transaction-pool.ts
@@ -10,7 +10,7 @@ export class TransactionsController extends AbstractController {
 
 	public async store(request: Hapi.Request) {
 		// @ts-ignore
-		const result = await this.processor.process(request.payload.transactions);
+		const result = await this.processor.process(request.payload.transactions.map((transaction: string) => Buffer.from(transaction, "hex")));
 		return {
 			data: {
 				accept: result.accept,

--- a/packages/api-transaction-pool/source/controllers/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/controllers/transaction-pool.ts
@@ -10,7 +10,9 @@ export class TransactionsController extends AbstractController {
 
 	public async store(request: Hapi.Request) {
 		// @ts-ignore
-		const result = await this.processor.process(request.payload.transactions.map((transaction: string) => Buffer.from(transaction, "hex")));
+		const result = await this.processor.process(
+			request.payload.transactions.map((transaction: string) => Buffer.from(transaction, "hex")),
+		);
 		return {
 			data: {
 				accept: result.accept,

--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -18,7 +18,6 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 						additionalProperties: false,
 						properties: {
 							transactions: {
-								$ref: "transactions",
 								items: {
 									allOf: [{ $ref: "hex" }, { maxLength: 4096 /* arbitrary cap */ }],
 									maxItems: server.app.app

--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -19,14 +19,18 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 						properties: {
 							transactions: {
 								$ref: "transactions",
-								maxItems: server.app.app
-									.getTagged<Providers.PluginConfiguration>(
-										Identifiers.PluginConfiguration,
-										"plugin",
-										"transaction-pool",
-									)
-									.get<number>("maxTransactionsPerRequest"),
-								minItems: 1,
+								items: {
+									allOf: [{ $ref: "hex" }, { maxLength: 4096 /* arbitrary cap */ }],
+									type: "array",
+									maxItems: server.app.app
+										.getTagged<Providers.PluginConfiguration>(
+											Identifiers.PluginConfiguration,
+											"plugin",
+											"transaction-pool",
+										)
+										.get<number>("maxTransactionsPerRequest"),
+									minItems: 1,
+								},
 							},
 						},
 						required: ["transactions"],

--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -21,7 +21,6 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 								$ref: "transactions",
 								items: {
 									allOf: [{ $ref: "hex" }, { maxLength: 4096 /* arbitrary cap */ }],
-									type: "array",
 									maxItems: server.app.app
 										.getTagged<Providers.PluginConfiguration>(
 											Identifiers.PluginConfiguration,
@@ -30,6 +29,7 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 										)
 										.get<number>("maxTransactionsPerRequest"),
 									minItems: 1,
+									type: "array",
 								},
 							},
 						},

--- a/packages/configuration-generator/source/generators/genesis-block.ts
+++ b/packages/configuration-generator/source/generators/genesis-block.ts
@@ -175,7 +175,7 @@ export class GenesisBlockGenerator extends Generator {
 			.sign(transaction.data, wallet.keys);
 		transaction.data.id = await this.app
 			.get<Contracts.Crypto.ITransactionUtils>(Identifiers.Cryptography.Transaction.Utils)
-			.getId(transaction.data);
+			.getId(transaction);
 
 		return transaction;
 	}

--- a/packages/contracts/source/contracts/crypto/block.ts
+++ b/packages/contracts/source/contracts/crypto/block.ts
@@ -114,8 +114,6 @@ export interface IBlockFactory {
 
 	fromProposedBytes(buff: Buffer): Promise<IProposedBlock>;
 
-	fromProposedJson(json: IProposedBlockJson): Promise<IProposedBlock>;
-
 	fromCommittedBytes(buff: Buffer): Promise<ICommittedBlock>;
 
 	fromCommittedJson(json: ICommittedBlockJson): Promise<ICommittedBlock>;

--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -170,7 +170,5 @@ export interface ITransactionUtils {
 
 	toHash(transaction: ITransactionData, options?: ISerializeOptions): Promise<Buffer>;
 
-	getId(transaction: ITransactionData, options?: ISerializeOptions): Promise<string>;
-
-	getIdFromHex(serialized: string): Promise<string>;
+	getId(transaction: ITransaction): Promise<string>;
 }

--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -171,4 +171,6 @@ export interface ITransactionUtils {
 	toHash(transaction: ITransactionData, options?: ISerializeOptions): Promise<Buffer>;
 
 	getId(transaction: ITransactionData, options?: ISerializeOptions): Promise<string>;
+
+	getIdFromHex(serialized: string): Promise<string>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/processor.ts
+++ b/packages/contracts/source/contracts/transaction-pool/processor.ts
@@ -1,4 +1,4 @@
-import { ITransaction, ITransactionJson } from "../crypto";
+import { ITransaction } from "../crypto";
 
 export type ProcessorError = {
 	type: string;
@@ -18,7 +18,7 @@ export interface ProcessorExtension {
 }
 
 export interface Processor {
-	process(data: ITransactionJson[] | Buffer[]): Promise<ProcessorResult>;
+	process(data: Buffer[]): Promise<ProcessorResult>;
 }
 
 export type ProcessorFactory = () => Processor;

--- a/packages/crypto-block/source/factory.ts
+++ b/packages/crypto-block/source/factory.ts
@@ -73,16 +73,6 @@ export class BlockFactory implements Contracts.Crypto.IBlockFactory {
 	}
 
 	// TODO: separate factory ?
-	public async fromProposedJson(json: Contracts.Crypto.IProposedBlockJson): Promise<Contracts.Crypto.IProposedBlock> {
-		const block = await this.fromJson(json.block);
-		return {
-			block,
-			lockProof: json.lockProof,
-			serialized: json.serialized,
-		};
-	}
-
-	// TODO: separate factory ?
 	public async fromCommittedBytes(buff: Buffer): Promise<Contracts.Crypto.ICommittedBlock> {
 		const buffer = ByteBuffer.fromBuffer(buff);
 
@@ -165,7 +155,7 @@ export class BlockFactory implements Contracts.Crypto.IBlockFactory {
 				throw new Exceptions.BlockSchemaError(
 					data.height,
 					`Invalid data${error.instancePath ? " at " + error.instancePath : ""}: ` +
-						`${error.message}: ${JSON.stringify(error.data)}`,
+					`${error.message}: ${JSON.stringify(error.data)}`,
 				);
 			}
 		}

--- a/packages/crypto-block/source/factory.ts
+++ b/packages/crypto-block/source/factory.ts
@@ -155,7 +155,7 @@ export class BlockFactory implements Contracts.Crypto.IBlockFactory {
 				throw new Exceptions.BlockSchemaError(
 					data.height,
 					`Invalid data${error.instancePath ? " at " + error.instancePath : ""}: ` +
-					`${error.message}: ${JSON.stringify(error.data)}`,
+						`${error.message}: ${JSON.stringify(error.data)}`,
 				);
 			}
 		}

--- a/packages/crypto-transaction/source/builders.ts
+++ b/packages/crypto-transaction/source/builders.ts
@@ -145,6 +145,14 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 		return struct;
 	}
 
+	public async toSerializedHex(): Promise<string> {
+		if (!this.data.senderPublicKey || (!this.data.signature && !this.data.signatures)) {
+			throw new Exceptions.MissingTransactionSignatureError();
+		}
+
+		return (await this.utils.toBytes(this.data)).toString("hex");
+	}
+
 	async #signWithKeyPair(keys: Contracts.Crypto.IKeyPair): Promise<TBuilder> {
 		this.data.senderPublicKey = keys.publicKey;
 

--- a/packages/crypto-transaction/source/builders.ts
+++ b/packages/crypto-transaction/source/builders.ts
@@ -128,7 +128,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 
 		const struct: Contracts.Crypto.ITransactionData = {
 			fee: this.data.fee,
-			id: await this.utils.getId(this.data),
+			id: await this.utils.getId(await this.build()),
 			network: this.data.network,
 			nonce: this.data.nonce,
 			senderPublicKey: this.data.senderPublicKey,

--- a/packages/crypto-transaction/source/builders.ts
+++ b/packages/crypto-transaction/source/builders.ts
@@ -145,14 +145,6 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 		return struct;
 	}
 
-	public async toSerializedHex(): Promise<string> {
-		if (!this.data.senderPublicKey || (!this.data.signature && !this.data.signatures)) {
-			throw new Exceptions.MissingTransactionSignatureError();
-		}
-
-		return (await this.utils.toBytes(this.data)).toString("hex");
-	}
-
 	async #signWithKeyPair(keys: Contracts.Crypto.IKeyPair): Promise<TBuilder> {
 		this.data.senderPublicKey = keys.publicKey;
 

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -53,7 +53,7 @@ export class TransactionFactory implements Contracts.Crypto.ITransactionFactory 
 	async #fromSerialized(serialized: string, strict = true): Promise<Contracts.Crypto.ITransaction> {
 		try {
 			const transaction = await this.deserializer.deserialize(serialized);
-			transaction.data.id = await this.utils.getIdFromHex(serialized);
+			transaction.data.id = await this.utils.getId(transaction);
 
 			const { error } = await this.verifier.verifySchema(transaction.data, strict);
 

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -53,7 +53,7 @@ export class TransactionFactory implements Contracts.Crypto.ITransactionFactory 
 	async #fromSerialized(serialized: string, strict = true): Promise<Contracts.Crypto.ITransaction> {
 		try {
 			const transaction = await this.deserializer.deserialize(serialized);
-			transaction.data.id = await this.utils.getId(transaction.data);
+			transaction.data.id = await this.utils.getIdFromHex(serialized);
 
 			const { error } = await this.verifier.verifySchema(transaction.data, strict);
 

--- a/packages/crypto-transaction/source/utils.ts
+++ b/packages/crypto-transaction/source/utils.ts
@@ -30,9 +30,7 @@ export class Utils implements Contracts.Crypto.ITransactionUtils {
 		return (await this.toHash(transaction, options)).toString("hex");
 	}
 
-	public async getIdFromHex(
-		serialized: string,
-	): Promise<string> {
+	public async getIdFromHex(serialized: string): Promise<string> {
 		return (await this.hashFactory.sha256(Buffer.from(serialized, "hex"))).toString("hex");
 	}
 }

--- a/packages/crypto-transaction/source/utils.ts
+++ b/packages/crypto-transaction/source/utils.ts
@@ -29,4 +29,10 @@ export class Utils implements Contracts.Crypto.ITransactionUtils {
 	): Promise<string> {
 		return (await this.toHash(transaction, options)).toString("hex");
 	}
+
+	public async getIdFromHex(
+		serialized: string,
+	): Promise<string> {
+		return (await this.hashFactory.sha256(Buffer.from(serialized, "hex"))).toString("hex");
+	}
 }

--- a/packages/crypto-transaction/source/utils.ts
+++ b/packages/crypto-transaction/source/utils.ts
@@ -24,13 +24,8 @@ export class Utils implements Contracts.Crypto.ITransactionUtils {
 	}
 
 	public async getId(
-		transaction: Contracts.Crypto.ITransactionData,
-		options: Contracts.Crypto.ISerializeOptions = {},
+		transaction: Contracts.Crypto.ITransaction,
 	): Promise<string> {
-		return (await this.toHash(transaction, options)).toString("hex");
-	}
-
-	public async getIdFromHex(serialized: string): Promise<string> {
-		return (await this.hashFactory.sha256(Buffer.from(serialized, "hex"))).toString("hex");
+		return (await this.hashFactory.sha256(transaction.serialized)).toString("hex");
 	}
 }

--- a/packages/crypto-transaction/source/utils.ts
+++ b/packages/crypto-transaction/source/utils.ts
@@ -23,9 +23,7 @@ export class Utils implements Contracts.Crypto.ITransactionUtils {
 		return this.hashFactory.sha256(await this.serializer.getBytes(transaction, options));
 	}
 
-	public async getId(
-		transaction: Contracts.Crypto.ITransaction,
-	): Promise<string> {
+	public async getId(transaction: Contracts.Crypto.ITransaction): Promise<string> {
 		return (await this.hashFactory.sha256(transaction.serialized)).toString("hex");
 	}
 }

--- a/packages/transaction-pool/source/processor.test.ts
+++ b/packages/transaction-pool/source/processor.test.ts
@@ -34,7 +34,7 @@ describe<{
 			},
 			fromBytes: (bytes) => {
 				return {};
-			}
+			},
 		};
 
 		context.blockSerializer = {

--- a/packages/transaction-pool/source/processor.test.ts
+++ b/packages/transaction-pool/source/processor.test.ts
@@ -32,6 +32,9 @@ describe<{
 			fromJson: (tx) => {
 				return tx;
 			},
+			fromBytes: (bytes) => {
+				return {};
+			}
 		};
 
 		context.blockSerializer = {

--- a/packages/transaction-pool/source/processor.ts
+++ b/packages/transaction-pool/source/processor.ts
@@ -20,9 +20,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
 	@inject(Identifiers.Cryptography.Transaction.Factory)
 	private readonly transactionFactory!: Contracts.Crypto.ITransactionFactory;
 
-	public async process(
-		data: Buffer[],
-	): Promise<Contracts.TransactionPool.ProcessorResult> {
+	public async process(data: Buffer[]): Promise<Contracts.TransactionPool.ProcessorResult> {
 		const accept: string[] = [];
 		const broadcast: string[] = [];
 		const invalid: string[] = [];
@@ -45,7 +43,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
 						await Promise.all(this.extensions.map((e) => e.throwIfCannotBroadcast(transaction)));
 						broadcastTransactions.push(transaction);
 						broadcast.push(entryId);
-					} catch { }
+					} catch {}
 				} catch (error) {
 					invalid.push(entryId);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
The transaction pool API now only accepts hex strings to remove the need to call `fromJson`. Furthermore, the id calculation can reuse the buffer directly instead of going through another transaction serialization.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
