### PR TITLE
refactor(crypto-transaction-evm-call): add interface types to break up cyclic dependency on evm

### DIFF
--- a/packages/contracts/source/contracts/evm/evm.ts
+++ b/packages/contracts/source/contracts/evm/evm.ts
@@ -1,0 +1,20 @@
+export interface Instance {
+	transact(txContext: TransactionContext): Promise<TransactionResult>;
+	view(txContext: TransactionContext): Promise<TransactionResult>;
+}
+
+export interface TransactionContext {
+	caller: string;
+	/** Omit recipient when deploying a contract */
+	recipient?: string;
+	data: Buffer;
+}
+
+export interface TransactionResult {
+	gasUsed: bigint;
+	gasRefunded: bigint;
+	success: boolean;
+	deployedContractAddress?: string;
+	logs: any;
+	output?: Buffer;
+}

--- a/packages/contracts/source/contracts/evm/index.ts
+++ b/packages/contracts/source/contracts/evm/index.ts
@@ -1,0 +1,1 @@
+export * from "./evm";

--- a/packages/contracts/source/contracts/index.ts
+++ b/packages/contracts/source/contracts/index.ts
@@ -3,6 +3,7 @@ export * as ApiSync from "./api-sync";
 export * as Consensus from "./consensus";
 export * as Crypto from "./crypto";
 export * as Database from "./database";
+export * as Evm from "./evm";
 export * as Fee from "./fees";
 export * as Kernel from "./kernel";
 export * as NetworkGenerator from "./network-generator";

--- a/packages/crypto-transaction-evm-call/package.json
+++ b/packages/crypto-transaction-evm-call/package.json
@@ -23,7 +23,6 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/crypto-transaction": "workspace:*",
-		"@mainsail/evm": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
 		"@mainsail/transactions": "workspace:*",
 		"@mainsail/utils": "workspace:*"

--- a/packages/crypto-transaction-evm-call/source/handlers/evm-call.ts
+++ b/packages/crypto-transaction-evm-call/source/handlers/evm-call.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import Transactions from "@mainsail/crypto-transaction";
-import { Bindings } from "@mainsail/evm";
 import { Utils as AppUtils } from "@mainsail/kernel";
 import { Handlers } from "@mainsail/transactions";
 
@@ -10,7 +9,7 @@ import { EvmCallTransaction } from "../versions";
 @injectable()
 export class EvmCallTransactionHandler extends Handlers.TransactionHandler {
 	@inject(Identifiers.Evm.Instance)
-	private readonly evm!: Bindings.Evm;
+	private readonly evm!: Contracts.Evm.Instance;
 
 	public dependencies(): ReadonlyArray<Handlers.TransactionHandlerConstructor> {
 		return [];

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -28,6 +28,7 @@
 		"@mainsail/kernel": "workspace:*"
 	},
 	"devDependencies": {
+		"@mainsail/test-framework": "workspace:*",
 		"@napi-rs/cli": "^2.18.0",
 		"uvu": "^0.5.6"
 	},

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -28,7 +28,6 @@
 		"@mainsail/kernel": "workspace:*"
 	},
 	"devDependencies": {
-		"@mainsail/test-framework": "workspace:*",
 		"@napi-rs/cli": "^2.18.0",
 		"uvu": "^0.5.6"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1802,9 +1802,6 @@ importers:
       '@mainsail/crypto-transaction':
         specifier: workspace:*
         version: link:../crypto-transaction
-      '@mainsail/evm':
-        specifier: workspace:*
-        version: link:../evm
       '@mainsail/kernel':
         specifier: workspace:*
         version: link:../kernel
@@ -2278,6 +2275,9 @@ importers:
         specifier: workspace:*
         version: link:../kernel
     devDependencies:
+      '@mainsail/test-framework':
+        specifier: workspace:*
+        version: link:../test-framework
       '@napi-rs/cli':
         specifier: ^2.18.0
         version: 2.18.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2275,9 +2275,6 @@ importers:
         specifier: workspace:*
         version: link:../kernel
     devDependencies:
-      '@mainsail/test-framework':
-        specifier: workspace:*
-        version: link:../test-framework
       '@napi-rs/cli':
         specifier: ^2.18.0
         version: 2.18.0


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

The `@mainsail/crypto-transaction-evm-call` package should not depend on `@mainsail/evm`  otherwise we get a cyclic dependency:

```
There are cyclic workspace dependencies: mainsail/packages/crypto-transaction-evm-call, mainsail/packages/evm, mainsail/packages/test-framework
```

To break it up add evm interface definitions to `@mainsail/contracts` and remove the `@mainsail/evm` dependency from `@mainsail/crypto-transaction-evm-call`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
