### PR TITLE
perf(consensus): store state only at dispose

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -38,9 +38,6 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	@inject(Identifiers.Consensus.RoundStateRepository)
 	private readonly roundStateRepository!: Contracts.Consensus.IRoundStateRepository;
 
-	@inject(Identifiers.Consensus.Storage)
-	private readonly storage!: Contracts.Consensus.IConsensusStorage;
-
 	@inject(Identifiers.Consensus.CommitLock)
 	private readonly commitLock!: Contracts.Kernel.ILock;
 
@@ -123,8 +120,6 @@ export class Consensus implements Contracts.Consensus.IConsensusService {
 	public async dispose(): Promise<void> {
 		this.scheduler.clear();
 		this.#isDisposed = true;
-
-		await this.storage.saveState(this.getState());
 	}
 
 	async handle(roundState: Contracts.Consensus.IRoundState): Promise<void> {

--- a/packages/consensus/source/index.ts
+++ b/packages/consensus/source/index.ts
@@ -53,6 +53,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
 	}
 
 	public async dispose(): Promise<void> {
-		await this.app.get<Consensus>(Identifiers.Consensus.Service).dispose();
+		const consensus = this.app.get<Consensus>(Identifiers.Consensus.Service);
+		await consensus.dispose();
+
+		const storage = this.app.get<Storage>(Identifiers.Consensus.Storage);
+		await storage.saveState(consensus.getState());
 	}
 }

--- a/packages/consensus/source/index.ts
+++ b/packages/consensus/source/index.ts
@@ -30,25 +30,17 @@ export class ServiceProvider extends Providers.ServiceProvider {
 					context.container.resolve(CommittedBlockState).configure(committedBlock),
 			);
 
-		// Storage for uncommitted blocks
-		const consensusStorage = this.app.get<RootDatabase>(Identifiers.Database.ConsensusStorage);
-
-		this.app
-			.bind(Identifiers.Database.ProposalStorage)
-			.toConstantValue(consensusStorage.openDB({ name: "proposals" }));
-		this.app
-			.bind(Identifiers.Database.PrevoteStorage)
-			.toConstantValue(consensusStorage.openDB({ name: "prevotes" }));
-		this.app
-			.bind(Identifiers.Database.PrecommitStorage)
-			.toConstantValue(consensusStorage.openDB({ name: "precommits" }));
+		// Storage for prevotes, precommits and proposals
+		const storage = this.app.get<RootDatabase>(Identifiers.Database.ConsensusStorage);
+		this.app.bind(Identifiers.Database.ProposalStorage).toConstantValue(storage.openDB({ name: "proposals" }));
+		this.app.bind(Identifiers.Database.PrevoteStorage).toConstantValue(storage.openDB({ name: "prevotes" }));
+		this.app.bind(Identifiers.Database.PrecommitStorage).toConstantValue(storage.openDB({ name: "precommits" }));
 		this.app
 			.bind(Identifiers.Database.ConsensusStateStorage)
-			.toConstantValue(consensusStorage.openDB({ name: "consensus" }));
+			.toConstantValue(storage.openDB({ name: "consensus" }));
 		this.app.bind(Identifiers.Consensus.Storage).to(Storage).inSingletonScope();
 
 		this.app.bind(Identifiers.Consensus.Bootstrapper).to(Bootstrapper).inSingletonScope();
-
 		this.app.bind(Identifiers.Consensus.Service).toConstantValue(this.app.resolve(Consensus));
 	}
 
@@ -58,5 +50,20 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		const storage = this.app.get<Storage>(Identifiers.Consensus.Storage);
 		await storage.saveState(consensus.getState());
+
+		const roundStates = this.app
+			.get<RoundStateRepository>(Identifiers.Consensus.RoundStateRepository)
+			.getRoundStates();
+
+		const proposals = roundStates
+			.map((roundState) => roundState.getProposal())
+			.filter((proposal): proposal is Contracts.Crypto.IProposal => !!proposal);
+		await storage.saveProposals(proposals);
+
+		const prevotes = roundStates.flatMap((roundState) => roundState.getPrevotes());
+		await storage.savePrevotes(prevotes);
+
+		const precommits = roundStates.flatMap((roundState) => roundState.getPrecommits());
+		await storage.savePrecommits(precommits);
 	}
 }

