### PR TITLE
pref(database): use `cache` and separete `persist` method

### DIFF
--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -103,6 +103,7 @@ export class Bootstrapper {
 		if (!(await this.databaseService.getLastBlock())) {
 			const genesisBlock = this.#stateStore.getGenesisBlock();
 			await this.databaseService.addCommit(genesisBlock);
+			await this.databaseService.persist();
 		}
 	}
 

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -102,7 +102,7 @@ export class Bootstrapper {
 	async #storeGenesisBlock(): Promise<void> {
 		if (!(await this.databaseService.getLastBlock())) {
 			const genesisBlock = this.#stateStore.getGenesisBlock();
-			await this.databaseService.saveCommit(genesisBlock);
+			await this.databaseService.addCommit(genesisBlock);
 		}
 	}
 

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -102,7 +102,7 @@ export class Bootstrapper {
 	async #storeGenesisBlock(): Promise<void> {
 		if (!(await this.databaseService.getLastBlock())) {
 			const genesisBlock = this.#stateStore.getGenesisBlock();
-			await this.databaseService.addCommit(genesisBlock);
+			this.databaseService.addCommit(genesisBlock);
 			await this.databaseService.persist();
 		}
 	}

--- a/packages/consensus/source/committed-block-state.ts
+++ b/packages/consensus/source/committed-block-state.ts
@@ -27,6 +27,10 @@ export class CommittedBlockState implements Contracts.Processor.IProcessableUnit
 		return this.#committedBlock.commit.round;
 	}
 
