### PR TITLE
fix(api-http): add missing fields to transaction resource

### DIFF
--- a/packages/api-common/source/server.ts
+++ b/packages/api-common/source/server.ts
@@ -46,7 +46,7 @@ export abstract class AbstractServer {
 		this.server.ext("onPreResponse", (request, h) => {
 			if ("isBoom" in request.response && request.response.isBoom && request.response.isServer) {
 				// @ts-ignore
-				this.logger.error(request.response.stack);
+				this.logger.error(`${request.path} - ${request.response.stack ?? request.response.message}`);
 			}
 			return h.continue;
 		});

--- a/packages/api-http/source/controllers/blocks.ts
+++ b/packages/api-http/source/controllers/blocks.ts
@@ -104,7 +104,11 @@ export class BlocksController extends Controller {
 			options,
 		);
 
-		return this.toPagination(transactions, TransactionResource, request.query.transform);
+		return this.toPagination(
+			await this.enrichTransactionResult(transactions),
+			TransactionResource,
+			request.query.transform,
+		);
 	}
 
 	private getBlockCriteriaByIdOrHeight(idOrHeight: string): Search.Criteria.OrBlockCriteria {

--- a/packages/api-http/source/controllers/controller.ts
+++ b/packages/api-http/source/controllers/controller.ts
@@ -9,7 +9,7 @@ import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers } from "@mainsail/kernel";
 