--- a/packages/consensus/source/processors/precommit-processor.ts
+++ b/packages/consensus/source/processors/precommit-processor.ts
@@ -18,9 +18,6 @@ export class PrecommitProcessor extends AbstractProcessor implements Contracts.C
 	@inject(Identifiers.Consensus.RoundStateRepository)
 	private readonly roundStateRepo!: Contracts.Consensus.IRoundStateRepository;
 
-	@inject(Identifiers.Consensus.Storage)
-	private readonly storage!: Contracts.Consensus.IConsensusStorage;
-
 	@inject(Identifiers.PeerBroadcaster)
 	private readonly broadcaster!: Contracts.P2P.Broadcaster;
 
@@ -43,7 +40,6 @@ export class PrecommitProcessor extends AbstractProcessor implements Contracts.C
 			}
 
 			roundState.addPrecommit(precommit);
-			await this.storage.savePrecommit(precommit);
 
 			if (broadcast) {
 				void this.broadcaster.broadcastPrecommit(precommit);

--- a/packages/consensus/source/processors/prevote-processor.ts
+++ b/packages/consensus/source/processors/prevote-processor.ts
@@ -18,9 +18,6 @@ export class PrevoteProcessor extends AbstractProcessor implements Contracts.Con
 	@inject(Identifiers.Consensus.RoundStateRepository)
 	private readonly roundStateRepo!: Contracts.Consensus.IRoundStateRepository;
 
-	@inject(Identifiers.Consensus.Storage)
-	private readonly storage!: Contracts.Consensus.IConsensusStorage;
-
 	@inject(Identifiers.PeerBroadcaster)
 	private readonly broadcaster!: Contracts.P2P.Broadcaster;
 
@@ -40,7 +37,6 @@ export class PrevoteProcessor extends AbstractProcessor implements Contracts.Con
 			}
 
 			roundState.addPrevote(prevote);
-			await this.storage.savePrevote(prevote);
 
 			if (broadcast) {
 				void this.broadcaster.broadcastPrevote(prevote);

--- a/packages/consensus/source/processors/proposal-processor.ts
+++ b/packages/consensus/source/processors/proposal-processor.ts
@@ -27,9 +27,6 @@ export class ProposalProcessor extends AbstractProcessor implements Contracts.Co
 	@inject(Identifiers.Consensus.RoundStateRepository)
 	private readonly roundStateRepo!: Contracts.Consensus.IRoundStateRepository;
 
-	@inject(Identifiers.Consensus.Storage)
-	private readonly storage!: Contracts.Consensus.IConsensusStorage;
-
 	@inject(Identifiers.PeerBroadcaster)
 	private readonly broadcaster!: Contracts.P2P.Broadcaster;
 
@@ -67,7 +64,6 @@ export class ProposalProcessor extends AbstractProcessor implements Contracts.Co
 			}
 
 			roundState.addProposal(proposal);
-			await this.storage.saveProposal(proposal);
 
 			if (broadcast) {
 				void this.broadcaster.broadcastProposal(proposal);

--- a/packages/consensus/source/round-state-repository.ts
+++ b/packages/consensus/source/round-state-repository.ts
@@ -20,6 +20,10 @@ export class RoundStateRepository implements Contracts.Consensus.IRoundStateRepo
 		return this.#roundStates.get(key)!;
 	}
 