+	get persist(): boolean {
+		return false; // Block downloader will store block in database, to improve performance
+	}
+
 	get validators(): string[] {
 		return [...this.#validators.keys()];
 	}

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -54,6 +54,10 @@ export class RoundState implements Contracts.Consensus.IRoundState {
 		return this.#round;
 	}
 
+	get persist(): boolean {
+		return true; // Store block in database every time
+	}
+
 	get validators(): string[] {
 		return [...this.#validators.keys()];
 	}

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -11,7 +11,7 @@ export interface IDatabaseService {
 
 	getLastBlock(): Promise<IBlock | undefined>;
 
-	addCommit(block: ICommittedBlock): Promise<void>;
+	addCommit(block: ICommittedBlock): void;
 
 	persist(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -12,4 +12,6 @@ export interface IDatabaseService {
 	getLastBlock(): Promise<IBlock | undefined>;
 
 	addCommit(block: ICommittedBlock): Promise<void>;
+
+	persist(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -11,5 +11,5 @@ export interface IDatabaseService {
 
 	getLastBlock(): Promise<IBlock | undefined>;
 
-	saveCommit(block: ICommittedBlock): Promise<void>;
+	addCommit(block: ICommittedBlock): Promise<void>;
 }

--- a/packages/contracts/source/contracts/processor.ts
+++ b/packages/contracts/source/contracts/processor.ts
@@ -4,6 +4,7 @@ import { WalletRepositoryClone } from "./state";
 export interface IProcessableUnit {
 	readonly height: number;
 	readonly round: number;
+	readonly persist: boolean;
 	getWalletRepository(): WalletRepositoryClone;
 	hasProcessorResult(): boolean;
 	getProcessorResult(): boolean;

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -75,11 +75,11 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 	}
 
 	async persist(): Promise<void> {
-		for (const [height, block] of this.#cache.entries()) {
-			void this.blockStorage.put(height, block);
-		}
-
-		await this.blockStorage.flushed;
+		await this.blockStorage.transaction(async () => {
+			for (const [height, block] of this.#cache.entries()) {
+				await this.blockStorage.put(height, block);
+			}
+		});
 
 		this.#cache.clear();
 	}

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -74,13 +74,9 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 		if (!this.blockStorage.doesExist(block.block.data.height) || !this.#cache.has(block.block.data.height)) {
 			this.#cache.set(block.block.data.height, Buffer.from(block.serialized, "hex"));
 		}
-
-		if (block.block.data.height % 1 === 0) {
-			await this.#saveCached();
-		}
 	}
 
-	async #saveCached(): Promise<void> {
+	async persist(): Promise<void> {
 		for (const [height, block] of this.#cache.entries()) {
 			void this.blockStorage.put(height, block);
 		}

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -70,10 +70,8 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 		}
 	}
 
-	public async addCommit(block: Contracts.Crypto.ICommittedBlock): Promise<void> {
-		if (!this.blockStorage.doesExist(block.block.data.height) || !this.#cache.has(block.block.data.height)) {
-			this.#cache.set(block.block.data.height, Buffer.from(block.serialized, "hex"));
-		}
+	public addCommit(block: Contracts.Crypto.ICommittedBlock): void {
+		this.#cache.set(block.block.data.height, Buffer.from(block.serialized, "hex"));
 	}
 
 	async persist(): Promise<void> {

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -70,7 +70,7 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 		}
 	}
 
-	public async saveCommit(block: Contracts.Crypto.ICommittedBlock): Promise<void> {
+	public async addCommit(block: Contracts.Crypto.ICommittedBlock): Promise<void> {
 		if (!this.blockStorage.doesExist(block.block.data.height) || !this.#cache.has(block.block.data.height)) {
 			this.#cache.set(block.block.data.height, Buffer.from(block.serialized, "hex"));
 		}

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -10,8 +10,10 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 	@inject(Identifiers.Cryptography.Block.Factory)
 	private readonly blockFactory!: Contracts.Crypto.IBlockFactory;
 
+	#cache = new Map<number, Buffer>();
+
 	public async getBlock(height: number): Promise<Contracts.Crypto.IBlock | undefined> {
-		const bytes = this.blockStorage.get(height);
+		const bytes = this.#get(height);
 
 		if (bytes) {
 			return (await this.blockFactory.fromCommittedBytes(bytes)).block;
@@ -30,12 +32,12 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 		return heights
 			.map((height: number) => {
 				try {
-					return this.blockStorage.get(height);
+					return this.#get(height);
 				} catch {
 					return;
 				}
 			})
-			.filter(Boolean);
+			.filter((block): block is Buffer => !!block);
 	}
 
 	public async findBlocks(start: number, end: number): Promise<Contracts.Crypto.IBlock[]> {
@@ -47,18 +49,21 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 
 	public async *readCommits(start: number, end: number): AsyncGenerator<Contracts.Crypto.ICommittedBlock> {
 		for (let height = start; height <= end; height++) {
-			const block = await this.blockFactory.fromCommittedBytes(this.blockStorage.get(height));
+			const block = await this.blockFactory.fromCommittedBytes(this.#get(height));
 			yield block;
 		}
 	}
 
 	public async getLastBlock(): Promise<Contracts.Crypto.IBlock | undefined> {
+		if (this.#cache.size > 0) {
+			return (await this.blockFactory.fromCommittedBytes([...this.#cache.values()].pop()!)).block;
+		}
+
 		try {
 			const lastCommittedBlock = await this.blockFactory.fromCommittedBytes(
 				this.blockStorage.getRange({ limit: 1, reverse: true }).asArray[0].value,
 			);
 
-			// TODO: return committed block or even have a dedicated storage for it?
 			return lastCommittedBlock.block;
 		} catch {
 			return undefined;
@@ -66,9 +71,31 @@ export class DatabaseService implements Contracts.Database.IDatabaseService {
 	}
 
 	public async saveCommit(block: Contracts.Crypto.ICommittedBlock): Promise<void> {
-		if (!this.blockStorage.doesExist(block.block.data.height)) {
-			await this.blockStorage.put(block.block.data.height, Buffer.from(block.serialized, "hex"));
+		if (!this.blockStorage.doesExist(block.block.data.height) || !this.#cache.has(block.block.data.height)) {
+			this.#cache.set(block.block.data.height, Buffer.from(block.serialized, "hex"));
 		}
+
+		if (block.block.data.height % 1 === 0) {
+			await this.#saveCached();
+		}
+	}
+
+	async #saveCached(): Promise<void> {
+		for (const [height, block] of this.#cache.entries()) {
+			void this.blockStorage.put(height, block);
+		}
+
+		await this.blockStorage.flushed;
+
+		this.#cache.clear();
+	}
+
+	#get(height: number): Buffer {
+		if (this.#cache.has(height)) {
+			return this.#cache.get(height)!;
+		}
+
+		return this.blockStorage.get(height);
 	}
 
 	async #map<T>(data: unknown[], callback: (...arguments_: any[]) => Promise<T>): Promise<T[]> {

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -76,7 +76,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 
 		const stateStore = this.stateService.getStateStore();
 		if (!stateStore.isBootstrap()) {
-			await this.databaseService.saveCommit(committedBlock);
+			await this.databaseService.addCommit(committedBlock);
 		}
 
 		stateStore.setTotalRound(stateStore.getTotalRound() + unit.round + 1);

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -76,8 +76,11 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 
 		const stateStore = this.stateService.getStateStore();
 		if (!stateStore.isBootstrap()) {
-			await this.databaseService.addCommit(committedBlock);
-			await this.databaseService.persist();
+			this.databaseService.addCommit(committedBlock);
+
+			if (unit.persist) {
+				await this.databaseService.persist();
+			}
 		}
 
 		stateStore.setTotalRound(stateStore.getTotalRound() + unit.round + 1);

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -77,6 +77,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 		const stateStore = this.stateService.getStateStore();
 		if (!stateStore.isBootstrap()) {
 			await this.databaseService.addCommit(committedBlock);
+			await this.databaseService.persist();
 		}
 
 		stateStore.setTotalRound(stateStore.getTotalRound() + unit.round + 1);


### PR DESCRIPTION
## Summary

Use cache to improve performance during block download. Blocks are stored at the end of download chunk. 

Separate persist method is implemented. Cached blocks are stored as atomic transaction. 

## Checklist


- [x] Tests _(if necessary)_
- [x] Ready to be merged
