### PR TITLE
refactor(transaction-pool): return tx indexes as integers

### DIFF
--- a/packages/contracts/source/contracts/p2p/endpoints.ts
+++ b/packages/contracts/source/contracts/p2p/endpoints.ts
@@ -104,5 +104,5 @@ export interface PostTransactionsRequest extends Request {
 }
 
 export interface PostTransactionsResponse extends Response {
-	accept: string[];
+	accept: number[];
 }

--- a/packages/contracts/source/contracts/transaction-pool/processor.ts
+++ b/packages/contracts/source/contracts/transaction-pool/processor.ts
@@ -6,11 +6,11 @@ export type ProcessorError = {
 };
 
 export type ProcessorResult = {
-	accept: string[];
-	broadcast: string[];
-	invalid: string[];
-	excess: string[];
-	errors?: { [id: string]: ProcessorError };
+	accept: number[];
+	broadcast: number[];
+	invalid: number[];
+	excess: number[];
+	errors?: { [index: string]: ProcessorError };
 };
 
 export interface ProcessorExtension {

--- a/packages/test-framework/source/mocks/transaction-pool-processor.ts
+++ b/packages/test-framework/source/mocks/transaction-pool-processor.ts
@@ -1,9 +1,9 @@
 import { Contracts } from "@mainsail/contracts";
 
-let accept: string[] = [];
-let broadcast: string[] = [];
-let invalid: string[] = [];
-let excess: string[] = [];
+let accept: number[] = [];
+let broadcast: number[] = [];
+let invalid: number[] = [];
+let excess: number[] = [];
 let errors: { [id: string]: Contracts.TransactionPool.ProcessorError } | undefined;
 
 export const setProcessorState = (state: any): void => {
@@ -17,10 +17,10 @@ export const setProcessorState = (state: any): void => {
 
 class TransactionPoolProcessorMock implements Partial<Contracts.TransactionPool.Processor> {
 	public async process(data: Contracts.Crypto.TransactionJson[] | Buffer[]): Promise<{
-		accept: string[];
-		broadcast: string[];
-		invalid: string[];
-		excess: string[];
+		accept: number[];
+		broadcast: number[];
+		invalid: number[];
+		excess: number[];
 		errors?: { [id: string]: Contracts.TransactionPool.ProcessorError };
 	}> {
 		return {

--- a/packages/transaction-pool/source/processor.test.ts
+++ b/packages/transaction-pool/source/processor.test.ts
@@ -117,7 +117,7 @@ describe<{
 		spiedExtension1.calledTimes(2);
 		spiedBroadcaster.neverCalled();
 
-		assert.equal(result.accept, ["0", "1"]);
+		assert.equal(result.accept, [0, 1]);
 		assert.equal(result.broadcast, []);
 		assert.equal(result.invalid, []);
 		assert.equal(result.excess, []);
@@ -145,9 +145,9 @@ describe<{
 		spiedExtension1.calledOnce();
 		spiedBroadcaster.calledOnce();
 
-		assert.equal(result.accept, ["0"]);
-		assert.equal(result.broadcast, ["0"]);
-		assert.equal(result.invalid, ["1"]);
+		assert.equal(result.accept, [0]);
+		assert.equal(result.broadcast, [0]);
+		assert.equal(result.invalid, [1]);
 		assert.equal(result.excess, []);
 		assert.truthy(result.errors["1"]);
 		assert.equal(result.errors["1"].type, "ERR_LOW_FEE");
@@ -175,8 +175,8 @@ describe<{
 		spiedExtension1.calledTimes(2);
 		spiedBroadcaster.called();
 
-		assert.equal(result.accept, ["0", "1"]);
-		assert.equal(result.broadcast, ["0"]);
+		assert.equal(result.accept, [0, 1]);
+		assert.equal(result.broadcast, [0]);
 		assert.equal(result.invalid, []);
 		assert.equal(result.excess, []);
 		assert.undefined(result.errors);
@@ -220,8 +220,8 @@ describe<{
 
 		assert.equal(result.accept, []);
 		assert.equal(result.broadcast, []);
-		assert.equal(result.invalid, ["0"]);
-		assert.equal(result.excess, ["0"]);
+		assert.equal(result.invalid, [0]);
+		assert.equal(result.excess, [0]);
 		assert.truthy(result.errors["0"]);
 		assert.equal(result.errors["0"].type, "ERR_EXCEEDS_MAX_COUNT");
 	});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Previously it would return a transaction id or an index, but this is no longer the case and now it always returns an index. Update the response to reflect it.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
