### PR TITLE
fix: use .js extension in `start` commands

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,7 @@
 		"build": "pnpm run clean && tsc",
 		"build:watch": "pnpm run clean && tsc -w",
 		"clean": "del distribution",
-		"mainsail-api": "node ./bin/run",
+		"mainsail-api": "node ./bin/run.js",
 		"release": "pnpm publish --access public",
 		"test": "uvu -r tsm source .test.ts",
 		"test:coverage": "c8 pnpm run test",

--- a/packages/api/source/commands/api-start.test.ts
+++ b/packages/api/source/commands/api-start.test.ts
@@ -1,8 +1,8 @@
 import { Identifiers, Services } from "@mainsail/cli";
-import { Console, describe } from "../../../test-framework/source";
 import { resolve } from "path";
 import { dirSync, setGracefulCleanup } from "tmp";
 
+import { Console, describe } from "../../../test-framework/source";
 import { Command } from "./api-start";
 
 describe<{
@@ -32,7 +32,7 @@ describe<{
 				},
 				name: "mainsail-api",
 				node_args: undefined,
-				script: resolve(__dirname, "../../../../packages/api/bin/run"),
+				script: resolve(__dirname, "../../../../packages/api/bin/run.js"),
 			},
 			{ "kill-timeout": 30_000, "max-restarts": 5, name: "mainsail-api" },
 		);

--- a/packages/api/source/commands/api-start.ts
+++ b/packages/api/source/commands/api-start.ts
@@ -34,7 +34,7 @@ export class Command extends Commands.Command {
 			{
 				args: `api:run ${Utils.Flags.castFlagsToString(flags, ["daemon"])}`,
 				name: `mainsail-api`,
-				script: resolve(dirname, "../../bin/run"),
+				script: resolve(dirname, "../../bin/run.js"),
 			},
 			flags,
 		);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
 		"build:watch": "pnpm run clean && tsc -w",
 		"clean": "del distribution",
 		"full:testnet": "cross-env-shell CORE_PATH_CONFIG=./bin/config/testnet pnpm run mainsail core:run -- --env=test",
-		"mainsail": "node ./bin/run",
+		"mainsail": "node ./bin/run.js",
 		"release": "pnpm publish --access public",
 		"test": "uvu -r tsm source .test.ts",
 		"test:coverage": "c8 pnpm run test",

--- a/packages/core/source/commands/core-start.test.ts
+++ b/packages/core/source/commands/core-start.test.ts
@@ -35,7 +35,7 @@ describe<{
 				},
 				name: "mainsail",
 				node_args: undefined,
-				script: resolve(__dirname, "../../../../packages/core/bin/run"),
+				script: resolve(__dirname, "../../../../packages/core/bin/run.js"),
 			},
 			{ "kill-timeout": 30_000, "max-restarts": 5, name: "mainsail" },
 		);

--- a/packages/core/source/commands/core-start.ts
+++ b/packages/core/source/commands/core-start.ts
@@ -40,7 +40,7 @@ export class Command extends Commands.Command {
 			{
 				args: `core:run ${Utils.Flags.castFlagsToString(flags, ["daemon"])}`,
 				name: `mainsail`,
-				script: resolve(dirname, "../../bin/run"),
+				script: resolve(dirname, "../../bin/run.js"),
 			},
 			flags,
 		);

--- a/packages/test-framework/source/cli/console.ts
+++ b/packages/test-framework/source/cli/console.ts
@@ -6,7 +6,7 @@ export class Console {
 
 	public pkg = {
 		bin: {
-			mainsail: "./bin/run",
+			mainsail: "./bin/run.js",
 		},
 		description: "Core of the Mainsail Blockchain",
 		name: "@mainsail/core",


### PR DESCRIPTION
## Summary

Fix failing start commands. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged

