### PR TITLE
feat(crypto-transaction-username-registration): limit one transaction by sender in pool

### DIFF
--- a/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
+++ b/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
@@ -50,6 +50,18 @@ export class UsernameRegistrationTransactionHandler extends Handlers.Transaction
 		AppUtils.assert.defined<Contracts.Crypto.TransactionAsset>(data.asset);
 		AppUtils.assert.defined<string>(data.asset.username);
 
+		const hasSender: boolean = await this.poolQuery
+			.getAllBySender(data.senderPublicKey)
+			.whereKind(transaction)
+			.has();
+
+		if (hasSender) {
+			throw new Exceptions.PoolError(
+				`Sender ${data.senderPublicKey} already has a transaction of type '${Contracts.Crypto.TransactionType.UsernameRegistration}' in the pool`,
+				"ERR_PENDING",
+			);
+		}
+
 		const username = data.asset.username;
 		const hasUsername: boolean = await this.poolQuery
 			.getAll()

--- a/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
+++ b/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
@@ -51,13 +51,13 @@ export class UsernameRegistrationTransactionHandler extends Handlers.Transaction
 		AppUtils.assert.defined<string>(data.asset.username);
 
 		const username = data.asset.username;
-		const hasPublicKey: boolean = await this.poolQuery
+		const hasUsername: boolean = await this.poolQuery
 			.getAll()
 			.whereKind(transaction)
 			.wherePredicate(async (t) => t.data.asset?.username === username)
 			.has();
 
-		if (hasPublicKey) {
+		if (hasUsername) {
 			throw new Exceptions.PoolError(
 				`Username registration for public key "${username}" already in the pool`,
 				"ERR_PENDING",

--- a/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
+++ b/packages/crypto-transaction-username-registration/source/handlers/username-registration.ts
@@ -59,7 +59,7 @@ export class UsernameRegistrationTransactionHandler extends Handlers.Transaction
 
 		if (hasUsername) {
 			throw new Exceptions.PoolError(
-				`Username registration for public key "${username}" already in the pool`,
+				`Username registration for username "${username}" already in the pool`,
 				"ERR_PENDING",
 			);
 		}


### PR DESCRIPTION
## Summary

Allow only 1 TX by sender in pool.
Fix error message. 

## Checklist

- [x] Ready to be merged
