### PR TITLE
fix(p2p): ban peer on `getBlocks` error in BlockDownloader

### DIFF
--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -141,8 +141,6 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 			this.state.resetLastMessageTime();
 		} catch (error) {
-			this.peerDisposer.banPeer(job.peer.ip, error);
-
 			this.#handleJobError(job, error);
 			return;
 		}
@@ -175,6 +173,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 				job.heightTo
 			} from ${job.peer.ip}. ${error.message}`,
 		);
+		this.peerDisposer.banPeer(job.peer.ip, error);
 
 		this.#replyJob(job);
 	}


### PR DESCRIPTION
## Summary

Ban peer on communication and processing errors. 

## Checklist

- [x] Ready to be merged
