### PR TITLE
feat(cli): support `config:forger:bip39` command

### DIFF
--- a/packages/core/source/commands/config-forger-bip38.test.ts
+++ b/packages/core/source/commands/config-forger-bip38.test.ts
@@ -1,0 +1,77 @@
+import { Console, describe } from "@mainsail/test-framework";
+import { ensureDirSync, writeJSONSync } from "fs-extra";
+import prompts from "prompts";
+import { dirSync, setGracefulCleanup } from "tmp";
+
+import { Command } from "./config-forger-bip38";
+import { Command as BIP39Command } from "./config-forger-bip39";
+
+describe<{
+	cli: Console;
+}>("ConfigForgerBIP38Command", ({ beforeEach, afterAll, it, assert }) => {
+	const bip39 = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
+	const bip39Flags = "venue below waste gather spin cruise title still boost mother flash tuna";
+	const bip39Prompt = "craft imitate step mixture patch forest volcano business charge around girl confirm";
+
+	beforeEach((context) => {
+		process.env.CORE_PATH_CONFIG = dirSync().name;
+
+		ensureDirSync(`${process.env.CORE_PATH_CONFIG}/mainsail/`);
+		writeJSONSync(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`, {});
+
+		context.cli = new Console();
+	});
+
+	afterAll(() => setGracefulCleanup());
+
+	it("should configure from flags", async ({ cli }) => {
+		await cli.withFlags({ bip39: bip39Flags, password: "password" }).execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [] });
+	});
+
+	it("should configure from a prompt if it receives a valid bip39 and confirmation", async ({ cli }) => {
+		prompts.inject([bip39Prompt, "password", "password"]);
+
+		await cli.execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [] });
+	});
+
+	it("should fail to configure from a prompt if it receives an invalid bip39", async ({ cli }) => {
+		await cli.withFlags({ bip39 }).execute(BIP39Command);
+
+		prompts.inject(["random-string", "password", "password"]);
+
+		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39] });
+	});
+
+	it("should configure from a prompt if it receives an invalid bip39 and skipValidation flag is set", async ({
+		cli,
+	}) => {
+		await cli.withFlags({ bip39 }).execute(BIP39Command);
+
+		prompts.inject(["random-string", "password", "password"]);
+
+		await cli.withFlags({ skipValidation: true }).execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), {
+			secrets: [],
+		});
+	});
+
+	it("should fail to configure from a prompt if it doesn't receive a bip39", async ({ cli }) => {
+		prompts.inject([null, true]);
+
+		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
+	});
+
+	it("should fail to configure from a prompt if it doesn't receive a valid bip39", async ({ cli }) => {
+		await assert.rejects(
+			() => cli.withFlags({ bip39: "random-string" }).execute(Command),
+			"Failed to verify the given passphrase as BIP39 compliant.",
+		);
+	});
+});

--- a/packages/core/source/commands/config-forger-bip38.ts
+++ b/packages/core/source/commands/config-forger-bip38.ts
@@ -6,100 +6,99 @@ import Joi from "joi";
 
 @injectable()
 export class Command extends Commands.Command {
-    public signature = "config:forger:bip38";
+	public signature = "config:forger:bip38";
 
-    public description = "Configure the forging validator (BIP38).";
+	public description = "Configure the forging validator (BIP38).";
 
-    public isHidden = true;
+	public isHidden = true;
 
-    public configure(): void {
-        this.definition
-            .setFlag("token", "The name of the token.", Joi.string())
-            .setFlag("network", "The name of the network.", Joi.string())
-            .setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
-            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
-            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
-    }
+	public configure(): void {
+		this.definition
+			.setFlag("token", "The name of the token.", Joi.string())
+			.setFlag("network", "The name of the network.", Joi.string())
+			.setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
+			.setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
+			.setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
+	}
 
-    public async execute(): Promise<void> {
-        if (this.hasFlag("bip39") && this.hasFlag("password")) {
-            return this.performConfiguration(this.getFlags());
-        }
+	public async execute(): Promise<void> {
+		if (this.hasFlag("bip39") && this.hasFlag("password")) {
+			return this.performConfiguration(this.getFlags());
+		}
 
-        const response = await this.components.prompt([
-            {
-                message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
-                name: "bip39",
-                type: "password",
-                validate: (value) =>
-                    !validateMnemonic(value) && !this.getFlag("skipValidation")
-                        ? `Failed to verify the given passphrase as BIP39 compliant.`
-                        : true,
-            },
-            {
-                type: "password",
-                name: "password",
-                message: "Please enter your custom password that encrypts the BIP39. Referred to as BIP38.",
-                validate: (value) =>
-                    typeof value !== "string" ? "The BIP38 password has to be a string." : true,
-            },
-        ]);
+		const response = await this.components.prompt([
+			{
+				message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
+				name: "bip39",
+				type: "password",
+				validate: (value) =>
+					!validateMnemonic(value) && !this.getFlag("skipValidation")
+						? `Failed to verify the given passphrase as BIP39 compliant.`
+						: true,
+			},
+			{
+				message: "Please enter your custom password that encrypts the BIP39. Referred to as BIP38.",
+				name: "password",
+				type: "password",
+				validate: (value) => (typeof value !== "string" ? "The BIP38 password has to be a string." : true),
+			},
+		]);
 
-        await this.components.prompt([
-            {
-                type: "password",
-                name: "passwordConfirmation",
-                message: "Confirm custom password that encrypts the BIP39. Referred to as BIP38.",
-                validate: (value) =>
-                    value !== response.password ? "Confirm password does not match BIP38 password." : true,
-            },
-        ]);
+		await this.components.prompt([
+			{
+				message: "Confirm custom password that encrypts the BIP39. Referred to as BIP38.",
+				name: "passwordConfirmation",
+				type: "password",
+				validate: (value) =>
+					value !== response.password ? "Confirm password does not match BIP38 password." : true,
+			},
+		]);
 
-        if (!response.bip39) {
-            throw new Error("Failed to verify the given passphrase as BIP39 compliant.");
-        }
+		if (!response.bip39) {
+			throw new Error("Failed to verify the given passphrase as BIP39 compliant.");
+		}
 
-        if (!response.password) {
-            throw new Error("The BIP38 password has to be a string.");
-        }
+		if (!response.password) {
+			throw new Error("The BIP38 password has to be a string.");
+		}
 
-        return this.performConfiguration({ ...this.getFlags(), ...response });
-    }
+		return this.performConfiguration({ ...this.getFlags(), ...response });
+	}
 
-    private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
-        //let decodedWIF;
+	private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
+		//let decodedWIF;
 
-        await this.components.taskList([
-            {
-                task: () => {
-                    if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
-                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
-                    }
-                },
-                title: "Validating passphrase is BIP39 compliant.",
-            },
-            {
-                title: "Loading private key.",
-                task: () => {
-                    // decodedWIF = wif.decode(Identities.WIF.fromPassphrase(flags.bip39));
-                },
-            },
-            {
-                task: () => {
-                    const validatorsConfig = this.app.getCorePath("config", "validators.json");
+		await this.components.taskList([
+			{
+				task: () => {
+					if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
+						throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
+					}
+				},
+				title: "Validating passphrase is BIP39 compliant.",
+			},
+			{
+				task: () => {
+					// decodedWIF = wif.decode(Identities.WIF.fromPassphrase(flags.bip39));
+				},
+				title: "Loading private key.",
+			},
+			{
+				task: () => {
+					const validatorsConfig = this.app.getCorePath("config", "validators.json");
 
-                    const validators: Record<string, string | string[]> = require(validatorsConfig);
-                    // validators.bip38 = bip38.encrypt(
-                    //     decodedWIF.privateKey,
-                    //     decodedWIF.compressed,
-                    //     flags.password,
-                    // );
-                    validators.secrets = [];
+					const validators: Record<string, string | string[]> = require(validatorsConfig);
+					// validators.bip38 = bip38.encrypt(
+					//     decodedWIF.privateKey,
+					//     decodedWIF.compressed,
+					//     flags.password,
+					// );
+					validators.secrets = [];
 
-                    writeJSONSync(validatorsConfig, validators);
-                },
-                title: "Writing BIP39 passphrase to configuration.",
-            },
-        ]);
-    }
+					writeJSONSync(validatorsConfig, validators);
+				},
+				title: "Writing BIP39 passphrase to configuration.",
+			},
+		]);
+	}
 }

--- a/packages/core/source/commands/config-forger-bip38.ts
+++ b/packages/core/source/commands/config-forger-bip38.ts
@@ -1,0 +1,105 @@
+import { Commands, Contracts } from "@mainsail/cli";
+import { injectable } from "@mainsail/container";
+import { validateMnemonic } from "bip39";
+import { writeJSONSync } from "fs-extra";
+import Joi from "joi";
+
+@injectable()
+export class Command extends Commands.Command {
+    public signature = "config:forger:bip38";
+
+    public description = "Configure the forging validator (BIP38).";
+
+    public isHidden = true;
+
+    public configure(): void {
+        this.definition
+            .setFlag("token", "The name of the token.", Joi.string())
+            .setFlag("network", "The name of the network.", Joi.string())
+            .setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
+            .setFlag("password", "A custom password that encrypts the BIP39. Referred to as BIP38.", Joi.string())
+            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
+    }
+
+    public async execute(): Promise<void> {
+        if (this.hasFlag("bip39") && this.hasFlag("password")) {
+            return this.performConfiguration(this.getFlags());
+        }
+
+        const response = await this.components.prompt([
+            {
+                message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
+                name: "bip39",
+                type: "password",
+                validate: (value) =>
+                    !validateMnemonic(value) && !this.getFlag("skipValidation")
+                        ? `Failed to verify the given passphrase as BIP39 compliant.`
+                        : true,
+            },
+            {
+                type: "password",
+                name: "password",
+                message: "Please enter your custom password that encrypts the BIP39. Referred to as BIP38.",
+                validate: (value) =>
+                    typeof value !== "string" ? "The BIP38 password has to be a string." : true,
+            },
+        ]);
+
+        await this.components.prompt([
+            {
+                type: "password",
+                name: "passwordConfirmation",
+                message: "Confirm custom password that encrypts the BIP39. Referred to as BIP38.",
+                validate: (value) =>
+                    value !== response.password ? "Confirm password does not match BIP38 password." : true,
+            },
+        ]);
+
+        if (!response.bip39) {
+            throw new Error("Failed to verify the given passphrase as BIP39 compliant.");
+        }
+
+        if (!response.password) {
+            throw new Error("The BIP38 password has to be a string.");
+        }
+
+        return this.performConfiguration({ ...this.getFlags(), ...response });
+    }
+
+    private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
+        //let decodedWIF;
+
+        await this.components.taskList([
+            {
+                task: () => {
+                    if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
+                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
+                    }
+                },
+                title: "Validating passphrase is BIP39 compliant.",
+            },
+            {
+                title: "Loading private key.",
+                task: () => {
+                    // decodedWIF = wif.decode(Identities.WIF.fromPassphrase(flags.bip39));
+                },
+            },
+            {
+                task: () => {
+                    const validatorsConfig = this.app.getCorePath("config", "validators.json");
+
+                    const validators: Record<string, string | string[]> = require(validatorsConfig);
+                    // validators.bip38 = bip38.encrypt(
+                    //     decodedWIF.privateKey,
+                    //     decodedWIF.compressed,
+                    //     flags.password,
+                    // );
+                    validators.secrets = [];
+
+                    writeJSONSync(validatorsConfig, validators);
+                },
+                title: "Writing BIP39 passphrase to configuration.",
+            },
+        ]);
+    }
+}

--- a/packages/core/source/commands/config-forger-bip39.test.ts
+++ b/packages/core/source/commands/config-forger-bip39.test.ts
@@ -1,0 +1,88 @@
+import { Console, describe } from "@mainsail/test-framework";
+import { ensureDirSync, writeJSONSync } from "fs-extra";
+import prompts from "prompts";
+import { dirSync, setGracefulCleanup } from "tmp";
+
+import { Command } from "./config-forger-bip39";
+
+describe<{
+	cli: Console;
+}>("ConfigForgerBIP39Command", ({ beforeEach, afterAll, it, assert }) => {
+	const bip39 = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
+	const bip39Flags = "venue below waste gather spin cruise title still boost mother flash tuna";
+	const bip39Prompt = "craft imitate step mixture patch forest volcano business charge around girl confirm";
+
+	beforeEach((context) => {
+		process.env.CORE_PATH_CONFIG = dirSync().name;
+
+		ensureDirSync(`${process.env.CORE_PATH_CONFIG}/mainsail/`);
+		writeJSONSync(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`, {});
+
+		context.cli = new Console();
+	});
+
+	afterAll(() => setGracefulCleanup());
+
+	it("should configure from flags", async ({ cli }) => {
+		await cli.withFlags({ bip39: bip39Flags }).execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39Flags] });
+	});
+
+	it("should configure from a prompt if it receives a valid bip39 and confirmation", async ({ cli }) => {
+		prompts.inject([bip39Prompt, true]);
+
+		await cli.execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39Prompt] });
+	});
+
+	it("should fail to configure from a prompt if it receives a valid bip39 and but no confirmation", async ({
+		cli,
+	}) => {
+		await cli.withFlags({ bip39 }).execute(Command);
+
+		prompts.inject([bip39Prompt, false]);
+
+		await cli.execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39] });
+	});
+
+	it("should fail to configure from a prompt if it receives an invalid bip39", async ({ cli }) => {
+		await cli.withFlags({ bip39 }).execute(Command);
+
+		prompts.inject(["random-string", true]);
+
+		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39] });
+	});
+
+	it("should configure from a prompt if it receives an invalid bip39 and skipValidation flag is set", async ({
+		cli,
+	}) => {
+		await cli.withFlags({ bip39 }).execute(Command);
+
+		prompts.inject(["random-string", true]);
+
+		await cli.withFlags({ skipValidation: true }).execute(Command);
+
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), {
+			secrets: ["random-string"],
+		});
+	});
+
+	it("should fail to configure from a prompt if it doesn't receive a bip39", async ({ cli }) => {
+		prompts.inject([null, true]);
+
+		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
+	});
+
+	it("should fail to configure from a prompt if it doesn't receive a valid bip39", async ({ cli }) => {
+		await assert.rejects(
+			() => cli.withFlags({ bip39: "random-string" }).execute(Command),
+			"Failed to verify the given passphrase as BIP39 compliant.",
+		);
+	});
+});

