### PR TITLE
refactor: remove `__dirname` usage

### DIFF
--- a/packages/api-database/source/service-provider.ts
+++ b/packages/api-database/source/service-provider.ts
@@ -54,15 +54,6 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		const options = this.config().get<PostgresConnectionOptions>("database");
 		Utils.assert.defined<PostgresConnectionOptions>(options);
 
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
 		try {
 			const dataSource = new DataSource({
 				...options,
@@ -80,7 +71,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 					ValidatorRound,
 					Wallet,
 				],
-				migrations: [dirname + "/migrations/*.js"],
+				migrations: [new URL(".", import.meta.url).pathname + "/migrations/*.js"],
 				migrationsRun: false,
 				namingStrategy: new SnakeNamingStrategy(),
 				synchronize: false,

--- a/packages/api/source/cli.ts
+++ b/packages/api/source/cli.ts
@@ -21,8 +21,7 @@ export class CommandLineInterface {
 
 	public async execute(dirname?: string): Promise<void> {
 		if (!dirname) {
-			const __dirname = new URL(".", import.meta.url).pathname;
-			dirname = __dirname;
+			dirname = new URL(".", import.meta.url).pathname;
 		}
 
 		// Set NODE_PATHS. Only required for plugins that uses @mainsail as peer dependencies.

--- a/packages/api/source/commands/api-run.ts
+++ b/packages/api/source/commands/api-run.ts
@@ -19,16 +19,7 @@ export class Command extends Commands.Command {
 	}
 
 	public async execute(): Promise<void> {
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
-		const { name } = readJSONSync(path.resolve(dirname, "../../package.json"));
+		const { name } = readJSONSync(path.resolve(new URL(".", import.meta.url).pathname, "../../package.json"));
 		AppUtils.assert.defined<string>(name);
 
 		const flags: Contracts.AnyObject = {

--- a/packages/api/source/commands/config-publish.ts
+++ b/packages/api/source/commands/config-publish.ts
@@ -29,17 +29,11 @@ export class Command extends Commands.Command {
 	async #performPublishment(flags: Contracts.AnyObject): Promise<void> {
 		this.app.rebind(Identifiers.ApplicationPaths).toConstantValue(this.environment.getPaths());
 
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
 		const configDestination = this.app.getCorePath("config");
-		const configSource = resolve(dirname, `../../bin/config/${this.app.get<string>(Identifiers.Application.Name)}`);
+		const configSource = resolve(
+			new URL(".", import.meta.url).pathname,
+			`../../bin/config/${this.app.get<string>(Identifiers.Application.Name)}`,
+		);
 
 		await this.components.taskList([
 			{

--- a/packages/cli/source/services/source-providers/npm.test.ts
+++ b/packages/cli/source/services/source-providers/npm.test.ts
@@ -118,7 +118,12 @@ describe<{
 
 		nock.fake(/.*/)
 			.get("/@arkecosystem/utils/-/utils-0.9.1.tgz")
-			.reply(200, fs.readFileSync(resolve(__dirname, "../../../test/files", "utils-0.9.1.tgz")));
+			.reply(
+				200,
+				fs.readFileSync(
+					resolve(new URL(".", import.meta.url).pathname, "../../../test/files", "utils-0.9.1.tgz"),
+				),
+			);
 
 		// Arrange
 		const removeSync = spy(fs, "removeSync");

--- a/packages/configuration-generator/source/generators/app.ts
+++ b/packages/configuration-generator/source/generators/app.ts
@@ -13,16 +13,9 @@ export class AppGenerator {
 	generateDefault(packageName = "core"): Contracts.Types.JsonObject {
 		packageName = packageName.replace("@mainsail/", "");
 
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
-		return readJSONSync(resolve(dirname, `../../../${packageName}/bin/config/testnet/core/app.json`));
+		return readJSONSync(
+			resolve(new URL(".", import.meta.url).pathname, `../../../${packageName}/bin/config/testnet/core/app.json`),
+		);
 	}
 
 	generate(options: Contracts.NetworkGenerator.InternalOptions): Contracts.Types.JsonObject {

--- a/packages/core/source/cli.ts
+++ b/packages/core/source/cli.ts
@@ -22,8 +22,7 @@ export class CommandLineInterface {
 
 	public async execute(dirname?: string): Promise<void> {
 		if (!dirname) {
-			const __dirname = new URL(".", import.meta.url).pathname;
-			dirname = __dirname;
+			dirname = new URL(".", import.meta.url).pathname;
 		}
 
 		// Set NODE_PATHS. Only required for plugins that uses @mainsail as peer dependencies.

--- a/packages/core/source/commands/config-publish.ts
+++ b/packages/core/source/commands/config-publish.ts
@@ -54,18 +54,9 @@ export class Command extends Commands.Command {
 	async #performPublishment(flags: Contracts.AnyObject): Promise<void> {
 		this.app.rebind(Identifiers.ApplicationPaths).toConstantValue(this.environment.getPaths());
 
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
 		const configDestination = this.app.getCorePath("config");
 		const configSource = resolve(
-			dirname,
+			new URL(".", import.meta.url).pathname,
 			`../../bin/config/${flags.network}/${this.app.get<string>(Identifiers.Application.Name)}`,
 		);
 

--- a/packages/core/source/commands/core-run.ts
+++ b/packages/core/source/commands/core-run.ts
@@ -25,16 +25,7 @@ export class Command extends Commands.Command {
 	}
 
 	public async execute(): Promise<void> {
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
-
-		const { name } = readJSONSync(path.resolve(dirname, "../../package.json"));
+		const { name } = readJSONSync(path.resolve(new URL(".", import.meta.url).pathname, "../../package.json"));
 		AppUtils.assert.defined<string>(name);
 
 		const flags: Contracts.AnyObject = {

--- a/packages/crypto-worker/source/service-provider.ts
+++ b/packages/crypto-worker/source/service-provider.ts
@@ -14,8 +14,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		this.app.bind(Identifiers.CryptoWorker.WorkerPool).to(WorkerPool).inSingletonScope();
 
 		this.app.bind(Identifiers.CryptoWorker.WorkerSubprocess.Factory).toFactory(() => () => {
-			const __dirname = new URL(".", import.meta.url).pathname;
-			const subprocess = fork(`${__dirname}/worker-script.js`, {});
+			const subprocess = fork(`${new URL(".", import.meta.url).pathname}/worker-script.js`, {});
 			return new Ipc.Subprocess(subprocess);
 		});
 

--- a/packages/kernel/source/bootstrap/load-service-providers.test.ts
+++ b/packages/kernel/source/bootstrap/load-service-providers.test.ts
@@ -33,7 +33,7 @@ describeSkip<{
 	});
 
 	it("should bootstrap with defaults", async (context) => {
-		stub(context.app, "dataPath").returnValue(resolve(__dirname, "../../test/stubs"));
+		stub(context.app, "dataPath").returnValue(resolve(new URL(".", import.meta.url).pathname, "../../test/stubs"));
 
 		context.configRepository.merge({
 			app: { plugins: [{ package: "stub-plugin-with-defaults" }] },
@@ -45,7 +45,7 @@ describeSkip<{
 	});
 
 	it("should bootstrap without defaults", async (context) => {
-		stub(context.app, "dataPath").returnValue(resolve(__dirname, "../../test/stubs"));
+		stub(context.app, "dataPath").returnValue(resolve(new URL(".", import.meta.url).pathname, "../../test/stubs"));
 
 		context.configRepository.merge({
 			app: { plugins: [{ package: "stub-plugin" }] },
@@ -57,7 +57,7 @@ describeSkip<{
 	});
 
 	it("should throw if package doesn't exist", async (context) => {
-		stub(context.app, "dataPath").returnValue(resolve(__dirname, "../../test/stubs"));
+		stub(context.app, "dataPath").returnValue(resolve(new URL(".", import.meta.url).pathname, "../../test/stubs"));
 
 		context.configRepository.merge({
 			app: { plugins: [{ package: "non-existing-plugin" }] },

--- a/packages/kernel/source/bootstrap/load-service-providers.ts
+++ b/packages/kernel/source/bootstrap/load-service-providers.ts
@@ -73,8 +73,7 @@ export class LoadServiceProviders implements Bootstrapper {
 					// ~/git/mainsail/packages/kernel/distribution/bootstrap
 					// ~/git/mainsail/packages/
 					// ~/git/mainsail/packages/validation/distribution/index.js
-					const __dirname = new URL(".", import.meta.url).pathname;
-					const fallback = path.resolve(__dirname, "..", "..", "..", localPath);
+					const fallback = path.resolve(new URL(".", import.meta.url).pathname, "..", "..", "..", localPath);
 					({ ServiceProvider } = await import(fallback));
 
 					// ~/git/mainsail/packages/validation/distribution/index.js

--- a/packages/kernel/source/bootstrap/register-base-bindings.ts
+++ b/packages/kernel/source/bootstrap/register-base-bindings.ts
@@ -16,17 +16,9 @@ export class RegisterBaseBindings implements Bootstrapper {
 
 	public async bootstrap(): Promise<void> {
 		const flags: Record<string, string> | undefined = this.app.config("app.flags");
-		const dirname = (() => {
-			try {
-				return new URL(".", import.meta.url).pathname;
-			} catch {
-				// eslint-disable-next-line unicorn/prefer-module
-				return __dirname;
-			}
-		})();
 
 		const { version } = this.fileSystem.readJSONSync<Contracts.Types.PackageJson>(
-			path.resolve(dirname, "../../package.json"),
+			path.resolve(new URL(".", import.meta.url).pathname, "../../package.json"),
 		);
 
 		assert.defined(version);

--- a/packages/p2p/source/hapi-nes/plugin.ts
+++ b/packages/p2p/source/hapi-nes/plugin.ts
@@ -49,21 +49,7 @@ internals.schema = Joi.object({
 });
 
 const plugin = {
-	pkg: readJSONSync(
-		resolve(
-			(() => {
-				try {
-					return new URL(".", import.meta.url).pathname;
-				} catch {
-					// eslint-disable-next-line unicorn/prefer-module
-					return __dirname;
-				}
-			})(),
-			"..",
-			"..",
-			"package.json",
-		),
-	),
+	pkg: readJSONSync(resolve(new URL(".", import.meta.url).pathname, "..", "..", "package.json")),
 	register: function (server, options) {
 		const settings: any = applyToDefaults(internals.defaults, options);
 

--- a/packages/test-framework/source/factories/factories/block.ts
+++ b/packages/test-framework/source/factories/factories/block.ts
@@ -2,7 +2,6 @@ import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 import { BigNumber } from "@mainsail/utils";
 import dayjs from "dayjs";
-import { join } from "path";
 
 import secrets from "../../internal/passphrases.json";
 import { Signer } from "../../internal/signer.js";
@@ -11,11 +10,9 @@ import { generateApp } from "./generate-app.js";
 
 export const registerBlockFactory = async (
 	factory: FactoryBuilder,
-	config?: Contracts.Crypto.NetworkConfigPartial,
+	config: Contracts.Crypto.NetworkConfigPartial,
 ): Promise<void> => {
-	const app = await generateApp(
-		config ?? require(join(__dirname, "../../../../core/bin/config/testnet/core/crypto.json")),
-	);
+	const app = await generateApp(config);
 
 	factory.set("Block", async ({ options }): Promise<Contracts.Crypto.Commit> => {
 		const previousBlock: Contracts.Crypto.BlockData = options.getPreviousBlock

--- a/packages/test-framework/source/factories/factories/identity.ts
+++ b/packages/test-framework/source/factories/factories/identity.ts
@@ -1,17 +1,14 @@
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { generateMnemonic } from "bip39";
-import { join } from "path";
 
 import { FactoryBuilder } from "../factory-builder.js";
 import { generateApp } from "./generate-app.js";
 
 export const registerIdentityFactory = async (
 	factory: FactoryBuilder,
-	config?: Contracts.Crypto.NetworkConfigPartial,
+	config: Contracts.Crypto.NetworkConfigPartial,
 ): Promise<void> => {
-	const app = await generateApp(
-		config ?? require(join(__dirname, "../../../../core/bin/config/testnet/core/crypto.json")),
-	);
+	const app = await generateApp(config);
 
 	factory.set("Identity", async ({ options }) => {
 		const passphrase: string = options.passphrase || generateMnemonic();

--- a/packages/test-framework/source/factories/factories/transaction.ts
+++ b/packages/test-framework/source/factories/factories/transaction.ts
@@ -7,7 +7,6 @@ import { ValidatorRegistrationBuilder } from "@mainsail/crypto-transaction-valid
 import { ValidatorResignationBuilder } from "@mainsail/crypto-transaction-validator-resignation";
 import { VoteBuilder } from "@mainsail/crypto-transaction-vote";
 import { BigNumber } from "@mainsail/utils";
-import { join } from "path";
 
 import secrets from "../../internal/passphrases.json";
 import { FactoryBuilder } from "../factory-builder.js";
@@ -244,11 +243,9 @@ export const registerMultiPaymentFactory = (factory: FactoryBuilder, app: Contra
 
 export const registerTransactionFactory = async (
 	factory: FactoryBuilder,
-	config?: Contracts.Crypto.NetworkConfigPartial,
+	config: Contracts.Crypto.NetworkConfigPartial,
 ): Promise<void> => {
-	const app = await generateApp(
-		config ?? require(join(__dirname, "../../../../core/bin/config/testnet/core/crypto.json")),
-	);
+	const app = await generateApp(config);
 
 	registerTransferFactory(factory, app);
 	registerValidatorRegistrationFactory(factory, app);

--- a/packages/test-framework/source/factories/helpers.ts
+++ b/packages/test-framework/source/factories/helpers.ts
@@ -5,7 +5,7 @@ import { registerBlockFactory, registerIdentityFactory, registerTransactionFacto
 import { Factory } from "./factory.js";
 import { FactoryBuilder } from "./factory-builder.js";
 
-const createFactory = memoizee(async (config?: Contracts.Crypto.NetworkConfigPartial): Promise<FactoryBuilder> => {
+const createFactory = memoizee(async (config: Contracts.Crypto.NetworkConfigPartial): Promise<FactoryBuilder> => {
 	const factory: FactoryBuilder = new FactoryBuilder();
 
 	await registerBlockFactory(factory, config);


### PR DESCRIPTION
## Summary

Remove usage of __dirname, because it is part of CJS. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
