### PR TITLE
fix(api-http): wallet resource response

### DIFF
--- a/packages/api-http/integration/routes/delegates.test.ts
+++ b/packages/api-http/integration/routes/delegates.test.ts
@@ -61,7 +61,10 @@ describe<{
 		];
 
 		for (const { id, result } of testCases) {
-			const { statusCode, data } = await request(`/delegates/${id}`, options);
+			const {
+				statusCode,
+				data: { data },
+			} = await request(`/delegates/${id}`, options);
 			assert.equal(statusCode, 200);
 			assert.equal(data, result);
 		}

--- a/packages/api-http/integration/routes/wallets.test.ts
+++ b/packages/api-http/integration/routes/wallets.test.ts
@@ -69,7 +69,10 @@ describe<{
 		];
 
 		for (const { id, result } of testCases) {
-			const { statusCode, data } = await request(`/wallets/${id}`, options);
+			const {
+				statusCode,
+				data: { data },
+			} = await request(`/wallets/${id}`, options);
 			assert.equal(statusCode, 200);
 			assert.equal(data, result);
 		}

--- a/packages/api-http/source/controllers/delegates.ts
+++ b/packages/api-http/source/controllers/delegates.ts
@@ -44,7 +44,7 @@ export class DelegatesController extends Controller {
 			return Boom.notFound("Delegate not found");
 		}
 
-		return this.toResource(delegate, DelegateResource, request.params.transform);
+		return this.respondWithResource(delegate, DelegateResource, request.params.transform);
 	}
 
 	public async voters(request: Hapi.Request) {

--- a/packages/api-http/source/controllers/wallets.ts
+++ b/packages/api-http/source/controllers/wallets.ts
@@ -45,7 +45,7 @@ export class WalletsController extends Controller {
 
 		const wallet = await this.getWallet(walletId);
 
-		return this.toResource(wallet, WalletResource, request.params.transform);
+		return this.respondWithResource(wallet, WalletResource, request.params.transform);
 	}
 
 	public async transactions(request: Hapi.Request) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Use `responseWithResource` so it correctly returns 404 if a wallet does not exist. Also makes the returned payload consistent with the other controllers.

This is a breaking change as it now wraps the returned resource in `{  "data": {  ... } }`.


See before and after comparison.

<details>
  <summary>Before</summary>

**Existing wallet**
```
/api/wallets/DA6dECuctJRW9W2AVZhWNrzftD4eSXmoon

{
    "address": "DA6dECuctJRW9W2AVZhWNrzftD4eSXmoon",
    "publicKey": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
    "balance": "140488000000",
    "nonce": "7",
    "attributes": {
        "vote": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
        "nonce": "7",
        "balance": "140488000000",
        "username": "arkmoon",
        "publicKey": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
        "validatorRank": 7,
        "validatorApproval": 1.89,
        "validatorLastBlock": {
            "id": "61414dbbc40f5dc9cb26e79f0cc93633fef6715d1ff0c6918fcca4a0d8fa5f6a",
            "height": 111730,
            "timestamp": 1710472139592
        },
        "validatorPublicKey": "90ec60efe46b401253c68ff98055ccc9e66a2457a6424761f296a07dc1558a795a868675c273c8064307b4c7a1461518",
        "validatorForgedFees": "10000000",
        "validatorForgedTotal": "135810000000",
        "validatorVoteBalance": "235995544603773",
        "validatorForgedRewards": "135800000000",
        "validatorProducedBlocks": 679
    },
    "updated_at": "111777"
}

```

**Non-existent wallet**

```
/api/wallets/doesnotexist

204 No Content
```
</details>

<details>
  <summary>After</summary>

**Existing wallet**

```
/api/wallets/DA6dECuctJRW9W2AVZhWNrzftD4eSXmoon

{
    "data" {
        "address": "DA6dECuctJRW9W2AVZhWNrzftD4eSXmoon",
        "publicKey": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
        "balance": "140488000000",
        "nonce": "7",
        "attributes": {
            "vote": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
            "nonce": "7",
            "balance": "140488000000",
            "username": "arkmoon",
            "publicKey": "03c521450f8fb765d7ee2fd3cabfd0ab0138ecc5ae4d69d47ed910088183c52451",
            "validatorRank": 7,
            "validatorApproval": 1.89,
            "validatorLastBlock": {
                "id": "61414dbbc40f5dc9cb26e79f0cc93633fef6715d1ff0c6918fcca4a0d8fa5f6a",
                "height": 111730,
                "timestamp": 1710472139592
            },
            "validatorPublicKey": "90ec60efe46b401253c68ff98055ccc9e66a2457a6424761f296a07dc1558a795a868675c273c8064307b4c7a1461518",
            "validatorForgedFees": "10000000",
            "validatorForgedTotal": "135810000000",
            "validatorVoteBalance": "235995544603773",
            "validatorForgedRewards": "135800000000",
            "validatorProducedBlocks": 679
        },
        "updated_at": "111777"
    }
}
```

**Non-existent wallet**
```
/api/wallets/doesnotexist

{
    "statusCode": 404,
    "error": "Not Found",
    "message": "Not Found"
}
```
</details>

Since the tx tester is affected it needs to be updated too.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
