### PR TITLE
refactor(database): return commits instead blocks

### DIFF
--- a/packages/api-development/source/controllers/blocks.ts
+++ b/packages/api-development/source/controllers/blocks.ts
@@ -99,6 +99,6 @@ export class BlocksController extends Controller {
 
 	// TODO: Support height only
 	private async getBlock(idOrHeight: string): Promise<Contracts.Crypto.Block | undefined> {
-		return this.database.getBlock(Number.parseInt(idOrHeight));
+		return (await this.database.getCommit(Number.parseInt(idOrHeight)))?.block;
 	}
 }

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -106,13 +106,13 @@ export class Bootstrapper {
 		this.#store.setGenesisCommit(genesisBlock);
 	}
 	async #checkStoredGenesisCommit(): Promise<void> {
-		const genesisBlock = await this.databaseService.getBlock(0);
+		const genesisCommit = await this.databaseService.getCommit(0);
 
-		if (!genesisBlock) {
+		if (!genesisCommit) {
 			return;
 		}
 
-		if (this.#store.getGenesisCommit().block.data.id !== genesisBlock.data.id) {
+		if (this.#store.getGenesisCommit().block.data.id !== genesisCommit.block.data.id) {
 			throw new Error("Block from crypto.json doesn't match stored genesis block");
 		}
 	}
@@ -145,10 +145,10 @@ export class Bootstrapper {
 		if (this.#store.getLastHeight() === 0) {
 			await this.#processGenesisBlock();
 		} else {
-			const block = await this.databaseService.getBlock(this.#store.getLastHeight());
-			Utils.assert.defined<Contracts.Crypto.Block>(block);
-			this.#store.setLastBlock(block);
-			this.configuration.setHeight(block.data.height + 1);
+			const commit = await this.databaseService.getCommit(this.#store.getLastHeight());
+			Utils.assert.defined(commit);
+			this.#store.setLastBlock(commit.block);
+			this.configuration.setHeight(commit.block.data.height + 1);
 
 			this.validatorSet.restore(this.#store);
 		}

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -118,7 +118,7 @@ export class Bootstrapper {
 	}
 
 	async #storeGenesisCommit(): Promise<void> {
-		if (!(await this.databaseService.getLastCommit())) {
+		if (this.databaseService.isEmpty()) {
 			const genesisBlock = this.#store.getGenesisCommit();
 			this.databaseService.addCommit(genesisBlock);
 			await this.databaseService.persist();
@@ -132,7 +132,7 @@ export class Bootstrapper {
 
 	async #restoreStateSnapshot(): Promise<void> {
 		const lastCommit = await this.databaseService.getLastCommit();
-		let restoreHeight = lastCommit?.block.data.height ?? 0;
+		let restoreHeight = lastCommit.block.data.height;
 		if (this.apiSync) {
 			restoreHeight = Math.min(await this.apiSync.getLastSyncedBlockHeight(), restoreHeight);
 		}
@@ -156,7 +156,6 @@ export class Bootstrapper {
 
 	async #processBlocks(): Promise<void> {
 		const lastCommit = await this.databaseService.getLastCommit();
-		Utils.assert.defined<Contracts.Crypto.Commit>(lastCommit);
 
 		for await (const commit of this.databaseService.readCommits(
 			this.#store.getLastHeight() + 1,

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -2,17 +2,14 @@ import { Block } from "./crypto/block.js";
 import { Commit } from "./crypto/commit.js";
 
 export interface DatabaseService {
+	isEmpty(): boolean;
+
 	getCommit(height: number): Promise<Commit | undefined>;
-
 	findCommitBuffers(start: number, end: number): Promise<Buffer[]>;
-
 	readCommits(start: number, end: number): AsyncGenerator<Commit>;
-
 	findBlocks(start: number, end: number): Promise<Block[]>;
 
-	getLastCommit(): Promise<Commit | undefined>;
-
+	getLastCommit(): Promise<Commit>;
 	addCommit(block: Commit): void;
-
 	persist(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -2,7 +2,7 @@ import { Block } from "./crypto/block.js";
 import { Commit } from "./crypto/commit.js";
 
 export interface DatabaseService {
-	getBlock(height: number): Promise<Block | undefined>;
+	getCommit(height: number): Promise<Commit | undefined>;
 
 	findCommitBuffers(start: number, end: number): Promise<Buffer[]>;
 

--- a/packages/contracts/source/contracts/database.ts
+++ b/packages/contracts/source/contracts/database.ts
@@ -10,7 +10,7 @@ export interface DatabaseService {
 
 	findBlocks(start: number, end: number): Promise<Block[]>;
 
-	getLastBlock(): Promise<Block | undefined>;
+	getLastCommit(): Promise<Commit | undefined>;
 
 	addCommit(block: Commit): void;
 

--- a/packages/database/source/database-service.test.ts
+++ b/packages/database/source/database-service.test.ts
@@ -97,59 +97,53 @@ describe<{
 
 	it("#addCommit - should add a commit, but not store it", async ({ databaseService, sandbox }) => {
 		const commit = await generateCommit();
-		assert.undefined(await databaseService.getBlock(commit.block.data.height));
+		assert.undefined(await databaseService.getCommit(commit.block.data.height));
 
 		databaseService.addCommit(commit);
 
-		assert.defined(await databaseService.getBlock(commit.block.data.height));
+		assert.defined(await databaseService.getCommit(commit.block.data.height));
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.Storage.Block).getKeysCount(), 0);
 	});
 
 	it("#persist - should store a commit", async ({ databaseService, sandbox }) => {
 		const commit = await generateCommit();
-		assert.undefined(await databaseService.getBlock(commit.block.data.height));
+		assert.undefined(await databaseService.getCommit(commit.block.data.height));
 
 		databaseService.addCommit(commit);
 		await databaseService.persist();
 
-		assert.defined(await databaseService.getBlock(commit.block.data.height));
+		assert.defined(await databaseService.getCommit(commit.block.data.height));
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.Storage.Block).getKeysCount(), 1);
 	});
 
 	it("#persist - should store a commit only once", async ({ databaseService, sandbox }) => {
 		const commit = await generateCommit();
-		assert.undefined(await databaseService.getBlock(commit.block.data.height));
+		assert.undefined(await databaseService.getCommit(commit.block.data.height));
 
 		databaseService.addCommit(commit);
 		databaseService.addCommit(commit);
 		await databaseService.persist();
 		await databaseService.persist();
 
-		assert.defined(await databaseService.getBlock(commit.block.data.height));
+		assert.defined(await databaseService.getCommit(commit.block.data.height));
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.Storage.Block).getKeysCount(), 1);
 	});
 
-	it("#getBlock - should return undefined if block doesn't exists", async ({ databaseService }) => {
-		assert.undefined(await databaseService.getBlock(-1));
+	it("#getCommit - should return undefined if commit doesn't exists", async ({ databaseService }) => {
+		assert.undefined(await databaseService.getCommit(-1));
 	});
 
-	it("#getBlock - should return block by height", async ({ databaseService }) => {
+	it("#getCommit - should return commit by height", async ({ databaseService }) => {
 		const blockFactory = await Factories.factory("Block", cryptoJson);
 		const block = await blockFactory.withOptions({ transactionsCount: 2 }).make<Contracts.Crypto.Commit>();
 
 		databaseService.addCommit(block);
 
-		assertBlockEqual(
-			(await databaseService.getBlock(block.block.data.height)) as unknown as Contracts.Crypto.Block,
-			block.block,
-		);
+		assertBlockEqual((await databaseService.getCommit(block.block.data.height))?.block!, block.block);
 
 		await databaseService.persist();
 
-		assertBlockEqual(
-			(await databaseService.getBlock(block.block.data.height)) as unknown as Contracts.Crypto.Block,
-			block.block,
-		);
+		assertBlockEqual((await databaseService.getCommit(block.block.data.height))?.block!, block.block);
 	});
 
 	it("#findCommitBuffers - should return empty array if blocks are not found", async ({ databaseService }) => {

--- a/packages/database/source/database-service.test.ts
+++ b/packages/database/source/database-service.test.ts
@@ -211,8 +211,8 @@ describe<{
 		);
 	});
 
-	it("#getLastBlock - should return undefined if block is not found", async ({ databaseService }) => {
-		assert.undefined(await databaseService.getLastBlock());
+	it("#getLastCommit - should return undefined if block is not found", async ({ databaseService }) => {
+		assert.undefined(await databaseService.getLastCommit());
 	});
 
 	it("#getLastBlock - should return last block", async ({ databaseService }) => {
@@ -221,14 +221,14 @@ describe<{
 			databaseService.addCommit(commit);
 		}
 
-		let lastBlock = (await databaseService.getLastBlock()) as Contracts.Crypto.Block;
+		let lastCommit = await databaseService.getLastCommit();
 
-		assertBlockEqual(lastBlock, commits[3].block);
+		assertBlockEqual(lastCommit?.block, commits[3].block);
 
 		await databaseService.persist();
-		lastBlock = (await databaseService.getLastBlock()) as Contracts.Crypto.Block;
+		lastCommit = await databaseService.getLastCommit();
 
-		assertBlockEqual(lastBlock, commits[3].block);
+		assertBlockEqual(lastCommit?.block, commits[3].block);
 	});
 
 	const assertBlocksEqual = (blocksA: Contracts.Crypto.Block[], blocksB: Contracts.Crypto.Block[]) => {

--- a/packages/database/source/database-service.test.ts
+++ b/packages/database/source/database-service.test.ts
@@ -105,6 +105,23 @@ describe<{
 		assert.equal(sandbox.app.get<lmdb.Database>(Identifiers.Database.Storage.Block).getKeysCount(), 0);
 	});
 
+	it("#isEmpty - should return true if no commits are stored", async ({ databaseService }) => {
+		assert.true(databaseService.isEmpty());
+	});
+
+	it("#isEmpty - should return false if commit is added", async ({ databaseService }) => {
+		databaseService.addCommit(await generateCommit());
+
+		assert.false(databaseService.isEmpty());
+	});
+
+	it("#isEmpty - should return false if commit is persisted", async ({ databaseService }) => {
+		databaseService.addCommit(await generateCommit());
+		await databaseService.persist();
+
+		assert.false(databaseService.isEmpty());
+	});
+
 	it("#persist - should store a commit", async ({ databaseService, sandbox }) => {
 		const commit = await generateCommit();
 		assert.undefined(await databaseService.getCommit(commit.block.data.height));
@@ -211,8 +228,8 @@ describe<{
 		);
 	});
 
-	it("#getLastCommit - should return undefined if block is not found", async ({ databaseService }) => {
-		assert.undefined(await databaseService.getLastCommit());
+	it("#getLastCommit - should return throw error if block is not found", async ({ databaseService }) => {
+		await assert.rejects(() => databaseService.getLastCommit(), "Database is empty");
 	});
 
 	it("#getLastBlock - should return last block", async ({ databaseService }) => {

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -12,11 +12,11 @@ export class DatabaseService implements Contracts.Database.DatabaseService {
 
 	#cache = new Map<number, Buffer>();
 
-	public async getBlock(height: number): Promise<Contracts.Crypto.Block | undefined> {
+	public async getCommit(height: number): Promise<Contracts.Crypto.Commit | undefined> {
 		const bytes = this.#get(height);
 
 		if (bytes) {
-			return (await this.commitFactory.fromBytes(bytes)).block;
+			return await this.commitFactory.fromBytes(bytes);
 		}
 
 		return undefined;

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -54,17 +54,15 @@ export class DatabaseService implements Contracts.Database.DatabaseService {
 		}
 	}
 
-	public async getLastBlock(): Promise<Contracts.Crypto.Block | undefined> {
+	public async getLastCommit(): Promise<Contracts.Crypto.Commit | undefined> {
 		if (this.#cache.size > 0) {
-			return (await this.commitFactory.fromBytes([...this.#cache.values()].pop()!)).block;
+			return await this.commitFactory.fromBytes([...this.#cache.values()].pop()!);
 		}
 
 		try {
-			const lastCommit = await this.commitFactory.fromBytes(
+			return await this.commitFactory.fromBytes(
 				this.blockStorage.getRange({ limit: 1, reverse: true }).asArray[0].value,
 			);
-
-			return lastCommit.block;
 		} catch {
 			return undefined;
 		}

--- a/packages/p2p/source/peer-verifier.ts
+++ b/packages/p2p/source/peer-verifier.ts
@@ -88,7 +88,7 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
 		const receivedCommit = await this.commitFactory.fromBytes(blocks[0]);
 
 		const blockToCompare =
-			block.data.height === heightToRequest ? block : await this.database.getBlock(heightToRequest);
+			block.data.height === heightToRequest ? block : (await this.database.getCommit(heightToRequest))?.block;
 
 		Utils.assert.defined<Contracts.Crypto.Block>(blockToCompare);
 


### PR DESCRIPTION

## Summary

- Return commit instead blocks.
- `getLastCommit` throws if database is empty
- add `isEmpty` method

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
