### PR TITLE
fix(api-http): implement missing `/transaction/fees` route

### DIFF
--- a/packages/api-http/integration/routes/transactions.test.ts
+++ b/packages/api-http/integration/routes/transactions.test.ts
@@ -2,10 +2,12 @@ import { describe, Sandbox } from "../../../test-framework/source";
 import { prepareSandbox, ApiContext } from "../../test/helpers/prepare-sandbox";
 import { request } from "../../test/helpers/request";
 
+import cryptoJson from "../../../core/bin/config/testnet/core/crypto.json";
 import transactions from "../../test/fixtures/transactions.json";
 import unconfirmedTransactions from "../../test/fixtures/unconfirmed_transactions.json";
 import transactionTypes from "../../test/fixtures/transactions_types.json";
 import transactionSchemas from "../../test/fixtures/transactions_schemas.json";
+import transactionFees from "../../test/fixtures/transactions_fees.json";
 
 describe<{
 	sandbox: Sandbox;
@@ -122,5 +124,19 @@ describe<{
 		const { statusCode, data } = await request(`/transactions/schemas`, options);
 		assert.equal(statusCode, 200);
 		assert.equal(data.data, transactionSchemas);
+	});
+
+	it("/transactions/fees", async () => {
+		await apiContext.transactionTypeRepository.save(transactionTypes);
+		await apiContext.configurationRepository.save({
+			activeMilestones: cryptoJson.milestones[0],
+			cryptoConfiguration: cryptoJson,
+			id: 1,
+			version: "0.0.1",
+		});
+
+		const { statusCode, data } = await request(`/transactions/fees`, {});
+		assert.equal(statusCode, 200);
+		assert.equal(data.data, transactionFees);
 	});
 });

--- a/packages/api-http/source/controllers/controller.ts
+++ b/packages/api-http/source/controllers/controller.ts
@@ -20,6 +20,9 @@ export class Controller extends AbstractController {
 	@inject(ApiDatabaseIdentifiers.StateRepositoryFactory)
 	protected readonly stateRepositoryFactory!: ApiDatabaseContracts.StateRepositoryFactory;
 
+	@inject(ApiDatabaseIdentifiers.ConfigurationRepositoryFactory)
+	private readonly configurationRepositoryFactory!: ApiDatabaseContracts.ConfigurationRepositoryFactory;
+
 	@inject(ApiDatabaseIdentifiers.WalletRepositoryFactory)
 	protected readonly walletRepositoryFactory!: ApiDatabaseContracts.WalletRepositoryFactory;
 
@@ -35,6 +38,13 @@ export class Controller extends AbstractController {
 		const stateRepository = this.stateRepositoryFactory();
 		const state = await stateRepository.createQueryBuilder().getOne();
 		return state ?? ({ height: "0", supply: "0" } as Models.State);
+	}
+
+	protected async getConfiguration(): Promise<Models.Configuration> {
+		const configurationRepository = this.configurationRepositoryFactory();
+		const configuration = await configurationRepository.createQueryBuilder().getOne();
+
+		return configuration ?? ({} as Models.Configuration);
 	}
 
 	protected async enrichBlockResult(

--- a/packages/api-http/source/controllers/node.ts
+++ b/packages/api-http/source/controllers/node.ts
@@ -12,9 +12,6 @@ import { Controller } from "./controller.js";
 
 @injectable()
 export class NodeController extends Controller {
-	@inject(ApiDatabaseIdentifiers.ConfigurationRepositoryFactory)
-	private readonly configurationRepositoryFactory!: ApiDatabaseContracts.ConfigurationRepositoryFactory;
-
 	@inject(ApiDatabaseIdentifiers.PluginRepositoryFactory)
 	private readonly pluginRepositoryFactory!: ApiDatabaseContracts.PluginRepositoryFactory;
 
@@ -155,13 +152,6 @@ export class NodeController extends Controller {
 		}
 
 		return result;
-	}
-
-	private async getConfiguration(): Promise<Models.Configuration> {
-		const configurationRepository = this.configurationRepositoryFactory();
-		const configuration = await configurationRepository.createQueryBuilder().getOne();
-
-		return configuration ?? ({} as Models.Configuration);
 	}
 
 	private async getPlugins(): Promise<Record<string, Models.Plugin>> {

--- a/packages/api-http/source/routes/transactions.ts
+++ b/packages/api-http/source/routes/transactions.ts
@@ -99,13 +99,6 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 	server.route({
 		handler: (request: Hapi.Request) => controller.fees(request),
 		method: "GET",
-		options: {
-			validate: {
-				query: Joi.object({
-					days: Joi.number().integer().min(1).max(30),
-				}),
-			},
-		},
 		path: "/transactions/fees",
 	});
 };

--- a/packages/api-http/source/routes/transactions.ts
+++ b/packages/api-http/source/routes/transactions.ts
@@ -95,4 +95,17 @@ export const register = (server: Contracts.Api.ApiServer): void => {
 		method: "GET",
 		path: "/transactions/schemas",
 	});
+
+	server.route({
+		handler: (request: Hapi.Request) => controller.fees(request),
+		method: "GET",
+		options: {
+			validate: {
+				query: Joi.object({
+					days: Joi.number().integer().min(1).max(30),
+				}),
+			},
+		},
+		path: "/transactions/fees",
+	});
 };

--- a/packages/api-http/test/fixtures/transactions_fees.json
+++ b/packages/api-http/test/fixtures/transactions_fees.json
@@ -1,0 +1,12 @@
+{
+    "1": {
+        "transfer": "10000000",
+        "validatorRegistration": "2500000000",
+        "vote": "100000000",
+        "multiSignature": "500000000",
+        "multiPayment": "10000000",
+        "validatorResignation": "2500000000",
+        "usernameRegistration": "2500000000",
+        "usernameResignation": "2500000000"
+    }
+}

--- a/packages/api-http/test/fixtures/transactions_fees.json
+++ b/packages/api-http/test/fixtures/transactions_fees.json
@@ -1,12 +1,12 @@
 {
-    "1": {
-        "transfer": "10000000",
-        "validatorRegistration": "2500000000",
-        "vote": "100000000",
-        "multiSignature": "500000000",
-        "multiPayment": "10000000",
-        "validatorResignation": "2500000000",
-        "usernameRegistration": "2500000000",
-        "usernameResignation": "2500000000"
-    }
+	"1": {
+		"transfer": "10000000",
+		"validatorRegistration": "2500000000",
+		"vote": "100000000",
+		"multiSignature": "500000000",
+		"multiPayment": "10000000",
+		"validatorResignation": "2500000000",
+		"usernameRegistration": "2500000000",
+		"usernameResignation": "2500000000"
+	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Works same as https://api.ark.io/api/transactions/fees

```shell
curl localhost:4003/api/transactions/fees | jq
{
  "data": {
     "1": {
        "transfer": "10000000",
        "validatorRegistration": "2500000000",
        "vote": "100000000",
        "multiSignature": "500000000",
        "multiPayment": "10000000",
        "validatorResignation": "2500000000",
        "usernameRegistration": "2500000000",
        "usernameResignation": "2500000000"
     }
   }
}
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
