### PR TITLE
feat(transaction-pool): support `in-memory` database

### DIFF
--- a/packages/transaction-pool/package.json
+++ b/packages/transaction-pool/package.json
@@ -34,8 +34,8 @@
 		"@mainsail/utils": "workspace:*",
 		"@types/better-sqlite3": "7.6.9",
 		"@types/fs-extra": "11.0.4",
-		"uvu": "^0.5.6",
-		"tmp": "0.2.3"
+		"tmp": "0.2.3",
+		"uvu": "^0.5.6"
 	},
 	"engines": {
 		"node": ">=20.x"

--- a/packages/transaction-pool/package.json
+++ b/packages/transaction-pool/package.json
@@ -34,7 +34,8 @@
 		"@mainsail/utils": "workspace:*",
 		"@types/better-sqlite3": "7.6.9",
 		"@types/fs-extra": "11.0.4",
-		"uvu": "^0.5.6"
+		"uvu": "^0.5.6",
+		"tmp": "0.2.3"
 	},
 	"engines": {
 		"node": ">=20.x"

--- a/packages/transaction-pool/source/storage.ts
+++ b/packages/transaction-pool/source/storage.ts
@@ -20,11 +20,15 @@ export class Storage implements Contracts.TransactionPool.Storage {
 
 	public boot(): void {
 		const filename = this.configuration.getRequired<string>("storage");
-		ensureFileSync(filename);
+
+		if (filename === ":memory:") {
+			this.#database = new BetterSqlite3(":memory:");
+		} else {
+			ensureFileSync(filename);
+			this.#database = new BetterSqlite3(filename);
+		}
 
 		const table = "pool_20201204";
-
-		this.#database = new BetterSqlite3(filename);
 		this.#database.exec(`
             PRAGMA journal_mode = WAL;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3050,6 +3050,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
+      tmp:
+        specifier: 0.2.3
+        version: 0.2.3
       uvu:
         specifier: ^0.5.6
         version: 0.5.6


### PR DESCRIPTION
## Summary

Support in-memory database using `:memory:` as filepath. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
