### PR TITLE
refactor(validator): use `validators.json` to generate only consensus keys

### DIFF
--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -190,19 +190,11 @@ export class Consensus implements Contracts.Consensus.ConsensusService {
 
 	public async onTimeoutStartRound(): Promise<void> {
 		const roundState = this.roundStateRepository.getRoundState(this.#height, this.#round);
-
 		this.logger.info(`>> Starting new round: ${this.#height}/${this.#round} with proposer: ${roundState.proposer}`);
 
-		const proposer = this.validatorsRepository.getValidator(roundState.proposer.getConsensusPublicKey());
-		if (proposer) {
-			this.logger.info(`Found registered proposer: ${roundState.proposer}`);
+		this.scheduler.scheduleTimeoutPropose(this.#height, this.#round);
 
-			// TODO: Error handling
-			await this.#propose(proposer);
-		} else {
-			// TODO: Can we call this even even proposer is known?
-			this.scheduler.scheduleTimeoutPropose(this.#height, this.#round);
-		}
+		await this.#propose(roundState);
 	}
 
 	protected async onProposal(roundState: Contracts.Consensus.RoundState): Promise<void> {
@@ -407,14 +399,28 @@ export class Consensus implements Contracts.Consensus.ConsensusService {
 		return false;
 	}
 
-	async #propose(proposer: Contracts.Validator.Validator): Promise<void> {
-		const roundState = this.roundStateRepository.getRoundState(this.#height, this.#round);
+	async #propose(roundState: Contracts.Consensus.RoundState): Promise<void> {
 		if (roundState.hasProposal()) {
 			return;
 		}
 
-		let proposal: Contracts.Crypto.Proposal | undefined;
+		const registeredProposer = this.validatorsRepository.getValidator(roundState.proposer.getConsensusPublicKey());
 
+		if (registeredProposer === undefined) {
+			return;
+		}
+
+		this.logger.info(`Found registered proposer: ${roundState.proposer}`);
+
+		const proposal = await this.#makeProposal(roundState, registeredProposer);
+
+		void this.proposalProcessor.process(proposal);
+	}
+
+	async #makeProposal(
+		roundState: Contracts.Consensus.RoundState,
+		registeredProposer: Contracts.Validator.Validator,
+	): Promise<Contracts.Crypto.Proposal> {
 		if (this.#validValue) {
 			const block = this.#validValue.getBlock();
 			const lockProof = await this.#validValue.aggregatePrevotes();
@@ -425,30 +431,40 @@ export class Consensus implements Contracts.Consensus.ConsensusService {
 				} from round ${this.getValidRound()} with blockId: ${block.data.id}`,
 			);
 
-			proposal = await proposer.propose(this.#round, this.#validValue.round, block, lockProof);
-		} else {
-			const block = await proposer.prepareBlock(this.#height, this.#round);
-
-			this.logger.info(`Proposing new block ${this.#height}/${this.#round} with blockId: ${block.data.id}`);
-			proposal = await proposer.propose(this.#round, undefined, block);
+			return await registeredProposer.propose(
+				this.validatorSet.getValidatorIndexByWalletPublicKey(roundState.proposer.getWalletPublicKey()),
+				this.#round,
+				this.#validValue.round,
+				block,
+				lockProof,
+			);
 		}
 
-		Utils.assert.defined(proposal);
-		void this.proposalProcessor.process(proposal);
+		const block = await registeredProposer.prepareBlock(roundState.proposer.getWalletPublicKey(), this.#round);
+		this.logger.info(`Proposing new block ${this.#height}/${this.#round} with blockId: ${block.data.id}`);
+
+		return registeredProposer.propose(
+			this.validatorSet.getValidatorIndexByWalletPublicKey(roundState.proposer.getWalletPublicKey()),
+			this.#round,
+			undefined,
+			block,
+		);
 	}
 
 	async #prevote(value?: string): Promise<void> {
 		const roundState = this.roundStateRepository.getRoundState(this.#height, this.#round);
-		for (const validator of this.validatorsRepository.getValidators(this.#getActiveValidators())) {
-			if (
-				roundState.hasPrevote(
-					this.validatorSet.getValidatorIndexByWalletPublicKey(validator.getWalletPublicKey()),
-				)
-			) {
+		for (const validator of this.validatorSet.getActiveValidators()) {
+			const localValidator = this.validatorsRepository.getValidator(validator.getConsensusPublicKey());
+			if (localValidator === undefined) {
 				continue;
 			}
 
-			const prevote = await validator.prevote(this.#height, this.#round, value);
+			const validatorIndex = this.validatorSet.getValidatorIndexByWalletPublicKey(validator.getWalletPublicKey());
+			if (roundState.hasPrevote(validatorIndex)) {
+				continue;
+			}
+
+			const prevote = await localValidator.prevote(validatorIndex, this.#height, this.#round, value);
 
 			void this.prevoteProcessor.process(prevote);
 		}
@@ -456,25 +472,21 @@ export class Consensus implements Contracts.Consensus.ConsensusService {
 
 	async #precommit(value?: string): Promise<void> {
 		const roundState = this.roundStateRepository.getRoundState(this.#height, this.#round);
-		for (const validator of this.validatorsRepository.getValidators(this.#getActiveValidators())) {
-			if (
-				roundState.hasPrecommit(
-					this.validatorSet.getValidatorIndexByWalletPublicKey(validator.getWalletPublicKey()),
-				)
-			) {
+		for (const validator of this.validatorSet.getActiveValidators()) {
+			const localValidator = this.validatorsRepository.getValidator(validator.getConsensusPublicKey());
+			if (localValidator === undefined) {
 				continue;
 			}
 
-			const precommit = await validator.precommit(this.#height, this.#round, value);
+			const validatorIndex = this.validatorSet.getValidatorIndexByWalletPublicKey(validator.getWalletPublicKey());
+			if (roundState.hasPrecommit(validatorIndex)) {
+				continue;
+			}
+
+			const precommit = await localValidator.precommit(validatorIndex, this.#height, this.#round, value);
 
 			void this.precommitProcessor.process(precommit);
 		}
-	}
-
-	#getActiveValidators(): string[] {
-		const activeValidators = this.validatorSet.getActiveValidators();
-
-		return activeValidators.map((validator) => validator.getConsensusPublicKey());
 	}
 
 	async #bootstrap(): Promise<void> {

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -47,7 +47,7 @@ export class Consensus implements Contracts.Consensus.ConsensusService {
 	@inject(Identifiers.LogService)
 	private readonly logger!: Contracts.Kernel.Logger;
 
-	#height = 2;
+	#height = 1;
 	#round = 0;
 	#step: Contracts.Consensus.Step = Contracts.Consensus.Step.Propose;
 	#lockedValue?: Contracts.Consensus.RoundState;

--- a/packages/contracts/source/contracts/validator.ts
+++ b/packages/contracts/source/contracts/validator.ts
@@ -1,18 +1,18 @@
 import { AggregatedSignature, Block, KeyPair, Precommit, Prevote, Proposal } from "./crypto";
 
 export interface Validator {
-	configure(publicKey: string, keyPair: KeyPair): Validator;
-	getWalletPublicKey(): string;
+	configure(keyPair: KeyPair): Validator;
 	getConsensusPublicKey(): string;
-	prepareBlock(height: number, round: number): Promise<Block>;
+	prepareBlock(generatorPublicKey: string, round: number): Promise<Block>;
 	propose(
+		validatorIndex: number,
 		round: number,
 		validRound: number | undefined,
 		block: Block,
 		lockProof?: AggregatedSignature,
 	): Promise<Proposal>;
-	prevote(height: number, round: number, blockId: string | undefined): Promise<Prevote>;
-	precommit(height: number, round: number, blockId: string | undefined): Promise<Precommit>;
+	prevote(validatorIndex: number, height: number, round: number, blockId: string | undefined): Promise<Prevote>;
+	precommit(validatorIndex: number, height: number, round: number, blockId: string | undefined): Promise<Precommit>;
 }
 
 export interface ValidatorRepository {

--- a/packages/contracts/source/contracts/validator.ts
+++ b/packages/contracts/source/contracts/validator.ts
@@ -17,5 +17,4 @@ export interface Validator {
 
 export interface ValidatorRepository {
 	getValidator(publicKey: string): Validator | undefined;
-	getValidators(publicKeys: string[]): Validator[];
 }

--- a/packages/validator/source/index.ts
+++ b/packages/validator/source/index.ts
@@ -6,12 +6,6 @@ import { ValidatorRepository } from "./validator-repository";
 
 export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {
-		const walletPublicKeyFactory = this.app.getTagged<Contracts.Crypto.PublicKeyFactory>(
-			Identifiers.Cryptography.Identity.PublicKeyFactory,
-			"type",
-			"wallet",
-		);
-
 		const consensusKeyPairFactory = this.app.getTagged<Contracts.Crypto.KeyPairFactory>(
 			Identifiers.Cryptography.Identity.KeyPairFactory,
 			"type",
@@ -24,11 +18,8 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		for (const secret of secrets.values()) {
 			const consensusKeyPair = await consensusKeyPairFactory.fromMnemonic(secret);
-			const walletPublicKey = await walletPublicKeyFactory.fromMnemonic(secret);
 
-			validators.push(
-				this.app.resolve<Contracts.Validator.Validator>(Validator).configure(walletPublicKey, consensusKeyPair),
-			);
+			validators.push(this.app.resolve<Contracts.Validator.Validator>(Validator).configure(consensusKeyPair));
 		}
 
 		this.app

--- a/packages/validator/source/validator-repository.test.ts
+++ b/packages/validator/source/validator-repository.test.ts
@@ -14,11 +14,9 @@ describe<{
 		await prepareSandbox(context);
 
 		const validators: Contracts.Consensus.IValidator[] = [];
-		for (const { consensusKeyPair, walletPublicKey } of validatorKeys) {
+		for (const { consensusKeyPair } of validatorKeys) {
 			validators.push(
-				context.sandbox.app
-					.resolve<Contracts.Consensus.IValidator>(Validator)
-					.configure(walletPublicKey, consensusKeyPair),
+				context.sandbox.app.resolve<Contracts.Consensus.IValidator>(Validator).configure(consensusKeyPair),
 			);
 		}
 
@@ -31,21 +29,5 @@ describe<{
 
 	it("#getValidator - should return existing validator", async ({ validatorRepository }) => {
 		assert.defined(validatorRepository.getValidator(validatorKeys[0].consensusKeyPair.publicKey));
-	});
-
-	it("#getValidators - should known validators", async ({ validatorRepository }) => {
-		assert.empty(validatorRepository.getValidators(["abc"]));
-		assert.length(
-			validatorRepository.getValidators(validatorKeys.map(({ consensusKeyPair: { publicKey } }) => publicKey)),
-			validatorKeys.length,
-		);
-		assert.length(
-			validatorRepository.getValidators([
-				...validatorKeys.map(({ consensusKeyPair: { publicKey } }) => publicKey),
-				"abc",
-				"def",
-			]),
-			validatorKeys.length,
-		);
 	});
 });

--- a/packages/validator/source/validator-repository.ts
+++ b/packages/validator/source/validator-repository.ts
@@ -14,10 +14,4 @@ export class ValidatorRepository implements Contracts.Validator.ValidatorReposit
 	public getValidator(consensusPublicKey: string): Contracts.Validator.Validator | undefined {
 		return this.#validators.get(consensusPublicKey);
 	}
-
-	getValidators(consensusPublicKeys: string[]): Contracts.Validator.Validator[] {
-		return consensusPublicKeys
-			.map((consensusPublicKey) => this.getValidator(consensusPublicKey))
-			.filter((validator): validator is Contracts.Validator.Validator => !!validator);
-	}
 }

--- a/packages/validator/source/validator.test.ts
+++ b/packages/validator/source/validator.test.ts
@@ -12,10 +12,10 @@ describe<{
 	beforeEach(async (context) => {
 		await prepareSandbox(context);
 
-		const { consensusKeyPair, walletPublicKey } = validatorKeys[0];
+		const { consensusKeyPair } = validatorKeys[0];
 		context.validator = context.sandbox.app
 			.resolve<Contracts.Validator.Validator>(Validator)
-			.configure(walletPublicKey, consensusKeyPair);
+			.configure(consensusKeyPair);
 	});
 
 	it("#getConsensusPublicKey", async ({ validator }) => {
@@ -23,28 +23,28 @@ describe<{
 	});
 
 	it("#prepareBlock - should prepare block", async ({ validator }) => {
-		const block = await validator.prepareBlock(1, 1);
+		const block = await validator.prepareBlock("walletPublicKey", 1);
 		assert.defined(block);
 		assert.equal(block.data.height, 2);
 	});
 
 	it("#propose - should create signed proposal", async ({ validator }) => {
-		const block = await validator.prepareBlock(1, 1);
-		const proposal = await validator.propose(1, undefined, block);
+		const block = await validator.prepareBlock("walletPublicKey", 1);
+		const proposal = await validator.propose(0, 1, undefined, block);
 		assert.defined(proposal);
 		assert.defined(proposal.signature);
 	});
 
 	it("#prevote - should create signed prevote", async ({ validator }) => {
-		const block = await validator.prepareBlock(1, 1);
-		const prevote = await validator.prevote(1, 1, block.header.id);
+		const block = await validator.prepareBlock("walletPublicKey", 1);
+		const prevote = await validator.prevote(0, 1, 1, block.header.id);
 		assert.defined(prevote);
 		assert.defined(prevote.signature);
 	});
 
 	it("#precommit - should create signed precommit", async ({ validator }) => {
-		const block = await validator.prepareBlock(1, 1);
-		const precommit = await validator.precommit(1, 1, block.header.id);
+		const block = await validator.prepareBlock("walletPublicKey", 1);
+		const precommit = await validator.precommit(0, 1, 1, block.header.id);
 		assert.defined(precommit);
 		assert.defined(precommit.signature);
 	});

--- a/packages/validator/test/fixtures/validator-keys.ts
+++ b/packages/validator/test/fixtures/validator-keys.ts
@@ -8,7 +8,6 @@ export const validatorKeys = [
 		},
 		mnemonic:
 			"endless deposit bright clip school doctor later surround strategy blouse damage drink diesel erase scrap inside over pledge talent blood bus luggage glad whale",
-		walletPublicKey: "2a453fefde568a298d26d4a3eaa66585ce6652d0dc59bd955be40746f7197a9d",
 	},
 	{
 		consensusKeyPair: {
@@ -19,6 +18,5 @@ export const validatorKeys = [
 		},
 		mnemonic:
 			"endless deposit bright clip school doctor later surround strategy blouse damage drink diesel erase scrap inside over pledge talent blood bus luggage glad whale",
-		walletPublicKey: "2a453fefde568a298d26d4a3eaa66585ce6652d0dc59bd955be40746f7197a9d",
 	},
 ];


### PR DESCRIPTION
## Summary

Don't generate wallet keys from validator.json. Consensus and wallet keys can be different.

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