--- a/packages/core/source/commands/config-forger-bip39.ts
+++ b/packages/core/source/commands/config-forger-bip39.ts
@@ -6,66 +6,66 @@ import Joi from "joi";
 
 @injectable()
 export class Command extends Commands.Command {
-    public signature = "config:forger:bip39";
+	public signature = "config:forger:bip39";
 
-    public description = "Configure the forging validator (BIP39).";
+	public description = "Configure the forging validator (BIP39).";
 
-    public configure(): void {
-        this.definition
-            .setFlag("token", "The name of the token.", Joi.string())
-            .setFlag("network", "The name of the network.", Joi.string())
-            .setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
-            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
-    }
+	public configure(): void {
+		this.definition
+			.setFlag("token", "The name of the token.", Joi.string())
+			.setFlag("network", "The name of the network.", Joi.string())
+			.setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
+			.setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
+	}
 
-    public async execute(): Promise<void> {
-        if (this.hasFlag("bip39")) {
-            return this.performConfiguration(this.getFlags());
-        }
+	public async execute(): Promise<void> {
+		if (this.hasFlag("bip39")) {
+			return this.performConfiguration(this.getFlags());
+		}
 
-        const response = await this.components.prompt([
-            {
-                message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
-                name: "bip39",
-                type: "password",
-                validate: (value) =>
-                    !validateMnemonic(value) && !this.getFlag("skipValidation")
-                        ? `Failed to verify the given passphrase as BIP39 compliant.`
-                        : true,
-            },
-            {
-                message: "Can you confirm?",
-                name: "confirm",
-                type: "confirm",
-            },
-        ]);
+		const response = await this.components.prompt([
+			{
+				message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
+				name: "bip39",
+				type: "password",
+				validate: (value) =>
+					!validateMnemonic(value) && !this.getFlag("skipValidation")
+						? `Failed to verify the given passphrase as BIP39 compliant.`
+						: true,
+			},
+			{
+				message: "Can you confirm?",
+				name: "confirm",
+				type: "confirm",
+			},
+		]);
 
-        if (response.confirm) {
-            return this.performConfiguration({ ...this.getFlags(), ...response });
-        }
-    }
+		if (response.confirm) {
+			return this.performConfiguration({ ...this.getFlags(), ...response });
+		}
+	}
 
-    private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
-        await this.components.taskList([
-            {
-                task: () => {
-                    if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
-                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
-                    }
-                },
-                title: "Validating passphrase is BIP39 compliant.",
-            },
-            {
-                task: () => {
-                    const validatorsConfig = this.app.getCorePath("config", "validators.json");
+	private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
+		await this.components.taskList([
+			{
+				task: () => {
+					if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
+						throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
+					}
+				},
+				title: "Validating passphrase is BIP39 compliant.",
+			},
+			{
+				task: () => {
+					const validatorsConfig = this.app.getCorePath("config", "validators.json");
 
-                    const validators: Record<string, string | string[]> = require(validatorsConfig);
-                    validators.secrets = [flags.bip39];
+					const validators: Record<string, string | string[]> = require(validatorsConfig);
+					validators.secrets = [flags.bip39];
 
-                    writeJSONSync(validatorsConfig, validators);
-                },
-                title: "Writing BIP39 passphrase to configuration.",
-            },
-        ]);
-    }
+					writeJSONSync(validatorsConfig, validators);
+				},
+				title: "Writing BIP39 passphrase to configuration.",
+			},
+		]);
+	}
 }

