### PR TITLE
refactor: tweak default `maxTransactionBytes` and `vendorField` length

### DIFF
--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -27,7 +27,7 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 											"plugin",
 											"transaction-pool",
 										)
-										.getRequired<number>("maxTransactionBytes"),
+										.getRequired<number>("maxTransactionBytes") * 2,
 								),
 						)
 						.min(1)

--- a/packages/crypto-transaction/source/builders.ts
+++ b/packages/crypto-transaction/source/builders.ts
@@ -91,7 +91,7 @@ export abstract class TransactionBuilder<TBuilder extends TransactionBuilder<TBu
 		const limit: number = this.configuration.getMilestone().vendorFieldLength;
 
 		if (vendorField) {
-			if (Buffer.from(vendorField).length > limit) {
+			if (Buffer.byteLength(vendorField, "utf8") > limit) {
 				throw new Exceptions.VendorFieldLengthExceededError(limit);
 			}
 

--- a/packages/crypto-transaction/source/validation/formats.ts
+++ b/packages/crypto-transaction/source/validation/formats.ts
@@ -6,7 +6,7 @@ export const makeFormats = (configuration: Contracts.Crypto.IConfiguration) => {
 		type: "string",
 		validate: (data) => {
 			try {
-				return Buffer.from(data, "utf8").length <= configuration.getMilestone().vendorFieldLength;
+				return Buffer.byteLength(data, "utf8") <= configuration.getMilestone().vendorFieldLength;
 			} catch {
 				return false;
 			}

--- a/packages/transaction-pool/source/defaults.ts
+++ b/packages/transaction-pool/source/defaults.ts
@@ -11,8 +11,8 @@ export const defaults = {
 	// then it will be removed.
 	maxTransactionAge: 2700,
 
-	// Based on a multipayment transaction with 256 recipients, vendor field, 16 signatures plus some leeway
-	maxTransactionBytes: 18_000,
+	// Based on a multipayment transaction with 256 recipients (base58), vendor field, 16 signatures plus some leeway
+	maxTransactionBytes: 9_000,
 
 	// When the pool contains that many transactions, then a new transaction is
 	// only accepted if its fee is higher than the transaction with the lowest

--- a/packages/transaction-pool/source/defaults.ts
+++ b/packages/transaction-pool/source/defaults.ts
@@ -12,7 +12,7 @@ export const defaults = {
 	maxTransactionAge: 2700,
 
 	// Based on a multipayment transaction with 256 recipients (base58), vendor field, 16 signatures plus some leeway
-	maxTransactionBytes: 9_000,
+	maxTransactionBytes: 9000,
 
 	// When the pool contains that many transactions, then a new transaction is
 	// only accepted if its fee is higher than the transaction with the lowest

--- a/packages/transaction-pool/source/defaults.ts
+++ b/packages/transaction-pool/source/defaults.ts
@@ -11,7 +11,7 @@ export const defaults = {
 	// then it will be removed.
 	maxTransactionAge: 2700,
 
-	maxTransactionBytes: 20_000, // TODO think of a value that makes sense ?
+	maxTransactionBytes: 32_000, // Based on a multipayment transaction with 256 recipients with some leeway
 
 	// When the pool contains that many transactions, then a new transaction is
 	// only accepted if its fee is higher than the transaction with the lowest

--- a/packages/transaction-pool/source/defaults.ts
+++ b/packages/transaction-pool/source/defaults.ts
@@ -11,7 +11,8 @@ export const defaults = {
 	// then it will be removed.
 	maxTransactionAge: 2700,
 
-	maxTransactionBytes: 32_000, // Based on a multipayment transaction with 256 recipients with some leeway
+	// Based on a multipayment transaction with 256 recipients, vendor field, 16 signatures plus some leeway
+	maxTransactionBytes: 18_000,
 
 	// When the pool contains that many transactions, then a new transaction is
 	// only accepted if its fee is higher than the transaction with the lowest


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Change default value for `maxTransactionBytes` so it can handle a multipayment transaction with 256 recipients.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
