### PR TITLE
fix(transaction-pool): invalid tx error reporting

### DIFF
--- a/packages/transaction-pool/source/processor.ts
+++ b/packages/transaction-pool/source/processor.ts
@@ -81,7 +81,7 @@ export class Processor implements Contracts.TransactionPool.Processor {
 
 	async #getTransactionFromBuffer(transactionData: Buffer): Promise<Contracts.Crypto.Transaction> {
 		try {
-			return this.transactionFactory.fromBytes(transactionData);
+			return await this.transactionFactory.fromBytes(transactionData);
 		} catch (error) {
 			throw new Exceptions.InvalidTransactionDataError(error.message);
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Ensure transaction deserialization is awaited so any thrown error is wrapped correctly.

```
curl -X POST "http://localhost:4007/api/transaction-pool" -H "Content-Type: application/json" -d '{"transactions": ["3452344"]}'
```

Before:
```json
{
    "statusCode": 500,
    "error": "Internal Server Error",
    "message": "An internal server error occurred"
}
```

After:
```json
{
    "data": {
        "accept": [],
        "broadcast": [],
        "excess": [],
        "invalid": [
            0
        ]
    },
    "errors": {
        "0": {
            "message": "Invalid transaction data: Failed to deserialize transaction, encountered invalid bytes: Attempt to access memory outside buffer bounds",
            "type": "ERR_BAD_DATA"
        }
    }
}
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