--- a/packages/core/source/commands/config-forger-bip39.ts
+++ b/packages/core/source/commands/config-forger-bip39.ts
@@ -1,0 +1,71 @@
+import { Commands, Contracts } from "@mainsail/cli";
+import { injectable } from "@mainsail/container";
+import { validateMnemonic } from "bip39";
+import { writeJSONSync } from "fs-extra";
+import Joi from "joi";
+
+@injectable()
+export class Command extends Commands.Command {
+    public signature = "config:forger:bip39";
+
+    public description = "Configure the forging validator (BIP39).";
+
+    public configure(): void {
+        this.definition
+            .setFlag("token", "The name of the token.", Joi.string())
+            .setFlag("network", "The name of the network.", Joi.string())
+            .setFlag("bip39", "A validator plain text passphrase. Referred to as BIP39.", Joi.string())
+            .setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
+    }
+
+    public async execute(): Promise<void> {
+        if (this.hasFlag("bip39")) {
+            return this.performConfiguration(this.getFlags());
+        }
+
+        const response = await this.components.prompt([
+            {
+                message: "Please enter your validator plain text passphrase. Referred to as BIP39.",
+                name: "bip39",
+                type: "password",
+                validate: (value) =>
+                    !validateMnemonic(value) && !this.getFlag("skipValidation")
+                        ? `Failed to verify the given passphrase as BIP39 compliant.`
+                        : true,
+            },
+            {
+                message: "Can you confirm?",
+                name: "confirm",
+                type: "confirm",
+            },
+        ]);
+
+        if (response.confirm) {
+            return this.performConfiguration({ ...this.getFlags(), ...response });
+        }
+    }
+
+    private async performConfiguration(flags: Contracts.AnyObject): Promise<void> {
+        await this.components.taskList([
+            {
+                task: () => {
+                    if (!flags.bip39 || (!validateMnemonic(flags.bip39) && !flags.skipValidation)) {
+                        throw new Error(`Failed to verify the given passphrase as BIP39 compliant.`);
+                    }
+                },
+                title: "Validating passphrase is BIP39 compliant.",
+            },
+            {
+                task: () => {
+                    const validatorsConfig = this.app.getCorePath("config", "validators.json");
+
+                    const validators: Record<string, string | string[]> = require(validatorsConfig);
+                    validators.secrets = [flags.bip39];
+
+                    writeJSONSync(validatorsConfig, validators);
+                },
+                title: "Writing BIP39 passphrase to configuration.",
+            },
+        ]);
+    }
+}

