### PR TITLE
refactor(state): extract `State`

### DIFF
--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -13,6 +13,9 @@ export class Bootstrapper {
 	@inject(Identifiers.Consensus.Service)
 	private readonly consensus!: Contracts.Consensus.ConsensusService;
 
+	@inject(Identifiers.State.State)
+	private readonly state!: Contracts.State.State;
+
 	@inject(Identifiers.State.Verifier)
 	private readonly stateVerifier!: Contracts.State.StateVerifier;
 
@@ -75,7 +78,7 @@ export class Bootstrapper {
 			await this.#initState();
 
 			await this.#processBlocks();
-			this.#store.setBootstrap(false);
+			this.state.setBootstrap(false);
 
 			this.stateVerifier.verifyWalletsConsistency();
 

--- a/packages/contracts/source/contracts/state/index.ts
+++ b/packages/contracts/source/contracts/state/index.ts
@@ -4,6 +4,7 @@ export * from "./index-set";
 export * from "./repository";
 export * from "./service";
 export * from "./snapshots";
+export * from "./state";
 export * from "./state-verifier";
 export * from "./store";
 export * from "./transaction-validator";

--- a/packages/contracts/source/contracts/state/state.ts
+++ b/packages/contracts/source/contracts/state/state.ts
@@ -1,0 +1,4 @@
+export interface State {
+	isBootstrap(): boolean;
+	setBootstrap(value: boolean): void;
+}

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -6,9 +6,6 @@ import { WalletRepository } from "./wallets";
 export interface Store extends CommitHandler {
 	readonly walletRepository: WalletRepository;
 
-	isBootstrap(): boolean;
-	setBootstrap(value: boolean): void;
-
 	getGenesisCommit(): Commit;
 	setGenesisCommit(block: Commit): void;
 

--- a/packages/contracts/source/identifiers.ts
+++ b/packages/contracts/source/identifiers.ts
@@ -231,6 +231,7 @@ export const Identifiers = {
 		Exporter: Symbol("State<Exporter>"),
 		Importer: Symbol("State<Importer>"),
 		Service: Symbol("State<Service>"),
+		State: Symbol("State<State>"),
 		Store: {
 			Factory: Symbol("State<Store<Factory>>"),
 		},

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -11,6 +11,9 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 	@inject(Identifiers.State.Service)
 	private readonly stateService!: Contracts.State.Service;
 
+	@inject(Identifiers.State.State)
+	private readonly state!: Contracts.State.State;
+
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration!: Contracts.Crypto.Configuration;
 
@@ -76,8 +79,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 
 		const commit = await unit.getCommit();
 
-		const store = this.stateService.getStore();
-		if (!store.isBootstrap()) {
+		if (!this.state.isBootstrap()) {
 			this.databaseService.addCommit(commit);
 
 			if (unit.persist) {
@@ -111,7 +113,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 		const height = block.data.height;
 		const totalTransactions = block.data.numberOfTransactions;
 
-		if (!unit.store.isBootstrap()) {
+		if (!this.state.isBootstrap()) {
 			this.logger.info(
 				`Block ${height.toLocaleString()} with ${totalTransactions.toLocaleString()} tx(s) committed`,
 			);
@@ -123,7 +125,7 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 		if (Utils.roundCalculator.isNewRound(height + 1, this.configuration)) {
 			const roundInfo = Utils.roundCalculator.calculateRound(height + 1, this.configuration);
 
-			if (!unit.store.isBootstrap()) {
+			if (!this.state.isBootstrap()) {
 				this.logger.debug(
 					`Starting validator round ${roundInfo.round} at height ${roundInfo.roundHeight} with ${roundInfo.maxValidators} validators`,
 				);

--- a/packages/state/source/service-provider.ts
+++ b/packages/state/source/service-provider.ts
@@ -8,6 +8,7 @@ import { BalanceMutator } from "./mutators/balance";
 import { Service } from "./service";
 import { Exporter } from "./snapshots/exporter";
 import { Importer } from "./snapshots/importer";
+import { State } from "./state";
 import { StateVerifier } from "./state-verifier";
 import { Store } from "./store";
 import { IndexSet, WalletRepository, WalletRepositoryBySender, WalletRepositoryClone } from "./wallets";
@@ -80,6 +81,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		this.app.bind(Identifiers.State.Exporter).to(Exporter);
 
 		this.app.bind(Identifiers.State.Service).to(Service).inSingletonScope();
+		this.app.bind(Identifiers.State.State).to(State).inSingletonScope();
 		this.app.bind(Identifiers.State.Verifier).to(StateVerifier);
 
 		this.app.bind(Identifiers.State.ValidatorMutator).to(AttributeMutator);

--- a/packages/state/source/service.ts
+++ b/packages/state/source/service.ts
@@ -8,6 +8,9 @@ export class Service implements Contracts.State.Service {
 	@tagged("plugin", "state")
 	private readonly configuration!: Providers.PluginConfiguration;
 
+	@inject(Identifiers.State.State)
+	private readonly state!: Contracts.State.State;
+
 	@inject(Identifiers.State.Store.Factory)
 	private readonly storeFactory!: Contracts.State.StoreFactory;
 
@@ -45,7 +48,7 @@ export class Service implements Contracts.State.Service {
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		unit.store.commitChanges();
 
-		if (this.#baseStore.isBootstrap() || !this.configuration.getRequired("export.enabled")) {
+		if (this.state.isBootstrap() || !this.configuration.getRequired("export.enabled")) {
 			return;
 		}
 

--- a/packages/state/source/state.test.ts
+++ b/packages/state/source/state.test.ts
@@ -1,0 +1,22 @@
+import { describe, Sandbox } from "../../test-framework/distribution";
+import { State } from "./state";
+
+describe<{
+	sandbox: Sandbox;
+	state: State;
+}>("State", ({ it, beforeEach, assert }) => {
+	beforeEach(async (context) => {
+		context.sandbox = new Sandbox();
+
+		context.state = context.sandbox.app.resolve(State);
+	});
+
+	it("#isBootstrap - should return true by default", ({ state }) => {
+		assert.true(state.isBootstrap());
+	});
+
+	it("#setBootstrap - should set bootstrap", ({ state }) => {
+		state.setBootstrap(false);
+		assert.false(state.isBootstrap());
+	});
+});

--- a/packages/state/source/state.ts
+++ b/packages/state/source/state.ts
@@ -1,0 +1,15 @@
+import { injectable } from "@mainsail/container";
+import { Contracts } from "@mainsail/contracts";
+
+@injectable()
+export class State implements Contracts.State.State {
+	#isBootstrap = true;
+
+	public isBootstrap(): boolean {
+		return this.#isBootstrap;
+	}
+
+	public setBootstrap(value: boolean): void {
+		this.#isBootstrap = value;
+	}
+}

--- a/packages/state/source/store.test.ts
+++ b/packages/state/source/store.test.ts
@@ -1,5 +1,4 @@
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { Enums } from "@mainsail/kernel";
 
 import { describe, Sandbox } from "../../test-framework/distribution";
 import { AttributeRepository } from "./attributes";
@@ -66,15 +65,6 @@ describe<{
 
 	it("#walletRepository - should return walletRepository", ({ store, walletRepository }) => {
 		assert.equal(store.walletRepository, walletRepository);
-	});
-
-	it("#isBootstrap - should return true by default", ({ store }) => {
-		assert.true(store.isBootstrap());
-	});
-
-	it("#setBootstrap - should set bootstrap", ({ store }) => {
-		store.setBootstrap(false);
-		assert.false(store.isBootstrap());
 	});
 
 	it("#getLastBlock - should throw if not set", ({ store }) => {
@@ -186,7 +176,7 @@ describe<{
 		context.storeClone = context.sandbox.app.resolve(Store).configure(context.store);
 	});
 
-	it("#initialize - should return original height and totalRound, isBootstrap, lastBlock and genesisBlock", ({
+	it("#initialize - should return original height and totalRound, lastBlock and genesisBlock", ({
 		store,
 		sandbox,
 	}) => {
@@ -194,28 +184,16 @@ describe<{
 		const block = { data: { height: 1 } };
 
 		store.setAttribute("totalRound", 2);
-		store.setBootstrap(false);
 		store.setGenesisCommit(genesisBlock as any);
 		store.setLastBlock(block as any);
 
 		const storeClone = sandbox.app.resolve(Store).configure(store);
 
 		assert.equal(storeClone.getTotalRound(), 2);
-		assert.false(storeClone.isBootstrap());
 	});
 
 	it("#walletRepository - should return walletRepository", ({ store, walletRepository }) => {
 		assert.equal(store.walletRepository, walletRepository);
-	});
-
-	it("#setBootstrap - should be set only on clone", ({ store, storeClone }) => {
-		assert.true(store.isBootstrap());
-		assert.true(storeClone.isBootstrap());
-
-		storeClone.setBootstrap(false);
-
-		assert.true(store.isBootstrap());
-		assert.false(storeClone.isBootstrap());
 	});
 
 	it("#setGenesisCommit - should be set only on clone", ({ store, storeClone }) => {
@@ -282,26 +260,19 @@ describe<{
 
 	it("#commitChanges - should copy changes back to original", ({ store, storeClone }) => {
 		assert.false(store.hasAttribute("customAttribute"));
-		assert.true(store.isBootstrap());
 		assert.throws(() => store.getGenesisCommit());
 		assert.throws(() => store.getLastBlock());
 
 		const genesisBlock = { block: { data: { height: 0 } } };
 		const block = { data: { height: 1 } };
 
-		storeClone.setBootstrap(false);
 		storeClone.setGenesisCommit(genesisBlock as any);
 		storeClone.setLastBlock(block as any);
 		storeClone.setAttribute("customAttribute", 1);
 
-		const unit = {
-			getBlock: () => block,
-			round: 1,
-		} as Contracts.Processor.ProcessableUnit;
-		storeClone.commitChanges(unit);
+		storeClone.commitChanges();
 
 		assert.equal(store.getAttribute("customAttribute"), 1);
-		assert.false(store.isBootstrap());
 		assert.equal(store.getGenesisCommit(), genesisBlock);
 		assert.equal(store.getLastBlock(), block);
 	});

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -14,7 +14,6 @@ export class Store implements Contracts.State.Store {
 
 	#genesisBlock?: Contracts.Crypto.Commit;
 	#lastBlock?: Contracts.Crypto.Block;
-	#isBootstrap = true;
 	#originalStore?: Store;
 
 	#repository!: Repository;
@@ -25,7 +24,6 @@ export class Store implements Contracts.State.Store {
 			this.#originalStore = store;
 			this.#genesisBlock = store.#genesisBlock;
 			this.#lastBlock = store.#lastBlock;
-			this.#isBootstrap = store.#isBootstrap;
 
 			this.#repository = new Repository(this.attributeRepository, store.#repository);
 			this.#walletRepository = this.walletRepositoryFactory(store.#walletRepository);
@@ -42,14 +40,6 @@ export class Store implements Contracts.State.Store {
 
 	public get walletRepository(): Contracts.State.WalletRepository {
 		return this.#walletRepository;
-	}
-
-	public isBootstrap(): boolean {
-		return this.#isBootstrap;
-	}
-
-	public setBootstrap(value: boolean): void {
-		this.#isBootstrap = value;
 	}
 
 	public getGenesisCommit(): Contracts.Crypto.Commit {
@@ -105,7 +95,6 @@ export class Store implements Contracts.State.Store {
 		if (this.#originalStore) {
 			this.#originalStore.#lastBlock = this.#lastBlock;
 			this.#originalStore.#genesisBlock = this.#genesisBlock;
-			this.#originalStore.#isBootstrap = this.#isBootstrap;
 
 			this.#repository.commitChanges();
 			this.#walletRepository.commitChanges();


### PR DESCRIPTION
## Summary

Extract `State` class which is responsible for holding blockchain state. In contract Store is used to store blockchain related logic, while state is used for the machine status and things, that don't need to be exported.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

