### PR TITLE
feat(api-evm): support `evm_call` method

### DIFF
--- a/packages/api-common/source/rcp/processor.ts
+++ b/packages/api-common/source/rcp/processor.ts
@@ -33,8 +33,9 @@ export class Processor implements Contracts.Api.RPC.Processor {
 
 		try {
 			return {
-				id: getRcpId(request),
 				jsonrpc: "2.0",
+				// eslint-disable-next-line sort-keys-fix/sort-keys-fix
+				id: getRcpId(request),
 				result: await action.handle(payload.params),
 			};
 		} catch {

--- a/packages/api-common/source/rcp/utils.ts
+++ b/packages/api-common/source/rcp/utils.ts
@@ -28,10 +28,12 @@ export const prepareRcpError = (
 	id: Contracts.Api.RPC.Id,
 	errorCode: Contracts.Api.RPC.ErrorCode,
 ): Contracts.Api.RPC.Error => ({
+	jsonrpc: "2.0",
+	// eslint-disable-next-line sort-keys-fix/sort-keys-fix
+	id,
+	// eslint-disable-next-line sort-keys-fix/sort-keys-fix
 	error: {
 		code: errorCode,
 		message: errorMessageMap[errorCode],
 	},
-	id,
-	jsonrpc: "2.0",
 });

--- a/packages/api-evm/package.json
+++ b/packages/api-evm/package.json
@@ -26,7 +26,8 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
-		"joi": "17.11.0"
+		"joi": "17.11.0",
+		"ethers": "6.11.0"
 	},
 	"devDependencies": {
 		"@types/semver": "7.5.6",

--- a/packages/api-evm/package.json
+++ b/packages/api-evm/package.json
@@ -26,8 +26,8 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
-		"joi": "17.11.0",
-		"ethers": "6.11.0"
+		"ethers": "6.11.0",
+		"joi": "17.11.0"
 	},
 	"devDependencies": {
 		"@types/semver": "7.5.6",

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -27,7 +27,7 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { type: "string" },
+					data: { $ref: "0xHex" },
 					from: { $ref: "address" },
 					to: { $ref: "address" },
 				},

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -51,7 +51,9 @@ export class CallAction implements Contracts.Api.RPC.Action {
 
 		const result = await this.evm.view(txContext);
 
-		console.log(result);
+		if (result.success) {
+			return `0x${result.output?.toString("hex")}`;
+		}
 
 		return `OK ${this.name}`;
 	}

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
+import { ethers } from "ethers";
 
 type BlockTag = "latest" | "earliest" | "pending";
 
@@ -44,7 +45,7 @@ export class CallAction implements Contracts.Api.RPC.Action {
 
 		const txContext = {
 			caller: data.from,
-			data: Buffer.from(data.data, "hex"),
+			data: Buffer.from(ethers.getBytes(data.data)),
 			recipient: data.to,
 		};
 

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -28,8 +28,8 @@ export class CallAction implements Contracts.Api.RPC.Action {
 				additionalProperties: false,
 				properties: {
 					data: { type: "string" },
-					from: { type: "string" },
-					to: { type: "string" },
+					from: { $ref: "address" },
+					to: { $ref: "address" },
 				},
 				required: ["from", "to", "data"],
 				type: "object",

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -27,7 +27,7 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "0xHex" },
+					data: { $ref: "prefixedHex" },
 					from: { $ref: "address" },
 					to: { $ref: "address" },
 				},

--- a/packages/api-evm/source/actions/call.ts
+++ b/packages/api-evm/source/actions/call.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "@mainsail/container";
-import { Contracts, Identifiers } from "@mainsail/contracts";
+import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
 import { ethers } from "ethers";
 
 type BlockTag = "latest" | "earliest" | "pending";
@@ -55,6 +55,6 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			return `0x${result.output?.toString("hex")}`;
 		}
 
-		return `OK ${this.name}`;
+		throw new Exceptions.RpcError("execution reverted");
 	}
 }

--- a/packages/contracts/source/exceptions/index.ts
+++ b/packages/contracts/source/exceptions/index.ts
@@ -10,6 +10,7 @@ export * from "./p2p";
 export * from "./plugins";
 export * from "./pool";
 export * from "./processor";
+export * from "./rpc";
 export * from "./runtime";
 export * from "./state";
 export * from "./validation";

--- a/packages/contracts/source/exceptions/rpc.ts
+++ b/packages/contracts/source/exceptions/rpc.ts
@@ -1,0 +1,10 @@
+import { Exception } from "./base";
+
+export class RpcError extends Exception {
+	public constructor(
+		message: string,
+		public code: number = -32_000,
+	) {
+		super(message);
+	}
+}

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -1,6 +1,6 @@
 import { SchemaObject } from "ajv";
 