--- a/packages/core/source/commands/config-forger.test.ts
+++ b/packages/core/source/commands/config-forger.test.ts
@@ -23,66 +23,23 @@ describe<{
 
 	afterAll(() => setGracefulCleanup());
 
-	it("should configure from flags", async ({ cli }) => {
-		await cli.withFlags({ bip39: bip39Flags }).execute(Command);
+	it("should configure from flags (BIP39)", async ({ cli }) => {
+		await cli.withFlags({ bip39: bip39Flags, method: "bip39" }).execute(Command);
 
 		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39Flags] });
 	});
 
-	it("should configure from a prompt if it receives a valid bip39 and confirmation", async ({ cli }) => {
-		prompts.inject([bip39Prompt, true]);
+	it("should configure from flags (BIP38)", async ({ cli }) => {
+		await cli.withFlags({ bip39: bip39Flags, method: "bip38", password: "password" }).execute(Command);
 
-		await cli.execute(Command);
-
-		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39Prompt] });
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [] });
 	});
 
-	it("should fail to configure from a prompt if it receives a valid bip39 and but no confirmation", async ({
-		cli,
-	}) => {
-		await cli.withFlags({ bip39 }).execute(Command);
+	it("should prompt if method is missing", async ({ cli }) => {
+		prompts.inject(["bip39"]);
 
-		prompts.inject([bip39Prompt, false]);
+		await cli.withFlags({ bip39: bip39Flags }).execute(Command);
 
-		await cli.execute(Command);
-
-		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39] });
-	});
-
-	it("should fail to configure from a prompt if it receives an invalid bip39", async ({ cli }) => {
-		await cli.withFlags({ bip39 }).execute(Command);
-
-		prompts.inject(["random-string", true]);
-
-		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
-
-		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39] });
-	});
-
-	it("should configure from a prompt if it receives an invalid bip39 and skipValidation flag is set", async ({
-		cli,
-	}) => {
-		await cli.withFlags({ bip39 }).execute(Command);
-
-		prompts.inject(["random-string", true]);
-
-		await cli.withFlags({ skipValidation: true }).execute(Command);
-
-		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), {
-			secrets: ["random-string"],
-		});
-	});
-
-	it("should fail to configure from a prompt if it doesn't receive a bip39", async ({ cli }) => {
-		prompts.inject([null, true]);
-
-		await assert.rejects(() => cli.execute(Command), "Failed to verify the given passphrase as BIP39 compliant.");
-	});
-
-	it("should fail to configure from a prompt if it doesn't receive a valid bip39", async ({ cli }) => {
-		await assert.rejects(
-			() => cli.withFlags({ bip39: "random-string" }).execute(Command),
-			"Failed to verify the given passphrase as BIP39 compliant.",
-		);
+		assert.equal(require(`${process.env.CORE_PATH_CONFIG}/mainsail/validators.json`), { secrets: [bip39Flags] });
 	});
 });

