### PR TITLE
refactor(state): make `WalletRepository` part of `Store`

### DIFF
--- a/packages/api-development/source/controllers/controller.ts
+++ b/packages/api-development/source/controllers/controller.ts
@@ -19,7 +19,7 @@ export class Controller {
 	protected readonly stateService!: Contracts.State.Service;
 
 	protected getWalletRepository(): Contracts.State.WalletRepository {
-		return this.stateService.getWalletRepository();
+		return this.stateService.getStore().walletRepository;
 	}
 
 	protected getQueryPagination(query: Hapi.RequestQuery): Contracts.Api.Pagination {

--- a/packages/api-development/source/resources/block.ts
+++ b/packages/api-development/source/resources/block.ts
@@ -13,8 +13,8 @@ export class BlockResource implements Contracts.Api.Resource {
 	public async transform(block: Contracts.Crypto.Block): Promise<object> {
 		const blockData: Contracts.Crypto.BlockData = block.data;
 		const generator: Contracts.State.Wallet = await this.stateService
-			.getWalletRepository()
-			.findByPublicKey(blockData.generatorPublicKey);
+			.getStore()
+			.walletRepository.findByPublicKey(blockData.generatorPublicKey);
 
 		return {
 			forged: {

--- a/packages/api-development/source/resources/transaction.ts
+++ b/packages/api-development/source/resources/transaction.ts
@@ -14,7 +14,7 @@ export class TransactionResource implements Contracts.Api.Resource {
 	public async transform(resource: Contracts.Crypto.TransactionData): Promise<object> {
 		AppUtils.assert.defined<string>(resource.senderPublicKey);
 
-		const wallet = await this.stateService.getWalletRepository().findByPublicKey(resource.senderPublicKey);
+		const wallet = await this.stateService.getStore().walletRepository.findByPublicKey(resource.senderPublicKey);
 		const sender: string = wallet.getAddress();
 
 		return {

--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -111,7 +111,7 @@ export class Sync implements Contracts.ApiSync.Service {
 			proof,
 		} = commit;
 
-		const dirtyWallets = [...unit.getWalletRepository().getDirtyWallets()];
+		const dirtyWallets = [...unit.store.walletRepository.getDirtyWallets()];
 
 		const deferredSync: DeferredSync = {
 			block: {

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -37,9 +37,6 @@ export class Bootstrapper {
 	@inject(Identifiers.State.Service)
 	private stateService!: Contracts.State.Service;
 
-	@inject(Identifiers.ValidatorSet.Service)
-	private readonly validatorSet!: Contracts.ValidatorSet.Service;
-
 	@inject(Identifiers.Processor.BlockProcessor)
 	private readonly blockProcessor!: Contracts.Processor.BlockProcessor;
 
@@ -73,8 +70,6 @@ export class Bootstrapper {
 			}
 
 			await this.#initState();
-
-			await this.validatorSet.initialize();
 
 			await this.#processBlocks();
 			this.#store.setBootstrap(false);

--- a/packages/consensus/source/commit-state.ts
+++ b/packages/consensus/source/commit-state.ts
@@ -9,7 +9,7 @@ export class CommitState implements Contracts.Processor.ProcessableUnit {
 	@inject(Identifiers.ValidatorSet.Service)
 	private readonly validatorSet!: Contracts.ValidatorSet.Service;
 
-	#walletRepository!: Contracts.State.WalletRepositoryClone;
+	#walletRepository!: Contracts.State.WalletRepository;
 	#commit!: Contracts.Crypto.Commit;
 	#processorResult?: boolean;
 	#validators = new Map<string, Contracts.State.ValidatorWallet>();
@@ -47,7 +47,7 @@ export class CommitState implements Contracts.Processor.ProcessableUnit {
 		return this;
 	}
 
-	public getWalletRepository(): Contracts.State.WalletRepositoryClone {
+	public getWalletRepository(): Contracts.State.WalletRepository {
 		return this.#walletRepository;
 	}
 

--- a/packages/consensus/source/commit-state.ts
+++ b/packages/consensus/source/commit-state.ts
@@ -9,30 +9,34 @@ export class CommitState implements Contracts.Processor.ProcessableUnit {
 	@inject(Identifiers.ValidatorSet.Service)
 	private readonly validatorSet!: Contracts.ValidatorSet.Service;
 
-	#walletRepository!: Contracts.State.WalletRepository;
+	#store!: Contracts.State.Store;
 	#commit!: Contracts.Crypto.Commit;
 	#processorResult?: boolean;
 	#validators = new Map<string, Contracts.State.ValidatorWallet>();
 
 	@postConstruct()
 	public initialize(): void {
-		this.#walletRepository = this.stateService.createWalletRepositoryClone();
+		this.#store = this.stateService.createStoreClone();
 	}
 
-	get height(): number {
+	public get height(): number {
 		return this.#commit.block.data.height;
 	}
 
-	get round(): number {
+	public get round(): number {
 		return this.#commit.proof.round;
 	}
 
-	get persist(): boolean {
+	public get persist(): boolean {
 		return false; // Block downloader will store block in database, to improve performance
 	}
 
-	get validators(): string[] {
+	public get validators(): string[] {
 		return [...this.#validators.keys()];
+	}
+
+	public get store(): Contracts.State.Store {
+		return this.#store;
 	}
 
 	public configure(commit: Contracts.Crypto.Commit): CommitState {
@@ -45,10 +49,6 @@ export class CommitState implements Contracts.Processor.ProcessableUnit {
 		}
 
 		return this;
-	}
-
-	public getWalletRepository(): Contracts.State.WalletRepository {
-		return this.#walletRepository;
 	}
 
 	public getBlock(): Contracts.Crypto.Block {

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -39,31 +39,35 @@ export class RoundState implements Contracts.Consensus.RoundState {
 	#proposer!: Contracts.State.ValidatorWallet;
 
 	#commit: Contracts.Crypto.Commit | undefined;
-	#walletRepository!: Contracts.State.WalletRepository;
+	#store!: Contracts.State.Store;
 
 	@postConstruct()
 	public initialize(): void {
-		this.#walletRepository = this.stateService.createWalletRepositoryClone();
+		this.#store = this.stateService.createStoreClone();
 	}
 
-	get height(): number {
+	public get height(): number {
 		return this.#height;
 	}
 
-	get round(): number {
+	public get round(): number {
 		return this.#round;
 	}
 
-	get persist(): boolean {
+	public get persist(): boolean {
 		return true; // Store block in database every time
 	}
 
-	get validators(): string[] {
+	public get validators(): string[] {
 		return [...this.#validators.keys()];
 	}
 
-	get proposer(): Contracts.State.ValidatorWallet {
+	public get proposer(): Contracts.State.ValidatorWallet {
 		return this.#proposer;
+	}
+
+	public get store(): Contracts.State.Store {
+		return this.#store;
 	}
 
 	public configure(height: number, round: number): RoundState {
@@ -89,10 +93,6 @@ export class RoundState implements Contracts.Consensus.RoundState {
 		const validator = this.#validators.get(consensusPublicKey);
 		Utils.assert.defined<Contracts.State.ValidatorWallet>(validator);
 		return validator;
-	}
-
-	public getWalletRepository(): Contracts.State.WalletRepository {
-		return this.#walletRepository;
 	}
 
 	public hasProposal(): boolean {

--- a/packages/consensus/source/round-state.ts
+++ b/packages/consensus/source/round-state.ts
@@ -39,7 +39,7 @@ export class RoundState implements Contracts.Consensus.RoundState {
 	#proposer!: Contracts.State.ValidatorWallet;
 
 	#commit: Contracts.Crypto.Commit | undefined;
-	#walletRepository!: Contracts.State.WalletRepositoryClone;
+	#walletRepository!: Contracts.State.WalletRepository;
 
 	@postConstruct()
 	public initialize(): void {
@@ -91,7 +91,7 @@ export class RoundState implements Contracts.Consensus.RoundState {
 		return validator;
 	}
 
-	public getWalletRepository(): Contracts.State.WalletRepositoryClone {
+	public getWalletRepository(): Contracts.State.WalletRepository {
 		return this.#walletRepository;
 	}
 

--- a/packages/contracts/source/contracts/processor.ts
+++ b/packages/contracts/source/contracts/processor.ts
@@ -24,7 +24,6 @@ export interface BlockProcessor {
 }
 
 export interface TransactionProcessor {
-	// TODO: Use state instead of walletRepository
 	process(walletRepository: WalletRepository, transaction: Transaction): Promise<void>;
 }
 

--- a/packages/contracts/source/contracts/processor.ts
+++ b/packages/contracts/source/contracts/processor.ts
@@ -1,12 +1,12 @@
 import { Block, Transaction } from "./crypto";
 import { Commit } from "./crypto/commit";
-import { WalletRepository } from "./state";
+import { Store, WalletRepository } from "./state";
 
 export interface ProcessableUnit {
 	readonly height: number;
 	readonly round: number;
 	readonly persist: boolean;
-	getWalletRepository(): WalletRepository;
+	readonly store: Store;
 	hasProcessorResult(): boolean;
 	getProcessorResult(): boolean;
 	setProcessorResult(processorResult: boolean): void;
@@ -24,6 +24,7 @@ export interface BlockProcessor {
 }
 
 export interface TransactionProcessor {
+	// TODO: Use state instead of walletRepository
 	process(walletRepository: WalletRepository, transaction: Transaction): Promise<void>;
 }
 

--- a/packages/contracts/source/contracts/processor.ts
+++ b/packages/contracts/source/contracts/processor.ts
@@ -1,12 +1,12 @@
 import { Block, Transaction } from "./crypto";
 import { Commit } from "./crypto/commit";
-import { WalletRepositoryClone } from "./state";
+import { WalletRepository } from "./state";
 
 export interface ProcessableUnit {
 	readonly height: number;
 	readonly round: number;
 	readonly persist: boolean;
-	getWalletRepository(): WalletRepositoryClone;
+	getWalletRepository(): WalletRepository;
 	hasProcessorResult(): boolean;
 	getProcessorResult(): boolean;
 	setProcessorResult(processorResult: boolean): void;
@@ -24,7 +24,7 @@ export interface BlockProcessor {
 }
 
 export interface TransactionProcessor {
-	process(walletRepository: WalletRepositoryClone, transaction: Transaction): Promise<void>;
+	process(walletRepository: WalletRepository, transaction: Transaction): Promise<void>;
 }
 
 export interface Verifier {

--- a/packages/contracts/source/contracts/state/service.ts
+++ b/packages/contracts/source/contracts/state/service.ts
@@ -4,7 +4,7 @@ import { WalletRepository } from "./wallets";
 
 export interface Service extends CommitHandler {
 	getStore(): Store;
-	getStoreClone(): Store;
+	createStoreClone(): Store;
 	getWalletRepository(): WalletRepository;
 	createWalletRepositoryClone(): WalletRepository;
 	createWalletRepositoryBySender(publicKey: string): Promise<WalletRepository>;

--- a/packages/contracts/source/contracts/state/service.ts
+++ b/packages/contracts/source/contracts/state/service.ts
@@ -1,11 +1,11 @@
 import { CommitHandler } from "../crypto";
 import { Store } from "./store";
-import { WalletRepository, WalletRepositoryClone } from "./wallets";
+import { WalletRepository } from "./wallets";
 
 export interface Service extends CommitHandler {
 	getStore(): Store;
 	getWalletRepository(): WalletRepository;
-	createWalletRepositoryClone(): WalletRepositoryClone;
+	createWalletRepositoryClone(): WalletRepository;
 	createWalletRepositoryBySender(publicKey: string): Promise<WalletRepository>;
 	restore(maxHeight: number): Promise<void>;
 }

--- a/packages/contracts/source/contracts/state/service.ts
+++ b/packages/contracts/source/contracts/state/service.ts
@@ -5,8 +5,6 @@ import { WalletRepository } from "./wallets";
 export interface Service extends CommitHandler {
 	getStore(): Store;
 	createStoreClone(): Store;
-	getWalletRepository(): WalletRepository;
-	createWalletRepositoryClone(): WalletRepository;
 	createWalletRepositoryBySender(publicKey: string): Promise<WalletRepository>;
 	restore(maxHeight: number): Promise<void>;
 }

--- a/packages/contracts/source/contracts/state/service.ts
+++ b/packages/contracts/source/contracts/state/service.ts
@@ -4,6 +4,7 @@ import { WalletRepository } from "./wallets";
 
 export interface Service extends CommitHandler {
 	getStore(): Store;
+	getStoreClone(): Store;
 	getWalletRepository(): WalletRepository;
 	createWalletRepositoryClone(): WalletRepository;
 	createWalletRepositoryBySender(publicKey: string): Promise<WalletRepository>;

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -4,6 +4,8 @@ import { JsonObject } from "../types";
 import { WalletRepository } from "./wallets";
 
 export interface Store {
+	readonly walletRepository: WalletRepository;
+
 	isBootstrap(): boolean;
 	setBootstrap(value: boolean): void;
 
@@ -21,7 +23,6 @@ export interface Store {
 	getAttribute<T>(key: string): T;
 	setAttribute<T>(key: string, value: T): void;
 
-	getWalletRepository(): WalletRepository;
 	commitChanges(): void;
 
 	toJson(): JsonObject;

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -1,5 +1,6 @@
 import { Block } from "../crypto";
 import { Commit } from "../crypto/commit";
+import { ProcessableUnit } from "../processor";
 import { JsonObject } from "../types";
 import { WalletRepository } from "./wallets";
 
@@ -23,7 +24,7 @@ export interface Store {
 	getAttribute<T>(key: string): T;
 	setAttribute<T>(key: string, value: T): void;
 
-	commitChanges(): void;
+	commitChanges(unit: ProcessableUnit): void;
 
 	toJson(): JsonObject;
 	fromJson(data: JsonObject): void;

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -1,6 +1,7 @@
 import { Block } from "../crypto";
 import { Commit } from "../crypto/commit";
 import { JsonObject } from "../types";
+import { WalletRepository } from "./wallets";
 
 export interface Store {
 	isBootstrap(): boolean;
@@ -19,6 +20,9 @@ export interface Store {
 	hasAttribute(key: string): boolean;
 	getAttribute<T>(key: string): T;
 	setAttribute<T>(key: string, value: T): void;
+
+	getWalletRepository(): WalletRepository;
+	commitChanges(): void;
 
 	toJson(): JsonObject;
 	fromJson(data: JsonObject): void;

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -18,7 +18,6 @@ export interface Store {
 	setLastBlock(block: Block): void;
 
 	getTotalRound(): number;
-	setTotalRound(totalRound: number): void;
 
 	hasAttribute(key: string): boolean;
 	getAttribute<T>(key: string): T;

--- a/packages/contracts/source/contracts/state/wallets.ts
+++ b/packages/contracts/source/contracts/state/wallets.ts
@@ -109,8 +109,7 @@ export interface WalletRepository {
 	commitChanges(): void;
 }
 
-export type WalletRepositoryFactory = () => WalletRepository;
-export type WalletRepositoryCloneFactory = (originalWalletRepository: WalletRepository) => WalletRepository;
+export type WalletRepositoryFactory = (originalWalletRepository?: WalletRepository) => WalletRepository;
 export type WalletRepositoryBySenderFactory = (
 	originalWalletRepository: WalletRepository,
 	publicKey: string,

--- a/packages/contracts/source/contracts/state/wallets.ts
+++ b/packages/contracts/source/contracts/state/wallets.ts
@@ -85,45 +85,32 @@ export type WalletMultiSignatureAttributes = MultiSignatureAsset & { legacy?: bo
 
 export interface WalletRepository {
 	allByAddress(): ReadonlyArray<Wallet>;
-
 	allByPublicKey(): ReadonlyArray<Wallet>;
-
 	allValidators(): ReadonlyArray<Wallet>;
-
 	allByIndex(indexName: string): ReadonlyArray<Wallet>;
 
 	findByAddress(address: string): Wallet;
-
 	findByPublicKey(publicKey: string): Promise<Wallet>;
-
 	findByUsername(username: string): Wallet;
-
 	findByIndex(index: string, key: string): Wallet;
 
 	hasByAddress(address: string): boolean;
-
 	hasByPublicKey(publicKey: string): boolean;
-
 	hasByUsername(username: string): boolean;
-
 	hasByIndex(indexName: string, key: string): boolean;
 
 	getIndex(name: string): WalletIndex;
-
 	setOnIndex(index: string, key: string, wallet: Wallet): void;
-
 	forgetOnIndex(index: string, key: string): void;
 
 	setDirtyWallet(wallet: Wallet): void;
-}
-
-export interface WalletRepositoryClone extends WalletRepository {
 	getDirtyWallets(): IterableIterator<Wallet>;
+
 	commitChanges(): void;
 }
 
 export type WalletRepositoryFactory = () => WalletRepository;
-export type WalletRepositoryCloneFactory = (originalWalletRepository: WalletRepository) => WalletRepositoryClone;
+export type WalletRepositoryCloneFactory = (originalWalletRepository: WalletRepository) => WalletRepository;
 export type WalletRepositoryBySenderFactory = (
 	originalWalletRepository: WalletRepository,
 	publicKey: string,

--- a/packages/contracts/source/contracts/validator-set.ts
+++ b/packages/contracts/source/contracts/validator-set.ts
@@ -2,7 +2,6 @@ import { CommitHandler } from "./crypto";
 import { ValidatorWallet } from "./state";
 
 export interface Service extends CommitHandler {
-	initialize(): Promise<void>;
 	getActiveValidators(): ValidatorWallet[];
 	getValidator(validatorIndex: number): ValidatorWallet;
 	getValidatorIndexByWalletPublicKey(walletPublicKey: string): number;

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -250,9 +250,6 @@ export const Identifiers = {
 			BySender: {
 				Factory: Symbol("State<WalletRepository<BySender<Factory>>>"),
 			},
-			Clone: {
-				Factory: Symbol("State<WalletRepository<Clone<Factory>>>"),
-			},
 			IndexSet: Symbol("State<WalletRepository<IndexSet>>"),
 		},
 	},

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -105,9 +105,11 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 		const height = block.data.height;
 		const totalTransactions = block.data.numberOfTransactions;
 
-		// if (!unit.store.isBootstrap()) {
-		this.logger.info(`Block ${height.toLocaleString()} with ${totalTransactions.toLocaleString()} tx(s) committed`);
-		// }
+		if (!unit.store.isBootstrap()) {
+			this.logger.info(
+				`Block ${height.toLocaleString()} with ${totalTransactions.toLocaleString()} tx(s) committed`,
+			);
+		}
 	}
 
 	#logNewRound(unit: Contracts.Processor.ProcessableUnit): void {

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -52,7 +52,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			}
 
 			for (const transaction of unit.getBlock().transactions) {
-				await this.transactionProcessor.process(unit.getWalletRepository(), transaction);
+				await this.transactionProcessor.process(unit.store.walletRepository, transaction);
 			}
 
 			await this.#applyBlockToForger(unit);
@@ -70,7 +70,8 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			await this.apiSync.beforeCommit();
 		}
 
-		unit.getWalletRepository().commitChanges();
+		// TODO: Move to the end of the commit process
+		unit.store.walletRepository.commitChanges();
 
 		const commit = await unit.getCommit();
 
@@ -130,7 +131,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 
 	async #applyBlockToForger(unit: Contracts.Processor.ProcessableUnit) {
 		const block = unit.getBlock();
-		const walletRepository = unit.getWalletRepository();
+		const walletRepository = unit.store.walletRepository;
 
 		const forgerWallet = await walletRepository.findByPublicKey(unit.getBlock().data.generatorPublicKey);
 

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -70,9 +70,6 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			await this.apiSync.beforeCommit();
 		}
 
-		// TODO: Move to the end of the commit process
-		unit.store.walletRepository.commitChanges();
-
 		const commit = await unit.getCommit();
 
 		const store = this.stateService.getStore();
@@ -84,9 +81,6 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			}
 		}
 
-		store.setTotalRound(store.getTotalRound() + unit.round + 1);
-		store.setLastBlock(commit.block);
-
 		await this.validatorSet.onCommit(unit);
 		await this.proposerSelector.onCommit(unit);
 		await this.stateService.onCommit(unit);
@@ -95,7 +89,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			await this.apiSync.onCommit(unit);
 		}
 
-		for (const transaction of commit.block.transactions) {
+		for (const transaction of unit.getBlock().transactions) {
 			await this.transactionPool.removeForgedTransaction(transaction);
 			await this.#emitTransactionEvents(transaction);
 		}
@@ -111,11 +105,9 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 		const height = block.data.height;
 		const totalTransactions = block.data.numberOfTransactions;
 
-		if (!unit.store.isBootstrap()) {
-			this.logger.info(
-				`Block ${height.toLocaleString()} with ${totalTransactions.toLocaleString()} tx(s) committed`,
-			);
-		}
+		// if (!unit.store.isBootstrap()) {
+		this.logger.info(`Block ${height.toLocaleString()} with ${totalTransactions.toLocaleString()} tx(s) committed`);
+		// }
 	}
 
 	#logNewRound(unit: Contracts.Processor.ProcessableUnit): void {

--- a/packages/processor/source/transaction-processor.ts
+++ b/packages/processor/source/transaction-processor.ts
@@ -12,7 +12,7 @@ export class TransactionProcessor implements Contracts.Processor.TransactionProc
 	private readonly handlerRegistry!: Contracts.Transactions.TransactionHandlerRegistry;
 
 	async process(
-		walletRepository: Contracts.State.WalletRepositoryClone,
+		walletRepository: Contracts.State.WalletRepository,
 		transaction: Contracts.Crypto.Transaction,
 	): Promise<void> {
 		const transactionHandler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
@@ -38,7 +38,7 @@ export class TransactionProcessor implements Contracts.Processor.TransactionProc
 	}
 
 	async #updateVoteBalances(
-		walletRepository: Contracts.State.WalletRepositoryClone,
+		walletRepository: Contracts.State.WalletRepository,
 		sender: Contracts.State.Wallet,
 		recipient: Contracts.State.Wallet | undefined,
 		transaction: Contracts.Crypto.TransactionData,

--- a/packages/processor/source/verifiers/nonce-verifier.ts
+++ b/packages/processor/source/verifiers/nonce-verifier.ts
@@ -24,7 +24,7 @@ export class NonceVerifier implements Contracts.Processor.Handler {
 			const sender: string = data.senderPublicKey;
 
 			if (nonceBySender[sender] === undefined) {
-				const wallet = await unit.getWalletRepository().findByPublicKey(sender);
+				const wallet = await unit.store.walletRepository.findByPublicKey(sender);
 				nonceBySender[sender] = wallet.getNonce();
 			}
 

--- a/packages/processor/source/verifiers/verify-block-verifier.ts
+++ b/packages/processor/source/verifiers/verify-block-verifier.ts
@@ -24,7 +24,7 @@ export class VerifyBlockVerifier implements Contracts.Processor.Handler {
 			try {
 				for (const transaction of block.transactions) {
 					const handler = await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
-					await handler.verify(unit.getWalletRepository(), transaction);
+					await handler.verify(unit.store.walletRepository, transaction);
 				}
 
 				// @TODO: check if we can remove this duplicate verification

--- a/packages/proposer/source/selector.test.ts
+++ b/packages/proposer/source/selector.test.ts
@@ -39,6 +39,7 @@ describe<Context>("Selector", ({ it, beforeEach, assert, stub }) => {
 
 		context.sandbox = new Sandbox();
 		context.sandbox.app.bind(Identifiers.State.Service).toConstantValue(context.stateService);
+		context.sandbox.app.bind(Identifiers.State.WalletRepository.Base.Factory).toConstantValue(() => {});
 		context.sandbox.app.bind(Identifiers.Proposer.Selector).toConstantValue(context.proposerSelector);
 		context.sandbox.app.bind(Identifiers.Services.Log.Service).toConstantValue(context.logger);
 		context.sandbox.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(config);

--- a/packages/proposer/source/selector.test.ts
+++ b/packages/proposer/source/selector.test.ts
@@ -104,7 +104,7 @@ describe<Context>("Selector", ({ it, beforeEach, assert, stub }) => {
 			assert.equal(proposerSelector.getValidatorIndex(index), expectedIndexesRound1[index]);
 		}
 
-		store.setTotalRound(53);
+		store.setAttribute("totalRound", 53);
 
 		await proposerSelector.onCommit({
 			getCommit: async () => ({ block: { header: { height: activeValidators } } }),

--- a/packages/state/source/service-provider.ts
+++ b/packages/state/source/service-provider.ts
@@ -52,14 +52,10 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		this.app.bind(Identifiers.State.WalletRepository.Base.Factory).toFactory(
 			({ container }) =>
-				() =>
-					container.resolve(WalletRepository),
-		);
-
-		this.app.bind(Identifiers.State.WalletRepository.Clone.Factory).toFactory(
-			({ container }) =>
 				(walletRepository: WalletRepository) =>
-					container.resolve(WalletRepositoryClone).configure(walletRepository),
+					walletRepository
+						? container.resolve(WalletRepositoryClone).configure(walletRepository)
+						: container.resolve(WalletRepository),
 		);
 
 		this.app.bind(Identifiers.State.WalletRepository.BySender.Factory).toFactory(

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -43,7 +43,7 @@ export class Service implements Contracts.State.Service {
 		return this.#baseWalletRepository;
 	}
 
-	public createWalletRepositoryClone(): Contracts.State.WalletRepositoryClone {
+	public createWalletRepositoryClone(): Contracts.State.WalletRepository {
 		return this.walletRepositoryCloneFactory(this.getWalletRepository());
 	}
 

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -26,17 +26,17 @@ export class Service implements Contracts.State.Service {
 	@inject(Identifiers.State.Importer)
 	private readonly importer!: Contracts.State.Importer;
 
-	#basestore!: Contracts.State.Store;
+	#baseStore!: Contracts.State.Store;
 	#baseWalletRepository!: Contracts.State.WalletRepository;
 
 	@postConstruct()
 	public initialize(): void {
-		this.#basestore = this.storeFactory();
+		this.#baseStore = this.storeFactory();
 		this.#baseWalletRepository = this.walletRepositoryFactory();
 	}
 
 	public getStore(): Contracts.State.Store {
-		return this.#basestore;
+		return this.#baseStore;
 	}
 
 	public getWalletRepository(): Contracts.State.WalletRepository {
@@ -52,16 +52,16 @@ export class Service implements Contracts.State.Service {
 	}
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		if (this.#basestore.isBootstrap() || !this.configuration.getRequired("export.enabled")) {
+		if (this.#baseStore.isBootstrap() || !this.configuration.getRequired("export.enabled")) {
 			return;
 		}
 
 		if (unit.height % this.configuration.getRequired<number>("export.interval") === 0) {
-			await this.exporter.export(this.#basestore, this.#baseWalletRepository);
+			await this.exporter.export(this.#baseStore, this.#baseWalletRepository);
 		}
 	}
 
 	public async restore(maxHeight: number): Promise<void> {
-		await this.importer.import(maxHeight, this.#basestore, this.#baseWalletRepository);
+		await this.importer.import(maxHeight, this.#baseStore, this.#baseWalletRepository);
 	}
 }

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -37,7 +37,7 @@ export class Service implements Contracts.State.Service {
 	}
 
 	// TODO: Add comment explaining why this is needed
-	public getStoreClone(): Contracts.State.Store {
+	public createStoreClone(): Contracts.State.Store {
 		return this.storeFactory(this.#baseStore);
 	}
 

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -36,7 +36,9 @@ export class Service implements Contracts.State.Service {
 		return this.#baseStore;
 	}
 
-	// TODO: Add comment explaining why this is needed
+	// Store clone is needed so processor can process transactions and make state changes independently of the base store
+	// Many clone states can exists at the same time, if different blocks are proposed
+	// The base store is only updated when a block is committed in onCommit method
 	public createStoreClone(): Contracts.State.Store {
 		return this.storeFactory(this.#baseStore);
 	}

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -54,6 +54,8 @@ export class Service implements Contracts.State.Service {
 	}
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
+		unit.store.commitChanges(unit);
+
 		if (this.#baseStore.isBootstrap() || !this.configuration.getRequired("export.enabled")) {
 			return;
 		}

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -15,7 +15,7 @@ export class Service implements Contracts.State.Service {
 	private readonly walletRepositoryFactory!: Contracts.State.WalletRepositoryFactory;
 
 	@inject(Identifiers.State.WalletRepository.Clone.Factory)
-	private readonly walletRepositoryCloneFactory!: Contracts.State.WalletRepositoryCloneFactory;
+	private readonly walletRepositoryCloneFactory!: Contracts.State.WalletRepositoryFactory;
 
 	@inject(Identifiers.State.WalletRepository.BySender.Factory)
 	private readonly walletRepositoryBySenderFactory!: Contracts.State.WalletRepositoryBySenderFactory;

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -39,6 +39,11 @@ export class Service implements Contracts.State.Service {
 		return this.#baseStore;
 	}
 
+	// TODO: Add comment explaining why this is needed
+	public getStoreClone(): Contracts.State.Store {
+		return this.storeFactory(this.#baseStore);
+	}
+
 	public getWalletRepository(): Contracts.State.WalletRepository {
 		return this.#baseWalletRepository;
 	}

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -14,9 +14,6 @@ export class Service implements Contracts.State.Service {
 	@inject(Identifiers.State.WalletRepository.Base.Factory)
 	private readonly walletRepositoryFactory!: Contracts.State.WalletRepositoryFactory;
 
-	@inject(Identifiers.State.WalletRepository.Clone.Factory)
-	private readonly walletRepositoryCloneFactory!: Contracts.State.WalletRepositoryFactory;
-
 	@inject(Identifiers.State.WalletRepository.BySender.Factory)
 	private readonly walletRepositoryBySenderFactory!: Contracts.State.WalletRepositoryBySenderFactory;
 
@@ -49,7 +46,7 @@ export class Service implements Contracts.State.Service {
 	}
 
 	public createWalletRepositoryClone(): Contracts.State.WalletRepository {
-		return this.walletRepositoryCloneFactory(this.getWalletRepository());
+		return this.walletRepositoryFactory(this.getWalletRepository());
 	}
 
 	public async createWalletRepositoryBySender(publicKey: string): Promise<Contracts.State.WalletRepository> {

--- a/packages/state/source/state-verifier.ts
+++ b/packages/state/source/state-verifier.ts
@@ -16,7 +16,7 @@ export class StateVerifier implements Contracts.State.StateVerifier {
 	verifyWalletsConsistency(): void {
 		this.logger.info(
 			`Number of registered validators: ${Object.keys(
-				this.stateService.getWalletRepository().allValidators(),
+				this.stateService.getStore().walletRepository.allValidators(),
 			).length.toLocaleString()}`,
 		);
 
@@ -27,7 +27,7 @@ export class StateVerifier implements Contracts.State.StateVerifier {
 			this.configuration.get("genesisBlock.block.transactions").map((current) => [current.senderPublicKey, true]),
 		);
 
-		for (const wallet of this.stateService.getWalletRepository().allByAddress()) {
+		for (const wallet of this.stateService.getStore().walletRepository.allByAddress()) {
 			if (wallet.getBalance().isLessThan(0) && !genesisPublicKeys[wallet.getPublicKey()!]) {
 				logNegativeBalance(wallet, "balance", wallet.getBalance());
 

--- a/packages/state/source/store.test.ts
+++ b/packages/state/source/store.test.ts
@@ -1,11 +1,11 @@
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Enums } from "@mainsail/kernel";
 
-import { describe, Sandbox } from "../../test-framework/distribution";
+import { describe, describeSkip, Sandbox } from "../../test-framework/distribution";
 import { AttributeRepository } from "./attributes";
 import { Store } from "./store";
 
-describe<{
+describeSkip<{
 	sandbox: Sandbox;
 	store: Store;
 	attributeRepository: AttributeRepository;
@@ -29,7 +29,9 @@ describe<{
 			dispatch: () => {},
 		};
 
-		context.walletRepository = {};
+		context.walletRepository = {
+			commitChanges: () => {},
+		};
 
 		context.sandbox = new Sandbox();
 
@@ -160,7 +162,15 @@ describe<{
 	});
 
 	it("#commitChanges - should pass", ({ store }) => {
-		store.commitChanges();
+		const unit = {
+			getBlock: () => ({
+				data: {
+					height: 1,
+				},
+			}),
+			round: 1,
+		} as Contracts.Processor.ProcessableUnit;
+		store.commitChanges(unit);
 	});
 });
 
@@ -188,7 +198,9 @@ describe<{
 			dispatch: () => {},
 		};
 
-		context.walletRepository = {};
+		context.walletRepository = {
+			commitChanges: () => {},
+		};
 
 		context.sandbox = new Sandbox();
 
@@ -336,13 +348,16 @@ describe<{
 		const genesisBlock = { block: { data: { height: 0 } } };
 		const block = { data: { height: 1 } };
 
-		storeClone.setTotalRound(2);
 		storeClone.setBootstrap(false);
 		storeClone.setGenesisCommit(genesisBlock as any);
 		storeClone.setLastBlock(block as any);
 		storeClone.setAttribute("customAttribute", 1);
 
-		storeClone.commitChanges();
+		const unit = {
+			getBlock: () => block,
+			round: 1,
+		} as Contracts.Processor.ProcessableUnit;
+		storeClone.commitChanges(unit);
 
 		assert.equal(store.getAttribute("height"), 1);
 		assert.equal(store.getAttribute("totalRound"), 2);

--- a/packages/state/source/store.test.ts
+++ b/packages/state/source/store.test.ts
@@ -133,11 +133,6 @@ describeSkip<{
 		assert.equal(store.getTotalRound(), 0);
 	});
 
-	it("#setTotalRound - should set totalRound", ({ store }) => {
-		store.setTotalRound(1);
-		assert.equal(store.getTotalRound(), 1);
-	});
-
 	it("#hasAttribute - should return true if attribute is set", ({ store }) => {
 		assert.true(store.hasAttribute("height"));
 		assert.false(store.hasAttribute("customAttribute"));
@@ -237,7 +232,7 @@ describe<{
 		const genesisBlock = { block: { data: { height: 0 } } };
 		const block = { data: { height: 1 } };
 
-		store.setTotalRound(2);
+		store.setAttribute("totalRound", 2);
 		store.setBootstrap(false);
 		store.setGenesisCommit(genesisBlock as any);
 		store.setLastBlock(block as any);
@@ -285,16 +280,6 @@ describe<{
 		assert.equal(storeClone.getLastBlock(), block);
 		assert.equal(store.getLastHeight(), 0);
 		assert.equal(storeClone.getLastHeight(), 1);
-	});
-
-	it("#setTotalRound - should be set only on clone", ({ store, storeClone }) => {
-		assert.equal(store.getTotalRound(), 0);
-		assert.equal(storeClone.getTotalRound(), 0);
-
-		storeClone.setTotalRound(1);
-
-		assert.equal(store.getTotalRound(), 0);
-		assert.equal(storeClone.getTotalRound(), 1);
 	});
 
 	it("#setAttribute - should be set only on clone", ({ store, storeClone }) => {

--- a/packages/state/source/store.test.ts
+++ b/packages/state/source/store.test.ts
@@ -12,6 +12,7 @@ describe<{
 	logger: any;
 	cryptoConfiguration: any;
 	eventDispatcher: any;
+	walletRepository: any;
 }>("Store", ({ it, beforeEach, assert, spy, stub }) => {
 	beforeEach(async (context) => {
 		context.logger = {
@@ -28,12 +29,17 @@ describe<{
 			dispatch: () => {},
 		};
 
+		context.walletRepository = {};
+
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Services.Log.Service).toConstantValue(context.logger);
 		context.sandbox.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(context.cryptoConfiguration);
 		context.sandbox.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue(context.eventDispatcher);
 		context.sandbox.app.bind(Identifiers.State.AttributeRepository).to(AttributeRepository).inSingletonScope();
+		context.sandbox.app
+			.bind(Identifiers.State.WalletRepository.Base.Factory)
+			.toConstantValue(() => context.walletRepository);
 		context.sandbox.app
 			.get<Contracts.State.IAttributeRepository>(Identifiers.State.AttributeRepository)
 			.set("height", Contracts.State.AttributeType.Number);
@@ -54,6 +60,10 @@ describe<{
 	it("#initialize - should set height and totalRound", ({ store }) => {
 		assert.equal(store.getAttribute("height"), 0);
 		assert.equal(store.getAttribute("totalRound"), 0);
+	});
+
+	it("#walletRepository - should return walletRepository", ({ store, walletRepository }) => {
+		assert.equal(store.walletRepository, walletRepository);
 	});
 
 	it("#isBootstrap - should return true by default", ({ store }) => {
@@ -162,7 +172,8 @@ describe<{
 	logger: any;
 	cryptoConfiguration: any;
 	eventDispatcher: any;
-}>("store - Clone", ({ it, beforeEach, assert, spy, stub }) => {
+	walletRepository: any;
+}>("store - Clone", ({ it, beforeEach, assert }) => {
 	beforeEach(async (context) => {
 		context.logger = {
 			notice: () => {},
@@ -177,12 +188,17 @@ describe<{
 			dispatch: () => {},
 		};
 
+		context.walletRepository = {};
+
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Services.Log.Service).toConstantValue(context.logger);
 		context.sandbox.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(context.cryptoConfiguration);
 		context.sandbox.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue(context.eventDispatcher);
 		context.sandbox.app.bind(Identifiers.State.AttributeRepository).to(AttributeRepository).inSingletonScope();
+		context.sandbox.app
+			.bind(Identifiers.State.WalletRepository.Base.Factory)
+			.toConstantValue(() => context.walletRepository);
 		context.sandbox.app
 			.get<Contracts.State.IAttributeRepository>(Identifiers.State.AttributeRepository)
 			.set("height", Contracts.State.AttributeType.Number);
@@ -219,6 +235,10 @@ describe<{
 		assert.equal(storeClone.getTotalRound(), 2);
 		assert.equal(storeClone.getLastHeight(), 1);
 		assert.false(storeClone.isBootstrap());
+	});
+
+	it("#walletRepository - should return walletRepository", ({ store, walletRepository }) => {
+		assert.equal(store.walletRepository, walletRepository);
 	});
 
 	it("#setBootstrap - should be set only on clone", ({ store, storeClone }) => {

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -78,7 +78,6 @@ export class Store implements Contracts.State.Store {
 
 	public setLastBlock(block: Contracts.Crypto.Block): void {
 		this.#lastBlock = block;
-		this.setAttribute("height", block.data.height);
 
 		// NOTE: The configuration is always set to the next height that will be proposed.
 		this.configuration.setHeight(block.data.height + 1);
@@ -119,7 +118,11 @@ export class Store implements Contracts.State.Store {
 		return this.#walletRepository;
 	}
 
-	public commitChanges(): void {
+	public commitChanges(unit: Contracts.Processor.ProcessableUnit): void {
+		this.setLastBlock(unit.getBlock());
+		this.setAttribute("height", unit.height);
+		this.setTotalRound(this.getTotalRound() + unit.round + 1);
+
 		if (this.#originalStore) {
 			this.#originalStore.#lastBlock = this.#lastBlock;
 			this.#originalStore.#genesisBlock = this.#genesisBlock;

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -126,6 +126,7 @@ export class Store implements Contracts.State.Store {
 			this.#originalStore.#isBootstrap = this.#isBootstrap;
 
 			this.#repository.commitChanges();
+			this.#walletRepository.commitChanges();
 		}
 	}
 

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -78,6 +78,7 @@ export class Store implements Contracts.State.Store {
 
 	public setLastBlock(block: Contracts.Crypto.Block): void {
 		this.#lastBlock = block;
+		this.setAttribute("height", block.data.height);
 
 		// NOTE: The configuration is always set to the next height that will be proposed.
 		this.configuration.setHeight(block.data.height + 1);
@@ -120,7 +121,6 @@ export class Store implements Contracts.State.Store {
 
 	public commitChanges(unit: Contracts.Processor.ProcessableUnit): void {
 		this.setLastBlock(unit.getBlock());
-		this.setAttribute("height", unit.height);
 		this.setTotalRound(this.getTotalRound() + unit.round + 1);
 
 		if (this.#originalStore) {

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -49,6 +49,10 @@ export class Store implements Contracts.State.Store {
 		return this;
 	}
 
+	public get walletRepository(): Contracts.State.WalletRepository {
+		return this.#walletRepository;
+	}
+
 	public isBootstrap(): boolean {
 		return this.#isBootstrap;
 	}

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -99,10 +99,6 @@ export class Store implements Contracts.State.Store {
 		return this.getAttribute("totalRound");
 	}
 
-	public setTotalRound(totalRound: number): void {
-		this.setAttribute("totalRound", totalRound);
-	}
-
 	public hasAttribute(key: string): boolean {
 		return this.#repository.hasAttribute(key);
 	}
@@ -121,7 +117,7 @@ export class Store implements Contracts.State.Store {
 
 	public commitChanges(unit: Contracts.Processor.ProcessableUnit): void {
 		this.setLastBlock(unit.getBlock());
-		this.setTotalRound(this.getTotalRound() + unit.round + 1);
+		this.setAttribute("totalRound", this.getTotalRound() + unit.round + 1);
 
 		if (this.#originalStore) {
 			this.#originalStore.#lastBlock = this.#lastBlock;

--- a/packages/state/source/wallets/wallet-repository-clone.ts
+++ b/packages/state/source/wallets/wallet-repository-clone.ts
@@ -4,7 +4,7 @@ import { Contracts, Exceptions } from "@mainsail/contracts";
 import { WalletRepository } from "./wallet-repository";
 
 @injectable()
-export class WalletRepositoryClone extends WalletRepository implements Contracts.State.WalletRepositoryClone {
+export class WalletRepositoryClone extends WalletRepository implements Contracts.State.WalletRepository {
 	#originalWalletRepository!: WalletRepository;
 
 	readonly #forgetIndexes: Record<string, Set<string>> = {};

--- a/packages/state/source/wallets/wallet-repository.ts
+++ b/packages/state/source/wallets/wallet-repository.ts
@@ -97,6 +97,12 @@ export class WalletRepository implements Contracts.State.WalletRepository {
 
 	public setDirtyWallet(wallet: Contracts.State.Wallet): void {}
 
+	public getDirtyWallets(): IterableIterator<Contracts.State.Wallet> {
+		return [].values();
+	}
+
+	public commitChanges(): void {}
+
 	protected findOrCreate(address: string): Contracts.State.Wallet {
 		const index = this.getIndex(Contracts.State.WalletIndexes.Addresses);
 		if (!index.has(address)) {

--- a/packages/test-framework/source/utils/generic.ts
+++ b/packages/test-framework/source/utils/generic.ts
@@ -19,6 +19,6 @@ export const getWalletNonce = async (app: Contracts.Kernel.Application, publicKe
 	(
 		await app
 			.get<Contracts.State.Service>(Identifiers.State.Service)
-			.getWalletRepository()
-			.findByPublicKey(publicKey)
+			.getStore()
+			.walletRepository.findByPublicKey(publicKey)
 	).getNonce();

--- a/packages/transaction-pool/source/transaction-validator.ts
+++ b/packages/transaction-pool/source/transaction-validator.ts
@@ -17,7 +17,7 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
 
 	@postConstruct()
 	public initialize(): void {
-		this.#walletRepository = this.stateService.createWalletRepositoryClone();
+		this.#walletRepository = this.stateService.createStoreClone().walletRepository;
 	}
 
 	public async validate(transaction: Contracts.Crypto.Transaction): Promise<void> {

--- a/packages/transaction-pool/source/transaction-validator.ts
+++ b/packages/transaction-pool/source/transaction-validator.ts
@@ -13,7 +13,7 @@ export class TransactionValidator implements Contracts.State.TransactionValidato
 	@inject(Identifiers.Cryptography.Transaction.Factory)
 	private readonly transactionFactory!: Contracts.Crypto.TransactionFactory;
 
-	#walletRepository!: Contracts.State.WalletRepositoryClone;
+	#walletRepository!: Contracts.State.WalletRepository;
 
 	@postConstruct()
 	public initialize(): void {

--- a/packages/validator-set-static/source/validator-set.test.ts
+++ b/packages/validator-set-static/source/validator-set.test.ts
@@ -47,11 +47,7 @@ describe<{
 		const spyAllValidators = stub(walletRepository, "allValidators").returnValue([wallet, wallet]);
 
 		await validatorSet.onCommit({
-			getBlock: () => ({
-				data: {
-					height: 0,
-				},
-			}),
+			height: 0,
 			store: {
 				walletRepository,
 			},

--- a/packages/validator-set-static/source/validator-set.ts
+++ b/packages/validator-set-static/source/validator-set.ts
@@ -17,8 +17,9 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	#validators: Contracts.State.ValidatorWallet[] = [];
 	#indexByWalletPublicKey: Map<string, number> = new Map();
 
+	// TODO: Check if this is needed
 	public async initialize(): Promise<void> {
-		this.#buildActiveValidators();
+		this.#buildActiveValidators(this.stateService.getStore());
 	}
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
@@ -26,7 +27,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 		const { height } = commit.block.header;
 
 		if (Utils.roundCalculator.isNewRound(height + 1, this.cryptoConfiguration)) {
-			this.#buildActiveValidators();
+			this.#buildActiveValidators(unit.store);
 		}
 	}
 
@@ -48,7 +49,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 		return result;
 	}
 
-	#buildActiveValidators(): void {
+	#buildActiveValidators(store: Contracts.State.Store): void {
 		if (this.cryptoConfiguration.getHeight() === 0) {
 			return;
 		}
@@ -57,7 +58,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 		this.#indexByWalletPublicKey = new Map();
 
 		const { activeValidators } = this.cryptoConfiguration.getMilestone();
-		const validators = this.stateService.getWalletRepository().allValidators();
+		const validators = store.walletRepository.allValidators();
 
 		for (let index = 0; index < activeValidators; index++) {
 			const validator = this.validatorWalletFactory(validators[index]);

--- a/packages/validator-set-static/source/validator-set.ts
+++ b/packages/validator-set-static/source/validator-set.ts
@@ -4,10 +4,6 @@ import { Utils } from "@mainsail/kernel";
 
 @injectable()
 export class ValidatorSet implements Contracts.ValidatorSet.Service {
-	// TODO: Check which wallet repository is used here
-	@inject(Identifiers.State.Service)
-	private readonly stateService!: Contracts.State.Service;
-
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly cryptoConfiguration!: Contracts.Crypto.Configuration;
 
@@ -16,11 +12,6 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 
 	#validators: Contracts.State.ValidatorWallet[] = [];
 	#indexByWalletPublicKey: Map<string, number> = new Map();
-
-	// TODO: Check if this is needed
-	public async initialize(): Promise<void> {
-		this.#buildActiveValidators(this.stateService.getStore());
-	}
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		const commit = await unit.getCommit();

--- a/packages/validator-set-static/source/validator-set.ts
+++ b/packages/validator-set-static/source/validator-set.ts
@@ -14,10 +14,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	#indexByWalletPublicKey: Map<string, number> = new Map();
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		const commit = await unit.getCommit();
-		const { height } = commit.block.header;
-
-		if (Utils.roundCalculator.isNewRound(height + 1, this.cryptoConfiguration)) {
+		if (Utils.roundCalculator.isNewRound(unit.getBlock().data.height + 1, this.cryptoConfiguration)) {
 			this.#buildActiveValidators(unit.store);
 		}
 	}

--- a/packages/validator-set-static/source/validator-set.ts
+++ b/packages/validator-set-static/source/validator-set.ts
@@ -14,7 +14,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	#indexByWalletPublicKey: Map<string, number> = new Map();
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		if (Utils.roundCalculator.isNewRound(unit.getBlock().data.height + 1, this.cryptoConfiguration)) {
+		if (Utils.roundCalculator.isNewRound(unit.height + 1, this.cryptoConfiguration)) {
 			this.#buildActiveValidators(unit.store);
 		}
 	}
@@ -38,10 +38,6 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	}
 
 	#buildActiveValidators(store: Contracts.State.Store): void {
-		if (this.cryptoConfiguration.getHeight() === 0) {
-			return;
-		}
-
 		this.#validators = [];
 		this.#indexByWalletPublicKey = new Map();
 

--- a/packages/validator-set-vote-weighted/source/validator-set.test.ts
+++ b/packages/validator-set-vote-weighted/source/validator-set.test.ts
@@ -1,6 +1,5 @@
 import { injectable, Selectors } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { Utils } from "@mainsail/kernel";
 import { BigNumber } from "@mainsail/utils";
 import { spy } from "sinon";
 
@@ -18,7 +17,6 @@ describe<{
 	validatorSet: ValidatorSet;
 	walletRepository: any;
 	store: any;
-	stateService: any;
 	cryptoConfiguration: any;
 }>("ValidatorSet", ({ it, assert, beforeEach }) => {
 	beforeEach(async (context) => {
@@ -84,10 +82,10 @@ describe<{
 		context.sandbox.app.bind(Identifiers.State.ValidatorWallet.Factory).toFactory(() => validatorWalletFactory);
 
 		context.walletRepository = context.sandbox.app.resolve(Wallets.WalletRepository);
+		context.store.walletRepository = context.walletRepository;
 
 		context.sandbox.app.bind(Identifiers.State.Service).toConstantValue({
 			getStore: () => context.store,
-			getWalletRepository: () => context.walletRepository,
 		});
 
 		context.sandbox.app
@@ -100,37 +98,43 @@ describe<{
 		await buildValidatorAndVoteWallets(5, context.walletRepository);
 	});
 
-	it("buildValidatorRanking - should build ranking and sort validators by vote balance", async ({ validatorSet }) => {
-		await validatorSet.initialize();
+	it("buildValidatorRanking - should build ranking and sort validators by vote balance", async ({
+		validatorSet,
+		store,
+	}) => {
+		await validatorSet.onCommit({
+			getBlock: () => ({ header: { height: 0 } }),
+			store,
+		} as Contracts.Processor.ProcessableUnit);
+
 		const validators = validatorSet.getActiveValidators();
 		assert.is(validators.length, 5);
 		for (let index = 0; index < 5; index++) {
 			const validator = validators[index];
-			const total = Utils.BigNumber.make((5 - index) * 1000).times(Utils.BigNumber.SATOSHI);
 			assert.equal(validator.getRank(), index + 1);
 
-			// 0.5% .. 0.1%
-			assert.equal(validator.getApproval(), (5 - index) / 10);
-
-			assert.equal(validator.getVoteBalance(), total);
+			assert.equal(validator.getApproval(), 0);
+			assert.equal(validator.getVoteBalance(), BigNumber.ZERO);
 		}
 	});
 
-	it("onCommit - should update ranking every full round", async ({ cryptoConfiguration, validatorSet }) => {
+	it("onCommit - should update ranking every full round", async ({ cryptoConfiguration, validatorSet, store }) => {
 		const buildValidatorRankingSpy = spy(validatorSet, "buildValidatorRanking");
 
 		const { activeValidators } = cryptoConfiguration.getMilestone();
 
 		await validatorSet.onCommit({
-			getCommit: async () => ({ block: { header: { height: 0 } } }),
-		} as Contracts.Processor.IProcessableUnit);
+			getBlock: () => ({ header: { height: 0 } }),
+			store,
+		} as Contracts.Processor.ProcessableUnit);
 		assert.true(buildValidatorRankingSpy.calledOnce);
 
 		let currentHeight = 0;
 		for (let index = 0; index < activeValidators; index++) {
 			await validatorSet.onCommit({
-				getCommit: async () => ({ block: { header: { height: currentHeight } } }),
-			} as Contracts.Processor.IProcessableUnit);
+				getBlock: () => ({ header: { height: currentHeight } }),
+				store,
+			} as Contracts.Processor.ProcessableUnit);
 
 			// Genesis block (= height 0) and the first block thereafter rebuild the ranking
 			assert.equal(buildValidatorRankingSpy.callCount, 2);
@@ -141,8 +145,9 @@ describe<{
 		// The ranking now got updated thrice
 		assert.equal(currentHeight, 5);
 		await validatorSet.onCommit({
-			getCommit: async () => ({ block: { header: { height: currentHeight } } }),
-		} as Contracts.Processor.IProcessableUnit);
+			getBlock: () => ({ header: { height: currentHeight } }),
+			store,
+		} as Contracts.Processor.ProcessableUnit);
 		assert.equal(buildValidatorRankingSpy.callCount, 3);
 		currentHeight++;
 
@@ -151,8 +156,9 @@ describe<{
 		// Simulate another round
 		for (let index = 0; index < activeValidators - 1; index++) {
 			await validatorSet.onCommit({
-				getCommit: async () => ({ block: { header: { height: currentHeight } } }),
-			} as Contracts.Processor.IProcessableUnit);
+				getBlock: () => ({ header: { height: currentHeight } }),
+				store,
+			} as Contracts.Processor.ProcessableUnit);
 			assert.true(buildValidatorRankingSpy.notCalled);
 			currentHeight++;
 		}
@@ -160,8 +166,9 @@ describe<{
 		// Called again after another round
 		assert.equal(currentHeight, 10);
 		await validatorSet.onCommit({
-			getCommit: async () => ({ block: { header: { height: currentHeight } } }),
-		} as Contracts.Processor.IProcessableUnit);
+			getBlock: () => ({ header: { height: currentHeight } }),
+			store,
+		} as Contracts.Processor.ProcessableUnit);
 		assert.true(buildValidatorRankingSpy.calledOnce);
 	});
 

--- a/packages/validator-set-vote-weighted/source/validator-set.test.ts
+++ b/packages/validator-set-vote-weighted/source/validator-set.test.ts
@@ -103,7 +103,7 @@ describe<{
 		store,
 	}) => {
 		await validatorSet.onCommit({
-			getBlock: () => ({ header: { height: 0 } }),
+			height: 0,
 			store,
 		} as Contracts.Processor.ProcessableUnit);
 
@@ -124,7 +124,7 @@ describe<{
 		const { activeValidators } = cryptoConfiguration.getMilestone();
 
 		await validatorSet.onCommit({
-			getBlock: () => ({ header: { height: 0 } }),
+			height: 0,
 			store,
 		} as Contracts.Processor.ProcessableUnit);
 		assert.true(buildValidatorRankingSpy.calledOnce);
@@ -132,7 +132,7 @@ describe<{
 		let currentHeight = 0;
 		for (let index = 0; index < activeValidators; index++) {
 			await validatorSet.onCommit({
-				getBlock: () => ({ header: { height: currentHeight } }),
+				height: currentHeight,
 				store,
 			} as Contracts.Processor.ProcessableUnit);
 
@@ -145,7 +145,7 @@ describe<{
 		// The ranking now got updated thrice
 		assert.equal(currentHeight, 5);
 		await validatorSet.onCommit({
-			getBlock: () => ({ header: { height: currentHeight } }),
+			height: currentHeight,
 			store,
 		} as Contracts.Processor.ProcessableUnit);
 		assert.equal(buildValidatorRankingSpy.callCount, 3);
@@ -156,7 +156,7 @@ describe<{
 		// Simulate another round
 		for (let index = 0; index < activeValidators - 1; index++) {
 			await validatorSet.onCommit({
-				getBlock: () => ({ header: { height: currentHeight } }),
+				height: currentHeight,
 				store,
 			} as Contracts.Processor.ProcessableUnit);
 			assert.true(buildValidatorRankingSpy.notCalled);
@@ -166,7 +166,7 @@ describe<{
 		// Called again after another round
 		assert.equal(currentHeight, 10);
 		await validatorSet.onCommit({
-			getBlock: () => ({ header: { height: currentHeight } }),
+			height: currentHeight,
 			store,
 		} as Contracts.Processor.ProcessableUnit);
 		assert.true(buildValidatorRankingSpy.calledOnce);

--- a/packages/validator-set-vote-weighted/source/validator-set.ts
+++ b/packages/validator-set-vote-weighted/source/validator-set.ts
@@ -14,8 +14,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	#indexByPublicKey: Map<string, number> = new Map();
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		const { height } = unit.getBlock().header;
-		if (Utils.roundCalculator.isNewRound(height + 1, this.cryptoConfiguration)) {
+		if (Utils.roundCalculator.isNewRound(unit.height + 1, this.cryptoConfiguration)) {
 			this.buildValidatorRanking(unit.store);
 		}
 	}

--- a/packages/validator-set-vote-weighted/source/validator-set.ts
+++ b/packages/validator-set-vote-weighted/source/validator-set.ts
@@ -14,8 +14,7 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 	#indexByPublicKey: Map<string, number> = new Map();
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		const commit = await unit.getCommit();
-		const { height } = commit.block.header;
+		const { height } = unit.getBlock().header;
 		if (Utils.roundCalculator.isNewRound(height + 1, this.cryptoConfiguration)) {
 			this.buildValidatorRanking(unit.store);
 		}

--- a/packages/validator-set-vote-weighted/source/validator-set.ts
+++ b/packages/validator-set-vote-weighted/source/validator-set.ts
@@ -45,22 +45,6 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 		return result;
 	}
 
-	// TODO: Check this method
-	// NOTE: only public for tests
-	public async buildVoteBalances(store: Contracts.State.Store): Promise<void> {
-		for (const voter of store.walletRepository.allByPublicKey()) {
-			if (voter.hasVoted()) {
-				const validator: Contracts.State.Wallet = await store.walletRepository.findByPublicKey(
-					voter.getAttribute("vote"),
-				);
-
-				const voteBalance: Utils.BigNumber = validator.getAttribute("validatorVoteBalance");
-
-				validator.setAttribute("validatorVoteBalance", voteBalance.plus(voter.getBalance()));
-			}
-		}
-	}
-
 	public buildValidatorRanking(store: Contracts.State.Store): void {
 		this.#validators = [];
 		this.#indexByPublicKey = new Map();


### PR DESCRIPTION
## Summary

Wallet repository is part of store. This is because when **Store** is cloned, **WalletRepository** is also cloned. Main store (with WalletRepo) is merged with the clone onCommit action at the end of block processing. 

Additionally validator-set logic is updated. There is no initialization, because genesis block will set up the first set in onCommit handler. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
