### PR TITLE
feat(api-transaction-pool): set `maxBytes` on route

### DIFF
--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -9,10 +9,29 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 	const controller = server.app.app.resolve(TransactionsController);
 	server.bind(controller);
 
+	const maxTransactionsPerRequest = server.app.app
+		.getTagged<Providers.PluginConfiguration>(
+			Identifiers.PluginConfiguration,
+			"plugin",
+			"transaction-pool",
+		)
+		.getRequired<number>("maxTransactionsPerRequest");
+
+	const maxTransactionBytes = server.app.app
+		.getTagged<Providers.PluginConfiguration>(
+			Identifiers.PluginConfiguration,
+			"plugin",
+			"transaction-pool",
+		)
+		.getRequired<number>("maxTransactionBytes");
+
 	server.route({
 		handler: (request: Hapi.Request) => controller.store(request),
 		method: "POST",
 		options: {
+			payload: {
+				maxBytes: 100 + (maxTransactionsPerRequest * maxTransactionBytes * 2),
+			},
 			validate: {
 				payload: Joi.object({
 					transactions: Joi.array()
@@ -20,26 +39,10 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 							Joi.string()
 								.lowercase()
 								.hex()
-								.max(
-									server.app.app
-										.getTagged<Providers.PluginConfiguration>(
-											Identifiers.PluginConfiguration,
-											"plugin",
-											"transaction-pool",
-										)
-										.getRequired<number>("maxTransactionBytes") * 2,
-								),
+								.max(maxTransactionBytes * 2),
 						)
 						.min(1)
-						.max(
-							server.app.app
-								.getTagged<Providers.PluginConfiguration>(
-									Identifiers.PluginConfiguration,
-									"plugin",
-									"transaction-pool",
-								)
-								.getRequired<number>("maxTransactionsPerRequest"),
-						),
+						.max(maxTransactionsPerRequest),
 				}),
 			},
 		},

--- a/packages/api-transaction-pool/source/routes/transaction-pool.ts
+++ b/packages/api-transaction-pool/source/routes/transaction-pool.ts
@@ -10,19 +10,11 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 	server.bind(controller);
 
 	const maxTransactionsPerRequest = server.app.app
-		.getTagged<Providers.PluginConfiguration>(
-			Identifiers.PluginConfiguration,
-			"plugin",
-			"transaction-pool",
-		)
+		.getTagged<Providers.PluginConfiguration>(Identifiers.PluginConfiguration, "plugin", "transaction-pool")
 		.getRequired<number>("maxTransactionsPerRequest");
 
 	const maxTransactionBytes = server.app.app
-		.getTagged<Providers.PluginConfiguration>(
-			Identifiers.PluginConfiguration,
-			"plugin",
-			"transaction-pool",
-		)
+		.getTagged<Providers.PluginConfiguration>(Identifiers.PluginConfiguration, "plugin", "transaction-pool")
 		.getRequired<number>("maxTransactionBytes");
 
 	server.route({
@@ -30,7 +22,7 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 		method: "POST",
 		options: {
 			payload: {
-				maxBytes: 100 + (maxTransactionsPerRequest * maxTransactionBytes * 2),
+				maxBytes: 100 + maxTransactionsPerRequest * maxTransactionBytes * 2,
 			},
 			validate: {
 				payload: Joi.object({

--- a/packages/crypto-validation/source/keywords.ts
+++ b/packages/crypto-validation/source/keywords.ts
@@ -3,7 +3,7 @@ import { AnySchemaObject, FuncKeywordDefinition } from "ajv";
 
 export const makeKeywords = () => {
 	const maxBytes: FuncKeywordDefinition = {
-		compile: (schema) => (data) => Buffer.from(data, "utf8").byteLength <= schema,
+		compile: (schema) => (data) => Buffer.byteLength(data, "utf8") <= schema,
 		errors: false,
 		keyword: "maxBytes",
 		metaSchema: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionspayloadmaxbytes

The default is `1MB`, but we now set it based on the allowed number of transactions per request and maximum transaction bytes which at default values is equal to `~700kb`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
