### PR TITLE
feat(validator): time limit transaction collation

### DIFF
--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -26,7 +26,8 @@
 		"@mainsail/container": "workspace:*",
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
-		"@mainsail/utils": "workspace:*"
+		"@mainsail/utils": "workspace:*",
+		"joi": "17.12.2"
 	},
 	"devDependencies": {
 		"@mainsail/crypto-address-bech32m": "workspace:*",

--- a/packages/validator/source/defaults.ts
+++ b/packages/validator/source/defaults.ts
@@ -1,0 +1,3 @@
+export const defaults = {
+	txCollatorFactor: 0.75, // Time slot of blockPrepareTime for txCollator
+};

--- a/packages/validator/source/index.ts
+++ b/packages/validator/source/index.ts
@@ -1,6 +1,7 @@
 import { Keystore } from "@chainsafe/bls-keystore";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers, Utils } from "@mainsail/kernel";
+import Joi from "joi";
 
 import { BIP38, BIP39 } from "./keys/index.js";
 import { Validator } from "./validator.js";
@@ -54,5 +55,11 @@ export class ServiceProvider extends Providers.ServiceProvider {
 		}
 
 		this.app.get<ValidatorRepository>(Identifiers.Validator.Repository).configure(validators);
+	}
+
+	public configSchema(): Joi.AnySchema {
+		return Joi.object({
+			txCollatorFactor: Joi.number().min(0).max(1).required(),
+		}).unknown(true);
 	}
 }

--- a/packages/validator/test/helpers/prepare-sandbox.ts
+++ b/packages/validator/test/helpers/prepare-sandbox.ts
@@ -40,6 +40,7 @@ export const prepareSandbox = async (context: { sandbox?: Sandbox }) => {
 	await context.sandbox.app.resolve(CoreConsensusBls12381).register();
 
 	context.sandbox.app.bind(Identifiers.Services.Log.Service).toConstantValue({});
+	context.sandbox.app.bind(Identifiers.ServiceProvider.Configuration).toConstantValue({ getRequired: () => 0.75 }); // txCollatorFactor
 	context.sandbox.app.get<Contracts.Crypto.Configuration>(Identifiers.Cryptography.Configuration).setConfig(crypto);
 
 	await context.sandbox.app.resolve(CoreCryptoTransaction).register();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3311,6 +3311,9 @@ importers:
       '@mainsail/utils':
         specifier: workspace:*
         version: link:../utils
+      joi:
+        specifier: 17.12.2
+        version: 17.12.2
     devDependencies:
       '@mainsail/crypto-address-bech32m':
         specifier: workspace:*

--- a/tests/functional/consensus/config/crypto.json
+++ b/tests/functional/consensus/config/crypto.json
@@ -357,7 +357,7 @@
 			},
 			"timeouts": {
 				"blockTime": 100,
-				"blockPrepareTime": 0,
+				"blockPrepareTime": 100,
 				"stageTimeout": 100,
 				"stageTimeoutIncrease": 100
 			},

--- a/tests/functional/transaction-pool-api/paths/config/crypto.json
+++ b/tests/functional/transaction-pool-api/paths/config/crypto.json
@@ -3429,7 +3429,7 @@
 			},
 			"timeouts": {
 				"blockTime": 100,
-				"blockPrepareTime": 0,
+				"blockPrepareTime": 100,
 				"stageTimeout": 100,
 				"stageTimeoutIncrease": 100
 			},


### PR DESCRIPTION
## Summary

Limit transaction collation to 75% of the time. Remaining time is used for block creations and signing. 

## Checklist

- [x] Ready to be merged