+	public getRoundStates(): Contracts.Consensus.IRoundState[] {
+		return [...this.#roundStates.values()];
+	}
+
 	public clear(): void {
 		this.#roundStates.clear();
 	}

--- a/packages/consensus/source/storage.ts
+++ b/packages/consensus/source/storage.ts
@@ -51,19 +51,40 @@ export class Storage implements Contracts.Consensus.IConsensusStorage {
 		await this.stateStorage.put("consensus-state", data);
 	}
 
-	public async saveProposal(proposal: Contracts.Crypto.IProposal): Promise<void> {
-		const validator = this.validatorSet.getValidator(proposal.validatorIndex);
-		await this.proposalStorage.put(`${proposal.round}-${validator.getConsensusPublicKey()}`, proposal.toData());
+	public async saveProposals(proposals: Contracts.Crypto.IProposal[]): Promise<void> {
+		await this.proposalStorage.transaction(async () => {
+			for (const proposal of proposals) {
+				const validator = this.validatorSet.getValidator(proposal.validatorIndex);
+				await this.proposalStorage.put(
+					`${proposal.round}-${validator.getConsensusPublicKey()}`,
+					proposal.toData(),
+				);
+			}
+		});
 	}
 
-	public async savePrevote(prevote: Contracts.Crypto.IPrevote): Promise<void> {
-		const validator = this.validatorSet.getValidator(prevote.validatorIndex);
-		await this.prevoteStorage.put(`${prevote.round}-${validator.getConsensusPublicKey()}`, prevote.toData());
+	public async savePrevotes(prevotes: Contracts.Crypto.IPrevote[]): Promise<void> {
+		await this.prevoteStorage.transaction(async () => {
+			for (const prevote of prevotes) {
+				const validator = this.validatorSet.getValidator(prevote.validatorIndex);
+				await this.prevoteStorage.put(
+					`${prevote.round}-${validator.getConsensusPublicKey()}`,
+					prevote.toData(),
+				);
+			}
+		});
 	}
 
-	public async savePrecommit(precommit: Contracts.Crypto.IPrecommit): Promise<void> {
-		const validator = this.validatorSet.getValidator(precommit.validatorIndex);
-		await this.precommitStorage.put(`${precommit.round}-${validator.getConsensusPublicKey()}`, precommit.toData());
+	public async savePrecommits(precommits: Contracts.Crypto.IPrecommit[]): Promise<void> {
+		await this.precommitStorage.transaction(async () => {
+			for (const precommit of precommits) {
+				const validator = this.validatorSet.getValidator(precommit.validatorIndex);
+				await this.precommitStorage.put(
+					`${precommit.round}-${validator.getConsensusPublicKey()}`,
+					precommit.toData(),
+				);
+			}
+		});
 	}
 
 	public async getProposals(): Promise<Contracts.Crypto.IProposal[]> {

--- a/packages/contracts/source/contracts/consensus/consensus.ts
+++ b/packages/contracts/source/contracts/consensus/consensus.ts
@@ -53,6 +53,7 @@ export interface IConsensusStateData {
 
 export interface IRoundStateRepository {
 	getRoundState(height: number, round: number): IRoundState;
+	getRoundStates(): IRoundState[];
 	clear(): void;
 }
 
@@ -79,9 +80,9 @@ export interface IConsensusState extends IConsensusStateData {
 export interface IConsensusStorage {
 	getState(): Promise<IConsensusStateData | undefined>;
 	saveState(state: IConsensusState): Promise<void>;
-	saveProposal(state: IProposal): Promise<void>;
-	savePrevote(state: IPrevote): Promise<void>;
-	savePrecommit(state: IPrecommit): Promise<void>;
+	saveProposals(proposal: IProposal[]): Promise<void>;
+	savePrevotes(prevotes: IPrevote[]): Promise<void>;
+	savePrecommits(precommits: IPrecommit[]): Promise<void>;
 	getProposals(): Promise<IProposal[]>;
 	getPrevotes(): Promise<IPrevote[]>;
 	getPrecommits(): Promise<IPrecommit[]>;


### PR DESCRIPTION
## Summary

Store state only at dispose to reduce writes to disk and improve sync performance.

## Checklist


- [x] Tests _(if necessary)_
- [x] Ready to be merged