-import { BlockModel, TransactionModel } from "../resources/index.js";
+import { BlockModel, EnrichedTransaction } from "../resources/index.js";
 
 @injectable()
 export class Controller extends AbstractController {
@@ -93,27 +93,23 @@ export class Controller extends AbstractController {
 	protected async enrichTransactionResult(
 		resultPage: Search.ResultsPage<Models.Transaction | Models.MempoolTransaction>,
 		context?: { state?: Models.State },
-	): Promise<Search.ResultsPage<TransactionModel>> {
+	): Promise<Search.ResultsPage<EnrichedTransaction>> {
 		const state = context?.state ?? (await this.getState());
 
-		const enriched: Promise<TransactionModel | null>[] = [];
+		const enriched: Promise<EnrichedTransaction>[] = [];
 		for (const transaction of resultPage.results) {
 			enriched.push(this.enrichTransaction(transaction, state));
 		}
 
 		// @ts-ignore
 		resultPage.results = await Promise.all(enriched);
-		return resultPage as Search.ResultsPage<TransactionModel>;
+		return resultPage as Search.ResultsPage<EnrichedTransaction>;
 	}
 
 	protected async enrichTransaction(
-		transaction: Models.Transaction | Models.MempoolTransaction | null,
+		transaction: Models.Transaction | Models.MempoolTransaction,
 		state?: Models.State,
-	): Promise<TransactionModel | null> {
-		if (!transaction) {
-			return null;
-		}
-
+	): Promise<EnrichedTransaction> {
 		const promises: Promise<any>[] = [];
 		if (!state) {
 			promises.push(
@@ -127,6 +123,6 @@ export class Controller extends AbstractController {
 			await Promise.all(promises);
 		}
 
-		return { ...transaction, state } as TransactionModel;
+		return { ...transaction, state } as EnrichedTransaction;
 	}
 }

--- a/packages/api-http/source/controllers/controller.ts
+++ b/packages/api-http/source/controllers/controller.ts
@@ -7,9 +7,9 @@ import {
 } from "@mainsail/api-database";
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { Providers } from "@mainsail/kernel";
+import { Providers, Utils } from "@mainsail/kernel";
 
-import { BlockModel, EnrichedTransaction } from "../resources/index.js";
+import { EnrichedBlock, EnrichedTransaction } from "../resources/index.js";
 
 @injectable()
 export class Controller extends AbstractController {
@@ -40,24 +40,24 @@ export class Controller extends AbstractController {
 	protected async enrichBlockResult(
 		resultPage: Search.ResultsPage<Models.Block>,
 		{ state, generators }: { state?: Models.State; generators: Record<string, Models.Wallet> },
-	): Promise<Search.ResultsPage<BlockModel>> {
+	): Promise<Search.ResultsPage<EnrichedBlock>> {
 		state = state ?? (await this.getState());
 
-		const enriched: Promise<BlockModel | null>[] = [];
+		const enriched: Promise<EnrichedBlock | null>[] = [];
 		for (const block of resultPage.results) {
 			enriched.push(this.enrichBlock(block, state, generators[block.generatorPublicKey]));
 		}
 
 		// @ts-ignore
 		resultPage.results = await Promise.all(enriched);
-		return resultPage as Search.ResultsPage<BlockModel>;
+		return resultPage as Search.ResultsPage<EnrichedBlock>;
 	}
 
 	protected async enrichBlock(
 		block: Models.Block | null,
 		state?: Models.State,
 		generator?: Models.Wallet,
-	): Promise<BlockModel | null> {
+	): Promise<EnrichedBlock | null> {
 		if (!block) {
 			return null;
 		}
@@ -87,7 +87,10 @@ export class Controller extends AbstractController {
 			await Promise.all(promises);
 		}
 
-		return { ...block, generator, state } as BlockModel;
+		Utils.assert.defined<Models.Wallet>(generator);
+		Utils.assert.defined<Models.Wallet>(state);
+
+		return { ...block, generator, state };
 	}
 
 	protected async enrichTransactionResult(

--- a/packages/api-http/source/controllers/controller.ts
+++ b/packages/api-http/source/controllers/controller.ts
@@ -95,15 +95,10 @@ export class Controller extends AbstractController {
 		context?: { state?: Models.State },
 	): Promise<Search.ResultsPage<EnrichedTransaction>> {
 		const state = context?.state ?? (await this.getState());
-
-		const enriched: Promise<EnrichedTransaction>[] = [];
-		for (const transaction of resultPage.results) {
-			enriched.push(this.enrichTransaction(transaction, state));
-		}
-
-		// @ts-ignore
-		resultPage.results = await Promise.all(enriched);
-		return resultPage as Search.ResultsPage<EnrichedTransaction>;
+		return {
+			...resultPage,
+			results: await Promise.all(resultPage.results.map((tx) => this.enrichTransaction(tx, state))),
+		};
 	}
 
 	protected async enrichTransaction(

--- a/packages/api-http/source/controllers/controller.ts
+++ b/packages/api-http/source/controllers/controller.ts
@@ -110,19 +110,6 @@ export class Controller extends AbstractController {
 		transaction: Models.Transaction | Models.MempoolTransaction,
 		state?: Models.State,
 	): Promise<EnrichedTransaction> {
-		const promises: Promise<any>[] = [];
-		if (!state) {
-			promises.push(
-				(async () => {
-					state = await this.getState();
-				})(),
-			);
-		}
-
-		if (promises.length > 0) {
-			await Promise.all(promises);
-		}
-
-		return { ...transaction, state } as EnrichedTransaction;
+		return { ...transaction, state: state ? state : await this.getState() };
 	}
 }

--- a/packages/api-http/source/controllers/transactions.ts
+++ b/packages/api-http/source/controllers/transactions.ts
@@ -1,3 +1,4 @@
+import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
 import {
 	Contracts as ApiDatabaseContracts,
@@ -131,6 +132,10 @@ export class TransactionsController extends Controller {
 		transaction: Models.Transaction | Models.MempoolTransaction | null,
 		request: Hapi.Request,
 	) {
+		if (!transaction) {
+			return Boom.notFound();
+		}
+
 		return this.respondWithResource(
 			await this.enrichTransaction(transaction),
 			TransactionResource,

--- a/packages/api-http/source/controllers/votes.ts
+++ b/packages/api-http/source/controllers/votes.ts
@@ -36,7 +36,11 @@ export class VotesController extends Controller {
 			options,
 		);
 
-		return this.toPagination(transactions, TransactionResource, request.query.transform);
+		return this.toPagination(
+			await this.enrichTransactionResult(transactions),
+			TransactionResource,
+			request.query.transform,
+		);
 	}
 
 	public async show(request: Hapi.Request) {
@@ -52,6 +56,10 @@ export class VotesController extends Controller {
 			return Boom.notFound("Vote not found");
 		}
 
-		return this.respondWithResource(transaction, TransactionResource, request.query.transform);
+		return this.respondWithResource(
+			await this.enrichTransaction(transaction),
+			TransactionResource,
+			request.query.transform,
+		);
 	}
 }

--- a/packages/api-http/source/controllers/wallets.ts
+++ b/packages/api-http/source/controllers/wallets.ts
@@ -120,7 +120,11 @@ export class WalletsController extends Controller {
 			options,
 		);
 
-		return this.toPagination(transactions, TransactionResource, request.query.transform);
+		return this.toPagination(
+			await this.enrichTransactionResult(transactions),
+			TransactionResource,
+			request.query.transform,
+		);
 	}
 
 	private async getWallet(walletId: string): Promise<Models.Wallet | null> {

--- a/packages/api-http/source/resources/block.ts
+++ b/packages/api-http/source/resources/block.ts
@@ -36,7 +36,7 @@ export class BlockResource implements Contracts.Api.Resource {
 			},
 			previous: resource.previousBlock,
 			signature: resource.signature,
-			timestamp: Math.trunc(+resource.timestamp / 1000),
+			timestamp: +resource.timestamp,
 			transactions: resource.numberOfTransactions,
 
 			version: resource.version,

--- a/packages/api-http/source/resources/block.ts
+++ b/packages/api-http/source/resources/block.ts
@@ -3,18 +3,18 @@ import { injectable } from "@mainsail/container";
 import { Contracts } from "@mainsail/contracts";
 import { BigNumber } from "@mainsail/utils";
 
-export interface BlockModel extends Models.Block {
+export interface EnrichedBlock extends Models.Block {
 	state: Models.State;
 	generator: Models.Wallet;
 }
 
 @injectable()
 export class BlockResource implements Contracts.Api.Resource {
-	public raw(resource: BlockModel): object {
+	public raw(resource: EnrichedBlock): object {
 		return { ...resource, generator: undefined, state: undefined };
 	}
 
-	public transform(resource: BlockModel): object {
+	public transform(resource: EnrichedBlock): object {
 		return {
 			confirmations: +resource.state.height ? Number(resource.state.height) - Number(resource.height) : 0,
 			forged: {

--- a/packages/api-http/source/resources/transaction.ts
+++ b/packages/api-http/source/resources/transaction.ts
@@ -2,36 +2,36 @@ import { Models } from "@mainsail/api-database";
 import { injectable } from "@mainsail/container";
 import { Contracts } from "@mainsail/contracts";
 
+export interface TransactionModel extends Models.Transaction {
+	state: Models.State;
+}
+
 @injectable()
 export class TransactionResource implements Contracts.Api.Resource {
-	public raw(resource: Models.Transaction): object {
-		return JSON.parse(JSON.stringify(resource));
+	public raw(resource: TransactionModel): object {
+		return { ...resource, state: undefined };
 	}
 
-	public async transform(resource: Models.Transaction): Promise<object> {
-		// TODO: address can be calculated from public key, no need to lookup the wallet
-		// const wallet = await this.walletRepository.findByPublicKey(transactionData.senderPublicKey);
-		// const sender: string = wallet.getAddress();
-		const recipient = resource.recipientId; // ?? sender;
-		// const confirmations: number = this.store.getLastHeight() - blockData.height + 1;
+	public async transform(resource: TransactionModel): Promise<object> {
+		const confirmations: number = +resource.state.height - +resource.blockHeight + 1;
 
 		return {
 			amount: resource.amount,
 			asset: resource.asset,
 			blockId: resource.blockId,
+			confirmations,
+
 			fee: resource.fee,
 			id: resource.id,
 			nonce: resource.nonce,
 
-			recipient,
+			recipient: resource.recipientId,
 			senderPublicKey: resource.senderPublicKey,
 
 			signature: resource.signature,
-			// TODO
-			// sender,
-			// timestamp: AppUtils.formatTimestamp(blockData.timestamp),
-			//confirmations,
-			//signatures: resource.signatures,
+			signatures: resource.signatures,
+
+			timestamp: +resource.timestamp,
 
 			type: resource.type,
 			typeGroup: resource.typeGroup,

--- a/packages/api-http/source/resources/transaction.ts
+++ b/packages/api-http/source/resources/transaction.ts
@@ -2,6 +2,7 @@ import { Models } from "@mainsail/api-database";
 import { injectable } from "@mainsail/container";
 import { Contracts } from "@mainsail/contracts";
 
+// https://stackoverflow.com/a/53742518
 type T_AND = Models.Transaction & Models.MempoolTransaction;
 type T_OR = Models.Transaction | Models.MempoolTransaction;
 type AnyTransaction = Partial<T_AND> & Pick<T_OR, keyof T_OR>;

--- a/packages/api-http/source/resources/transaction.ts
+++ b/packages/api-http/source/resources/transaction.ts
@@ -2,17 +2,17 @@ import { Models } from "@mainsail/api-database";
 import { injectable } from "@mainsail/container";
 import { Contracts } from "@mainsail/contracts";
 
-export interface TransactionModel extends Models.Transaction {
+export interface EnrichedTransaction extends Models.Transaction {
 	state: Models.State;
 }
 
 @injectable()
 export class TransactionResource implements Contracts.Api.Resource {
-	public raw(resource: TransactionModel): object {
+	public raw(resource: EnrichedTransaction): object {
 		return { ...resource, state: undefined };
 	}
 
-	public async transform(resource: TransactionModel): Promise<object> {
+	public async transform(resource: EnrichedTransaction): Promise<object> {
 		const confirmations: number = +resource.state.height - +resource.blockHeight + 1;
 
 		return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix the `TransactionResource` not returning `timestamp`, `signatures` and `confirmations`.  

Regarding the sender address , a client can just calculate it from `senderPublicKey` with an appropriate `AddressFactory` so we don't really need to have it on the API response.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
