### PR TITLE
chore: use external docker network

### DIFF
--- a/docker/production/devnet/docker-compose-build.yml
+++ b/docker/production/devnet/docker-compose-build.yml
@@ -32,3 +32,4 @@ volumes:
   core:
 networks:
   core:
+    external: true

--- a/docker/production/devnet/docker-compose.yml
+++ b/docker/production/devnet/docker-compose.yml
@@ -27,3 +27,4 @@ volumes:
   core:
 networks:
   core:
+    external: true

--- a/docker/production/mainnet/docker-compose.yml
+++ b/docker/production/mainnet/docker-compose.yml
@@ -27,3 +27,4 @@ volumes:
   core:
 networks:
   core:
+    external: true

--- a/docker/testnet/README.md
+++ b/docker/testnet/README.md
@@ -23,6 +23,12 @@ Run Relay only node using [Docker Compose](https://docs.docker.com/compose/)
 cd ~/docker/testnet/core
 ```
 
+> Create docker network:
+
+```bash
+docker network create core
+```
+
 > [!NOTE]
 > Please pay attention to the following option in your [`testnet.env`](./core/testnet.env) file!
 
@@ -47,15 +53,24 @@ docker logs --tail mainsail-testnet -f
 ```bash
 docker-compose down -v --rmi all
 ```
+
 > [!WARNING]  
 > If you have set `API=true` Mainsail Core will log errors untill the API container gets up, so you should next proceed with deploying API node.
 
 > [!IMPORTANT]  
 > If you prefer to build your own image instead of using our pre-built from [Docker Hub](https://hub.docker.com/r/arkecosystem/mainsail-core), then you can proceed as follows:
 
+
 ```bash
 cd ~/docker/testnet/core
 ```
+
+> Create docker network:
+
+```bash
+docker network create core
+```
+
 > _Start_:
 
 ```bash
@@ -99,6 +114,12 @@ Run API node using [Docker Compose](https://docs.docker.com/compose/)
 cd ~/docker/testnet/api
 ```
 
+> Create docker network:
+
+```bash
+docker network create core
+```
+
 > [!NOTE]
 > Please pay attention to the following option in your Mainsail Core [`testnet.env`](./core/testnet.env) file!
 
@@ -126,6 +147,7 @@ docker-compose down -v --rmi all
 > [!NOTE]
 > At this stage your Mainsail Core node should pick up.
 
+
 ```bash
 docker logs --tail mainsail-testnet -f
 ```
@@ -133,9 +155,17 @@ docker logs --tail mainsail-testnet -f
 > [!IMPORTANT]
 > If you prefer to build your own image instead of using our pre-built from [Docker Hub](https://hub.docker.com/r/arkecosystem/mainsail-api), then you can proceed as follows:
 
+
 ```bash
 cd ~/docker/testnet/api
 ```
+
+> Create docker network:
+
+```bash
+docker network create core
+```
+
 > _Start_:
 
 ```bash

--- a/docker/testnet/api/docker-compose-build.yml
+++ b/docker/testnet/api/docker-compose-build.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks: 
-      - api 
+      - core 
     environment:
      POSTGRES_PASSWORD: password
      POSTGRES_DB: api_testnet
@@ -33,7 +33,7 @@ services:
      - ~/.local/state/mainsail:/home/node/.local/state/mainsail
      - /etc/localtime:/etc/localtime:ro
     networks:
-      - api 
+      - core
     env_file: ./testnet.env
     tty: true
     links:
@@ -44,6 +44,6 @@ volumes:
   postgres:
   api:
 networks:
-  api:
-    external: 
-      name: core
+  core:
+    external: true 
+      

--- a/docker/testnet/api/docker-compose.yml
+++ b/docker/testnet/api/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     volumes:
       - 'postgres:/var/lib/postgresql/data'
     networks: 
-      - api 
+      - core 
     environment:
      POSTGRES_PASSWORD: password
      POSTGRES_DB: api_testnet
      POSTGRES_USER: node
   api:
-    image: arkecosystem/mainsail-core:testnet 
+    image: arkecosystem/mainsail-api:testnet 
     container_name: mainsail-api-testnet 
     restart: always
     ports:
@@ -28,7 +28,7 @@ services:
      - ~/.local/state/mainsail:/home/node/.local/state/mainsail
      - /etc/localtime:/etc/localtime:ro
     networks:
-      - api 
+      - core
     env_file: ./testnet.env
     tty: true
     links:
@@ -39,6 +39,5 @@ volumes:
   postgres:
   api:
 networks:
-  api:
-    external: 
-      name: core
+  core:
+    external: true 

--- a/docker/testnet/core/docker-compose-build.yml
+++ b/docker/testnet/core/docker-compose-build.yml
@@ -28,10 +28,8 @@ services:
       - core
     env_file: testnet.env
     tty: true
-    external_links:
-     - mainsail-api-testnet 
 volumes:
   core:
 networks:
   core:
-    name: core
+    external: true

--- a/docker/testnet/core/docker-compose.yml
+++ b/docker/testnet/core/docker-compose.yml
@@ -23,10 +23,9 @@ services:
       - core
     env_file: testnet.env
     tty: true
-    external_links:
-     - mainsail-api-testnet
 volumes:
   core:
 networks:
   core:
-    name: core
+    external: true
+


### PR DESCRIPTION
## Summary

- Use external docker network for both core and api containers.
- Update README.