-export const schemas: Record<"alphanumeric" | "hex", SchemaObject> = {
+export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex", SchemaObject> = {
 	alphanumeric: {
 		$id: "alphanumeric",
 		pattern: "^[a-z0-9]+$",
@@ -9,6 +9,11 @@ export const schemas: Record<"alphanumeric" | "hex", SchemaObject> = {
 	hex: {
 		$id: "hex",
 		pattern: "^[0123456789a-f]+$",
+		type: "string",
+	},
+	prefixedHex: {
+		$id: "0xHex",
+		pattern: "^0x[0-9a-f]+$",
 		type: "string",
 	},
 };

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -12,7 +12,7 @@ export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex", SchemaObjec
 		type: "string",
 	},
 	prefixedHex: {
-		$id: "0xHex",
+		$id: "prefixedHex",
 		pattern: "^0x[0-9a-f]+$",
 		type: "string",
 	},

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -28,8 +28,8 @@
 		"@mainsail/kernel": "workspace:*"
 	},
 	"devDependencies": {
-		"ethers": "6.11.0",
 		"@napi-rs/cli": "^2.18.0",
+		"ethers": "6.11.0",
 		"uvu": "^0.5.6"
 	},
 	"engines": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -28,6 +28,7 @@
 		"@mainsail/kernel": "workspace:*"
 	},
 	"devDependencies": {
+		"ethers": "6.11.0",
 		"@napi-rs/cli": "^2.18.0",
 		"uvu": "^0.5.6"
 	},

--- a/packages/evm/source/instance.test.ts
+++ b/packages/evm/source/instance.test.ts
@@ -30,7 +30,7 @@ describe<{
 		assert.equal(result.deployedContractAddress, "0x0c2485e7d05894BC4f4413c52B080b6D1eca122a");
 	});
 
-	it.only("should deploy, transfer and call balanceOf", async ({ instance }) => {
+	it("should deploy, transfer and call balanceOf", async ({ instance }) => {
 		const [sender, recipient] = wallets;
 
 		const result = await instance.transact({

--- a/packages/evm/test/fixtures/wallets.ts
+++ b/packages/evm/test/fixtures/wallets.ts
@@ -4,4 +4,9 @@ export const wallets = [
 		passphrase:
 			"violin hello resist adult roof breeze blood old tell source enforce token void wagon sweet detail raw coast viable garden cause gasp soap fat",
 	},
+	{
+		address: "0xEcC2717Ac3558141bFe0f512ACD5c62C5AB303C7",
+		passphrase:
+			"extend coach swift member onion reduce furnace cash romance hope ginger project breeze siren foot river rocket ten picnic quick mimic identify aspect forward",
+	},
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@mainsail/kernel':
         specifier: workspace:*
         version: link:../kernel
+      ethers:
+        specifier: 6.11.0
+        version: 6.11.0
       joi:
         specifier: 17.11.0
         version: 17.11.0
@@ -8995,7 +8998,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: true
 
   /ethers@6.11.1:
     resolution: {integrity: sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2278,6 +2278,9 @@ importers:
       '@napi-rs/cli':
         specifier: ^2.18.0
         version: 2.18.0
+      ethers:
+        specifier: 6.11.0
+        version: 6.11.0
       uvu:
         specifier: ^0.5.6
         version: 0.5.6
@@ -8977,6 +8980,22 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  /ethers@6.11.0:
+    resolution: {integrity: sha512-kPHNTnhVWiWU6AVo6CAeTjXEK24SpCXyZvwG9ROFjT0Vlux0EOhWKBAeC+45iDj80QNJTYaT1SDEmeunT0vDNw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 18.15.13
+      aes-js: 4.0.0-beta.5
+      tslib: 2.4.0
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
 
   /ethers@6.11.1:
     resolution: {integrity: sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==}


### PR DESCRIPTION
## Summary

 Support `evm_call` method. Use correct request schema.
 
 Add support for custom JSON-RPC errors. 
 

 
## Example

  **balanceOf** can be checked using following data:
 
 ```
 {"jsonrpc":"2.0","method":"eth_call","params":[{"from":"0xBd6F65c58A46427AF4B257cBE231D0eD69eD5508", "to": "0xD3D80a3Df661414a76aAd7738a136A8d7aAa1666","data":"0x70a08231000000000000000000000000bd6f65c58a46427af4b257cbe231d0ed69ed5508"}, "latest"],"id":1}
```

or request:

```
curl --location 'http:/127.0.0.1:4008/api/' \
--header 'Content-Type: application/json' \
--data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from":"0xBd6F65c58A46427AF4B257cBE231D0eD69eD5508", "to": "0xD3D80a3Df661414a76aAd7738a136A8d7aAa1666","data":"0x70a08231000000000000000000000000bd6f65c58a46427af4b257cbe231d0ed69ed5508"}, "latest"],"id":1}'
```

## Checklist

- [x] Ready to be merged
