### PR TITLE
fix(api): sync active milestones on change

### DIFF
--- a/packages/api-database/source/models/configuration.ts
+++ b/packages/api-database/source/models/configuration.ts
@@ -20,4 +20,10 @@ export class Configuration {
 		type: "jsonb",
 	})
 	public cryptoConfiguration!: Record<string, any>;
+
+	@Column({
+		nullable: false,
+		type: "jsonb",
+	})
+	public activeMilestones!: Record<string, any>;
 }

--- a/packages/api-http/integration/routes/node.test.ts
+++ b/packages/api-http/integration/routes/node.test.ts
@@ -55,6 +55,7 @@ describe<{
 
 	it("/node/configuration", async () => {
 		await apiContext.configurationRepository.save({
+			activeMilestones: cryptoJson.milestones[0],
 			cryptoConfiguration: cryptoJson,
 			id: 1,
 			version: "0.0.1",
@@ -67,6 +68,7 @@ describe<{
 
 	it("/node/configuration/crypto", async () => {
 		await apiContext.configurationRepository.save({
+			activeMilestones: cryptoJson.milestones[0],
 			cryptoConfiguration: cryptoJson,
 			id: 1,
 			version: "0.0.1",
@@ -79,6 +81,7 @@ describe<{
 
 	it("/node/fees", async () => {
 		await apiContext.configurationRepository.save({
+			activeMilestones: cryptoJson.milestones[0],
 			cryptoConfiguration: cryptoJson,
 			id: 1,
 			version: "0.0.1",

--- a/packages/api-http/source/controllers/node.ts
+++ b/packages/api-http/source/controllers/node.ts
@@ -97,7 +97,6 @@ export class NodeController extends Controller {
 
 	public async configuration(request: Hapi.Request) {
 		const configuration = await this.getConfiguration();
-		const state = await this.getState();
 		const plugins = await this.getPlugins();
 		const transactionPoolConfiguration = plugins["@mainsail/transaction-pool"]?.configuration ?? {};
 
@@ -106,7 +105,7 @@ export class NodeController extends Controller {
 
 		return {
 			data: {
-				constants: this.getMilestone(+state.height, cryptoConfiguration),
+				constants: configuration.activeMilestones,
 				core: {
 					version: configuration.version,
 				},
@@ -137,20 +136,6 @@ export class NodeController extends Controller {
 		return {
 			data: configuration?.cryptoConfiguration ?? {},
 		};
-	}
-
-	private getMilestone(height: number, configuration: Contracts.Crypto.NetworkConfig) {
-		const milestones = configuration.milestones ?? [];
-
-		let milestone = milestones[0];
-		for (let index = milestones.length - 1; index >= 0; index--) {
-			milestone = milestones[index];
-			if (milestone.height <= height) {
-				break;
-			}
-		}
-
-		return milestone;
 	}
 
 	private buildPortMapping(plugins: Record<string, Models.Plugin>) {

--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -9,13 +9,14 @@ import { Providers, Types, Utils } from "@mainsail/kernel";
 import { sleep, validatorSetPack } from "@mainsail/utils";
 import { performance } from "perf_hooks";
 
-import * as ApiSyncContracts from "./contracts.js";
+import { Listeners } from "./contracts.js";
 
 interface DeferredSync {
 	block: Models.Block;
 	transactions: Models.Transaction[];
 	validatorRound?: Models.ValidatorRound;
 	wallets: Models.Wallet[];
+	newMilestones?: Record<string, any>;
 }
 
 const drainQueue = async (queue: Contracts.Kernel.Queue) => new Promise((resolve) => queue.once("drain", resolve));
@@ -79,7 +80,7 @@ export class Sync implements Contracts.ApiSync.Service {
 	#queue!: Contracts.Kernel.Queue;
 
 	@inject(Identifiers.ApiSync.Listener)
-	private readonly listeners!: ApiSyncContracts.Listeners;
+	private readonly listeners!: Listeners;
 
 	public async prepareBootstrap(): Promise<void> {
 		await this.migrations.run();
@@ -168,6 +169,12 @@ export class Sync implements Contracts.ApiSync.Service {
 						validatorRound: this.#createValidatorRound(header.height + 1),
 					}
 				: {}),
+
+			...(this.configuration.isNewMilestone(header.height + 1)
+				? {
+						newMilestones: this.configuration.getMilestone(header.height + 1),
+					}
+				: {}),
 		};
 
 		return this.#queueDeferredSync(deferredSync);
@@ -190,14 +197,17 @@ export class Sync implements Contracts.ApiSync.Service {
 	}
 
 	async #bootstrapConfiguration(): Promise<void> {
-		await this.configurationRepositoryFactory().upsert(
-			{
+		await this.configurationRepositoryFactory()
+			.createQueryBuilder()
+			.insert()
+			.orIgnore()
+			.values({
+				activeMilestones: this.configuration.getMilestone(0) as Record<string, any>,
 				cryptoConfiguration: (this.configuration.all() ?? {}) as Record<string, any>,
 				id: 1,
 				version: this.app.version(),
-			},
-			["id"],
-		);
+			})
+			.execute();
 	}
 
 	async #bootstrapState(): Promise<void> {
@@ -281,6 +291,7 @@ export class Sync implements Contracts.ApiSync.Service {
 
 		await this.dataSource.transaction("REPEATABLE READ", async (entityManager) => {
 			const blockRepository = this.blockRepositoryFactory(entityManager);
+			const configurationRepository = this.configurationRepositoryFactory(entityManager);
 			const stateRepository = this.stateRepositoryFactory(entityManager);
 			const transactionRepository = this.transactionRepositoryFactory(entityManager);
 			const validatorRoundRepository = this.validatorRoundRepositoryFactory(entityManager);
@@ -315,6 +326,17 @@ export class Sync implements Contracts.ApiSync.Service {
 					.insert()
 					.orIgnore()
 					.values(deferred.validatorRound)
+					.execute();
+			}
+
+			if (deferred.newMilestones) {
+				await configurationRepository
+					.createQueryBuilder()
+					.update()
+					.set({
+						activeMilestones: deferred.newMilestones,
+					})
+					.where("id = :id", { id: 1 })
 					.execute();
 			}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Sync active milestones to the `configuration` table on milestone change so that the API can easily use them.

NOTE: Since this adds a new table column it requires a postgres reset.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
