### PR TITLE
test(cli): fix polluting working directory 

### DIFF
--- a/packages/cli/source/services/environment.test.ts
+++ b/packages/cli/source/services/environment.test.ts
@@ -27,6 +27,8 @@ describe<{
 		process.env.CORE_PATH_CONFIG = "something";
 
 		assert.true(environment.getPaths("ark", "testnet", "mainsail").config.endsWith("/something/mainsail"));
+
+		delete process.env.CORE_PATH_CONFIG;
 	});
 
 	it("should fail to update the variables if the file doesn't exist", async ({ environment }) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix unit test from polluting the working directory by resetting the environment variable.

```shell
$ git status -u

Untracked files:
  packages/cli/something/mainsail/.env
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
