### PR TITLE
fix(transaction-pool): sync unconfirmed transactions on boot

### DIFF
--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -4,7 +4,7 @@ export interface Service {
 	getPoolSize(): number;
 
 	addTransaction(transaction: ITransaction): Promise<void>;
-	reAddTransactions(previouslyForgedTransactions?: ITransaction[]): Promise<void>;
+	reAddTransactions(): Promise<void>;
 	removeTransaction(transaction: ITransaction): Promise<void>;
 	removeForgedTransaction(transaction: ITransaction): Promise<void>;
 	cleanUp(): Promise<void>;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Dispatch `AddedToPool` when re-adding unconfirmed transactions on boot, so that the api-sync listener can pick them up.

Also remove unused `previouslyForgedTransactions` parameter and related code.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