--- a/packages/core/source/commands/config-forger.ts
+++ b/packages/core/source/commands/config-forger.ts
@@ -20,7 +20,7 @@ export class Command extends Commands.Command {
 			.setFlag(
 				"method",
 				"The configuration method to use (BIP38 or BIP39).",
-				Joi.string().valid(...["bip38", "bip39"]),
+				Joi.string().valid("bip38", "bip39"),
 			)
 			.setFlag("skipValidation", "Skip BIP39 mnemonic validation", Joi.boolean().default(false));
 	}
@@ -28,15 +28,15 @@ export class Command extends Commands.Command {
 	public async execute(): Promise<void> {
 		let method = this.getFlag("method");
 		if (!method) {
-			let response = await this.components.prompt([
+			const response = await this.components.prompt([
 				{
-					type: "select",
-					name: "method",
-					message: "Please select how you wish to store your delegate passphrase?",
 					choices: [
 						{ title: "Encrypted BIP38 (Recommended)", value: "bip38" },
 						{ title: "Plain BIP39", value: "bip39" },
 					],
+					message: "Please select how you wish to store your delegate passphrase?",
+					name: "method",
+					type: "select",
 				},
 			]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Support `config:forger:bip39` similar to V3.

Used by e.g. the docker entrypoint: https://github.com/ArkEcosystem/mainsail/blob/develop/docker/production/entrypoint.sh#L20

Note that this also adds the BIP38 command (password encryption), but it's not doing anything yet.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
