### PR TITLE
fix(api-sync): process transactions in chunks to support very large blocks

### DIFF
--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -6,7 +6,7 @@ import {
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers, Types, Utils } from "@mainsail/kernel";
-import { sleep, validatorSetPack, chunk } from "@mainsail/utils";
+import { chunk, sleep, validatorSetPack } from "@mainsail/utils";
 import { performance } from "perf_hooks";
 
 import { Listeners } from "./contracts.js";

--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -6,7 +6,7 @@ import {
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers, Types, Utils } from "@mainsail/kernel";
-import { sleep, validatorSetPack } from "@mainsail/utils";
+import { sleep, validatorSetPack, chunk } from "@mainsail/utils";
 import { performance } from "perf_hooks";
 
 import { Listeners } from "./contracts.js";
@@ -307,18 +307,14 @@ export class Sync implements Contracts.ApiSync.Service {
 					supply: () => `supply + ${deferred.block.reward}`,
 				})
 				.where("id = :id", { id: 1 })
-				// TODO: consider additional check constraint (OLD.height = NEW.height - 1)
 				.andWhere("height = :previousHeight", {
 					previousHeight: Utils.BigNumber.make(deferred.block.height).minus(1).toFixed(),
 				})
 				.execute();
 
-			await transactionRepository
-				.createQueryBuilder()
-				.insert()
-				.orIgnore()
-				.values(deferred.transactions)
-				.execute();
+			for (const batch of chunk(deferred.transactions, 256)) {
+				await transactionRepository.createQueryBuilder().insert().orIgnore().values(batch).execute();
+			}
 
 			if (deferred.validatorRound) {
 				await validatorRoundRepository


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Resolve errors such as `sync encountered exception: bind message has 18464 parameter formats but 0 parameters` when processing blocks containing >1000 transactions.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
