### PR TITLE
feat: add `env:paths:clear` commands

### DIFF
--- a/packages/api/source/commands/env-paths-clear.ts
+++ b/packages/api/source/commands/env-paths-clear.ts
@@ -38,7 +38,7 @@ export class Command extends Commands.Command {
 			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
 		}
 		if (this.hasFlag("temp") || this.hasFlag("all")) {
-			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
+			await this.#clear("Temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 
 		if (this.hasFlag("plugins")) {

--- a/packages/api/source/commands/env-paths-clear.ts
+++ b/packages/api/source/commands/env-paths-clear.ts
@@ -18,25 +18,26 @@ export class Command extends Commands.Command {
 		this.definition.setFlag("cache", "Clear cache.", Joi.boolean());
 		this.definition.setFlag("log", "Clear log.", Joi.boolean());
 		this.definition.setFlag("temp", "Clear temp.", Joi.boolean());
+		this.definition.setFlag("all", "Clear all.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
-		if (this.hasFlag("data")) {
+		if (this.hasFlag("data") || this.hasFlag("all")) {
 			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
 		}
 
-		if (this.hasFlag("config")) {
+		if (this.hasFlag("config") || this.hasFlag("all")) {
 			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
 		}
 
-		if (this.hasFlag("cache")) {
+		if (this.hasFlag("cache") || this.hasFlag("all")) {
 			await this.#clear("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
 		}
 
-		if (this.hasFlag("log")) {
+		if (this.hasFlag("log") || this.hasFlag("all")) {
 			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
 		}
-		if (this.hasFlag("temp")) {
+		if (this.hasFlag("temp") || this.hasFlag("all")) {
 			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 

--- a/packages/api/source/commands/env-paths-clear.ts
+++ b/packages/api/source/commands/env-paths-clear.ts
@@ -1,0 +1,58 @@
+// eslint-disable-next-line unicorn/prevent-abbreviations
+import { Commands, Contracts, Identifiers } from "@mainsail/cli";
+import { injectable } from "@mainsail/container";
+import { emptyDirSync, existsSync, readdirSync } from "fs-extra";
+import Joi from "joi";
+import { join } from "path";
+
+@injectable()
+export class Command extends Commands.Command {
+	public signature = "env:paths:clear";
+
+	public description = "Clear data on environment paths.";
+
+	public configure(): void {
+		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
+		this.definition.setFlag("data", "Clear data.", Joi.boolean());
+		this.definition.setFlag("config", "Clear config.", Joi.boolean());
+		this.definition.setFlag("cache", "Clear cache.", Joi.boolean());
+		this.definition.setFlag("log", "Clear log.", Joi.boolean());
+		this.definition.setFlag("temp", "Clear temp.", Joi.boolean());
+	}
+
+	public async execute(): Promise<void> {
+		if (this.hasFlag("data")) {
+			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
+		}
+
+		if (this.hasFlag("config")) {
+			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
+		}
+
+		if (this.hasFlag("cache")) {
+			await this.#clear("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
+		}
+
+		if (this.hasFlag("log")) {
+			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
+		}
+		if (this.hasFlag("temp")) {
+			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
+		}
+
+		if (this.hasFlag("plugins")) {
+			await this.#clear(
+				"Plugins",
+				join(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data, "plugins"),
+			);
+		}
+	}
+
+	async #clear(name, path: string) {
+		if (existsSync(path) && readdirSync(path).length > 0) {
+			emptyDirSync(path);
+
+			this.components.log(`${name} path (${path}) has been cleared.`);
+		}
+	}
+}

--- a/packages/api/source/commands/env-paths.ts
+++ b/packages/api/source/commands/env-paths.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line unicorn/prevent-abbreviations
-import { Commands, Identifiers } from "@mainsail/cli";
+import { Commands, Contracts, Identifiers } from "@mainsail/cli";
 import { injectable } from "@mainsail/container";
 
 @injectable()
@@ -10,7 +10,7 @@ export class Command extends Commands.Command {
 
 	public async execute(): Promise<void> {
 		this.components.table(["Type", "Path"], (table) => {
-			for (const [type, path] of Object.entries(this.app.get<{}>(Identifiers.ApplicationPaths))) {
+			for (const [type, path] of Object.entries(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths))) {
 				table.push([type, path]);
 			}
 		});

--- a/packages/cli/source/application.ts
+++ b/packages/cli/source/application.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "os";
 // eslint-disable-next-line unicorn/import-style
 import { resolve } from "path";
 
-import { Paths } from "./env-paths";
+import { Paths } from "./contracts";
 import { Identifiers } from "./ioc";
 
 export class Application {

--- a/packages/cli/source/contracts.ts
+++ b/packages/cli/source/contracts.ts
@@ -1,5 +1,6 @@
 import { interfaces } from "@mainsail/container";
 import { AnySchema } from "joi";
+export { Paths } from "env-paths";
 
 export type InputValue = any;
 export type InputValues = Record<string, InputValue>;

--- a/packages/cli/source/services/environment.ts
+++ b/packages/cli/source/services/environment.ts
@@ -4,7 +4,8 @@ import { parse, stringify } from "envfile";
 import { existsSync, readFileSync, writeFileSync } from "fs-extra";
 import path from "path";
 
-import { envPaths as environmentPaths, Paths } from "../env-paths";
+import { Paths } from "../contracts";
+import { envPaths as environmentPaths } from "../env-paths";
 import { Identifiers } from "../ioc";
 
 @injectable()

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line unicorn/prevent-abbreviations
-import { Commands, Identifiers } from "@mainsail/cli";
+import { Commands, Contracts, Identifiers } from "@mainsail/cli";
 import { injectable } from "@mainsail/container";
 import { emptyDirSync, existsSync, readdirSync } from "fs-extra";
 import Joi from "joi";
@@ -15,6 +15,7 @@ export class Command extends Commands.Command {
 		this.definition.setFlag("state-export", "Clear state exports.", Joi.boolean());
 		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
 		this.definition.setFlag("data", "Clear data path.", Joi.boolean());
+		this.definition.setFlag("config", "Clear config path.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
@@ -25,20 +26,24 @@ export class Command extends Commands.Command {
 		// });
 
 		if (this.hasFlag("data")) {
-			await this.#clear("Data", this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data);
+			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
+		}
+
+		if (this.hasFlag("config")) {
+			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
 		}
 
 		if (this.hasFlag("state-export")) {
 			await this.#clear(
 				"State export",
-				join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "state-export"),
+				join(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data, "state-export"),
 			);
 		}
 
 		if (this.hasFlag("plugins")) {
 			await this.#clear(
 				"Plugins",
-				join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "plugins"),
+				join(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data, "plugins"),
 			);
 		}
 	}

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -1,0 +1,46 @@
+// eslint-disable-next-line unicorn/prevent-abbreviations
+import { Commands, Identifiers } from "@mainsail/cli";
+import { injectable } from "@mainsail/container";
+import { emptyDirSync, existsSync, readdirSync } from "fs-extra";
+import Joi from "joi";
+import { join } from "path";
+
+@injectable()
+export class Command extends Commands.Command {
+	public signature = "env:paths:clear";
+
+	public description = "Clear data on environment paths.";
+
+	public configure(): void {
+		this.definition.setFlag("state-export", "Remove state exports.", Joi.boolean());
+		this.definition.setFlag("plugins", "Remove installed plugins.", Joi.boolean());
+	}
+
+	public async execute(): Promise<void> {
+		// this.components.table(["Type", "Path"], (table) => {
+		// 	for (const [type, path] of Object.entries<{}>(this.app.get(Identifiers.ApplicationPaths))) {
+		// 		table.push([type, path]);
+		// 	}
+		// });
+
+		if (this.hasFlag("state-export")) {
+			const path = join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "state-export");
+			await this.#clear("State export", path);
+		}
+
+		if (this.hasFlag("plugins")) {
+			const path = join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "plugins");
+			await this.#clear("Plugins", path);
+		}
+	}
+
+	async #clear(name, path: string) {
+		if (existsSync(path) && readdirSync(path).length > 0) {
+			emptyDirSync(path);
+
+			this.components.log(`${name} path (${path}) has been cleared.`);
+		} else {
+			this.components.log(`${name} path (${path}) is already empty.`);
+		}
+	}
+}

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -19,25 +19,26 @@ export class Command extends Commands.Command {
 		this.definition.setFlag("cache", "Clear cache.", Joi.boolean());
 		this.definition.setFlag("log", "Clear log.", Joi.boolean());
 		this.definition.setFlag("temp", "Clear temp.", Joi.boolean());
+		this.definition.setFlag("all", "Clear all.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
-		if (this.hasFlag("data")) {
+		if (this.hasFlag("data") || this.hasFlag("all")) {
 			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
 		}
 
-		if (this.hasFlag("config")) {
+		if (this.hasFlag("config") || this.hasFlag("all")) {
 			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
 		}
 
-		if (this.hasFlag("cache")) {
+		if (this.hasFlag("cache") || this.hasFlag("all")) {
 			await this.#clear("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
 		}
 
-		if (this.hasFlag("log")) {
+		if (this.hasFlag("log") || this.hasFlag("all")) {
 			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
 		}
-		if (this.hasFlag("temp")) {
+		if (this.hasFlag("temp") || this.hasFlag("all")) {
 			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -29,13 +29,17 @@ export class Command extends Commands.Command {
 		}
 
 		if (this.hasFlag("state-export")) {
-			const path = join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "state-export");
-			await this.#clear("State export", path);
+			await this.#clear(
+				"State export",
+				join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "state-export"),
+			);
 		}
 
 		if (this.hasFlag("plugins")) {
-			const path = join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "plugins");
-			await this.#clear("Plugins", path);
+			await this.#clear(
+				"Plugins",
+				join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "plugins"),
+			);
 		}
 	}
 

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -39,7 +39,7 @@ export class Command extends Commands.Command {
 			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
 		}
 		if (this.hasFlag("temp") || this.hasFlag("all")) {
-			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
+			await this.#clear("Temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 
 		if (this.hasFlag("state-export")) {

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -14,20 +14,14 @@ export class Command extends Commands.Command {
 	public configure(): void {
 		this.definition.setFlag("state-export", "Clear state exports.", Joi.boolean());
 		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
-		this.definition.setFlag("data", "Clear data path.", Joi.boolean());
-		this.definition.setFlag("config", "Clear config path.", Joi.boolean());
-		this.definition.setFlag("cache", "Clear cache path.", Joi.boolean());
-		this.definition.setFlag("log", "Clear log path.", Joi.boolean());
-		this.definition.setFlag("temp", "Clear temp path.", Joi.boolean());
+		this.definition.setFlag("data", "Clear data.", Joi.boolean());
+		this.definition.setFlag("config", "Clear config.", Joi.boolean());
+		this.definition.setFlag("cache", "Clear cache.", Joi.boolean());
+		this.definition.setFlag("log", "Clear log.", Joi.boolean());
+		this.definition.setFlag("temp", "Clear temp.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
-		// this.components.table(["Type", "Path"], (table) => {
-		// 	for (const [type, path] of Object.entries<{}>(this.app.get(Identifiers.ApplicationPaths))) {
-		// 		table.push([type, path]);
-		// 	}
-		// });
-
 		if (this.hasFlag("data")) {
 			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
 		}

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -12,8 +12,9 @@ export class Command extends Commands.Command {
 	public description = "Clear data on environment paths.";
 
 	public configure(): void {
-		this.definition.setFlag("state-export", "Remove state exports.", Joi.boolean());
-		this.definition.setFlag("plugins", "Remove installed plugins.", Joi.boolean());
+		this.definition.setFlag("state-export", "Clear state exports.", Joi.boolean());
+		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
+		this.definition.setFlag("data", "Clear data path.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
@@ -22,6 +23,10 @@ export class Command extends Commands.Command {
 		// 		table.push([type, path]);
 		// 	}
 		// });
+
+		if (this.hasFlag("data")) {
+			await this.#clear("Data", this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data);
+		}
 
 		if (this.hasFlag("state-export")) {
 			const path = join(this.app.get<{ data: string }>(Identifiers.ApplicationPaths).data, "state-export");
@@ -39,8 +44,6 @@ export class Command extends Commands.Command {
 			emptyDirSync(path);
 
 			this.components.log(`${name} path (${path}) has been cleared.`);
-		} else {
-			this.components.log(`${name} path (${path}) is already empty.`);
 		}
 	}
 }

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -16,6 +16,9 @@ export class Command extends Commands.Command {
 		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
 		this.definition.setFlag("data", "Clear data path.", Joi.boolean());
 		this.definition.setFlag("config", "Clear config path.", Joi.boolean());
+		this.definition.setFlag("cache", "Clear cache path.", Joi.boolean());
+		this.definition.setFlag("log", "Clear log path.", Joi.boolean());
+		this.definition.setFlag("temp", "Clear temp path.", Joi.boolean());
 	}
 
 	public async execute(): Promise<void> {
@@ -31,6 +34,17 @@ export class Command extends Commands.Command {
 
 		if (this.hasFlag("config")) {
 			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
+		}
+
+		if (this.hasFlag("cache")) {
+			await this.#clear("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
+		}
+
+		if (this.hasFlag("log")) {
+			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
+		}
+		if (this.hasFlag("temp")) {
+			await this.#clear("temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 
 		if (this.hasFlag("state-export")) {

--- a/packages/core/source/commands/env-paths.ts
+++ b/packages/core/source/commands/env-paths.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line unicorn/prevent-abbreviations
-import { Commands, Identifiers } from "@mainsail/cli";
+import { Commands, Contracts, Identifiers } from "@mainsail/cli";
 import { injectable } from "@mainsail/container";
 
 @injectable()
@@ -10,7 +10,7 @@ export class Command extends Commands.Command {
 
 	public async execute(): Promise<void> {
 		this.components.table(["Type", "Path"], (table) => {
-			for (const [type, path] of Object.entries<{}>(this.app.get(Identifiers.ApplicationPaths))) {
+			for (const [type, path] of Object.entries(this.app.get<Contracts.Flags>(Identifiers.ApplicationPaths))) {
 				table.push([type, path]);
 			}
 		});


### PR DESCRIPTION
## Summary

Clear folders on the predefined paths. Options:

- state-export
- plugins
- data
- config
- cache
- log
- temp
- all
 

## Checklist

- [x] Ready to be merged
