### PR TITLE
fix(api-transaction-pool): use maxTransactionBytes setting

### DIFF
--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -16,7 +16,20 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 			validate: {
 				payload: Joi.object({
 					transactions: Joi.array()
-						.items(Joi.string().lowercase().hex().max(4096 /* arbitrary cap */))
+						.items(
+							Joi.string()
+								.lowercase()
+								.hex()
+								.max(
+									server.app.app
+										.getTagged<Providers.PluginConfiguration>(
+											Identifiers.PluginConfiguration,
+											"plugin",
+											"transaction-pool",
+										)
+										.getRequired<number>("maxTransactionBytes"),
+								),
+						)
 						.min(1)
 						.max(
 							server.app.app

--- a/packages/transaction-pool/source/defaults.ts
+++ b/packages/transaction-pool/source/defaults.ts
@@ -11,7 +11,7 @@ export const defaults = {
 	// then it will be removed.
 	maxTransactionAge: 2700,
 
-	maxTransactionBytes: 2_000_000, // TODO think of a value that makes sense ?
+	maxTransactionBytes: 20_000, // TODO think of a value that makes sense ?
 
 	// When the pool contains that many transactions, then a new transaction is
 	// only accepted if its fee is higher than the transaction with the lowest


### PR DESCRIPTION
## Summary

Use maxTransactionBytes limit for transaction.

## Checklist

- [x] Ready to be merged

