### PR TITLE
feat(transaction-pool-service): re-add transactions on invalid states

### DIFF
--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "../crypto/transactions.js";
+import { Block, Transaction } from "../crypto/index.js";
 import { SenderMempool } from "./sender-mempool.js";
 
 export interface Mempool {
@@ -7,6 +7,8 @@ export interface Mempool {
 	hasSenderMempool(senderPublicKey: string): boolean;
 	getSenderMempool(senderPublicKey: string): SenderMempool;
 	getSenderMempools(): Iterable<SenderMempool>;
+
+	commit(block: Block, removedTransactions: Transaction[]): Promise<void>;
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -8,7 +8,7 @@ export interface Mempool {
 	getSenderMempool(senderPublicKey: string): SenderMempool;
 	getSenderMempools(): Iterable<SenderMempool>;
 
-	commit(block: Block, removedTransactions: Transaction[]): Promise<void>;
+	commit(block: Block, removedTransactions: Transaction[]): Promise<Transaction[]>;
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -10,7 +10,6 @@ export interface Mempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;
-	removeForgedTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;
 
 	flush(): void;
 }

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -1,4 +1,4 @@
-import { Block, Transaction } from "../crypto/index.js";
+import { Transaction } from "../crypto/index.js";
 import { SenderMempool } from "./sender-mempool.js";
 
 export interface Mempool {
@@ -7,8 +7,6 @@ export interface Mempool {
 	hasSenderMempool(senderPublicKey: string): boolean;
 	getSenderMempool(senderPublicKey: string): SenderMempool;
 	getSenderMempools(): Iterable<SenderMempool>;
-
-	commit(block: Block, removedTransactions: Transaction[]): Promise<Transaction[]>;
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -12,6 +12,9 @@ export interface Mempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;
+	removeForgedTransaction(senderPublicKey: string, id: string): Promise<Transaction[]>;
+
+	fixInvalidStates(): Promise<Transaction[]>;
 
 	flush(): void;
 }

--- a/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
@@ -9,7 +9,7 @@ export interface SenderMempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(id: string): Promise<Transaction[]>;
-	removeForgedTransaction(id: string): Promise<boolean>;
+	removeForgedTransaction(id: string): Promise<Transaction | undefined>;
 }
 
 export type SenderMempoolFactory = (publicKey: string) => Promise<SenderMempool>;

--- a/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
@@ -9,7 +9,7 @@ export interface SenderMempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(id: string): Promise<Transaction[]>;
-	removeForgedTransaction(id: string): Promise<Transaction[]>;
+	removeForgedTransaction(id: string): Promise<boolean>;
 }
 
 export type SenderMempoolFactory = (publicKey: string) => Promise<SenderMempool>;

--- a/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
@@ -8,8 +8,8 @@ export interface SenderMempool {
 	getFromLatest(): Iterable<Transaction>;
 
 	addTransaction(transaction: Transaction): Promise<void>;
-	removeTransaction(id: string): Promise<Transaction[]>;
-	removeForgedTransaction(id: string): Promise<Transaction | undefined>;
+	removeTransaction(id: string): Transaction[];
+	removeForgedTransaction(id: string): Transaction | undefined;
 }
 
 export type SenderMempoolFactory = (publicKey: string) => Promise<SenderMempool>;

--- a/packages/contracts/source/contracts/transaction-pool/sender-state.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-state.ts
@@ -3,5 +3,4 @@ import { Transaction } from "../crypto/transactions.js";
 export interface SenderState {
 	configure(publicKey: string): Promise<SenderState>;
 	apply(transaction: Transaction): Promise<void>;
-	revert(transaction: Transaction): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -5,7 +5,6 @@ export interface Service {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
-	removeTransaction(transaction: Transaction): Promise<void>;
 	commit(block: Block, removedTransactions: string[]): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "../crypto/index.js";
+import { Block, Transaction } from "../crypto/index.js";
 
 export interface Service {
 	getPoolSize(): number;
@@ -6,6 +6,7 @@ export interface Service {
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
 	removeTransaction(transaction: Transaction): Promise<void>;
+	commit(block: Block, removedTransactions: string[]): Promise<void>;
 	cleanUp(): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "../crypto/transactions.js";
+import { Transaction } from "../crypto/index.js";
 
 export interface Service {
 	getPoolSize(): number;
@@ -6,7 +6,6 @@ export interface Service {
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
 	removeTransaction(transaction: Transaction): Promise<void>;
-	removeForgedTransaction(transaction: Transaction): Promise<void>;
 	cleanUp(): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -7,6 +7,5 @@ export interface Service {
 	reAddTransactions(): Promise<void>;
 	removeTransaction(transaction: Transaction): Promise<void>;
 	commit(block: Block, removedTransactions: string[]): Promise<void>;
-	cleanUp(): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -5,6 +5,6 @@ export interface Service {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
-	commit(block: Block, removedTransactions: string[]): Promise<void>;
+	commit(block: Block, failedTransactionIds: string[]): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/transaction-pool-service/source/mempool.test.ts
+++ b/packages/transaction-pool-service/source/mempool.test.ts
@@ -5,11 +5,11 @@ import { Configuration } from "@mainsail/crypto-config";
 import { AddressFactory } from "../../crypto-address-base58/source/address.factory";
 import { KeyPairFactory } from "../../crypto-key-pair-schnorr/source/pair";
 import { PublicKeyFactory } from "../../crypto-key-pair-schnorr/source/public";
-import { describe } from "../../test-framework/source";
+import { describeSkip } from "../../test-framework/source";
 import { Stub } from "../../test-runner/distribution/stub";
 import { Mempool } from ".";
 
-describe<{
+describeSkip<{
 	container: Container;
 	logger: any;
 	config: Configuration;

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -87,8 +87,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 	}
 
 	public async addTransaction(transaction: Contracts.Crypto.Transaction): Promise<void> {
-		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
-
 		let senderMempool = this.#senderMempools.get(transaction.data.senderPublicKey);
 		if (!senderMempool) {
 			senderMempool = await this.createSenderMempool.call(this, transaction.data.senderPublicKey);

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -76,22 +76,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		}
 	}
 
-	public async removeForgedTransaction(senderPublicKey: string, id: string): Promise<Contracts.Crypto.Transaction[]> {
-		const senderMempool = this.#senderMempools.get(senderPublicKey);
-		if (!senderMempool) {
-			return [];
-		}
-
-		try {
-			return await senderMempool.removeForgedTransaction(id);
-		} finally {
-			if (senderMempool.isDisposable()) {
-				this.#senderMempools.delete(senderPublicKey);
-				this.logger.debug(`${await this.addressFactory.fromPublicKey(senderPublicKey)} state disposed`);
-			}
-		}
-	}
-
 	public flush(): void {
 		this.#senderMempools.clear();
 	}

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -44,13 +44,13 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 
 			const newSenderMempool = await this.createSenderMempool.call(this, senderPublicKey);
 
-			for (let i = 0; i < transactionsForReadd.length; i++) {
-				const transaction = transactionsForReadd[i];
+			for (let index = 0; index < transactionsForReadd.length; index++) {
+				const transaction = transactionsForReadd[index];
 
 				try {
 					await newSenderMempool.addTransaction(transaction);
 				} catch {
-					transactionsForReadd.slice(i).map((tx) => {
+					transactionsForReadd.slice(index).map((tx) => {
 						removedTransactions.push(tx);
 					});
 					break;

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -36,6 +36,11 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		return this.#senderMempools.values();
 	}
 
+	public async commit(
+		block: Contracts.Crypto.Block,
+		removedTransactions: Contracts.Crypto.Transaction[],
+	): Promise<void> {}
+
 	public async addTransaction(transaction: Contracts.Crypto.Transaction): Promise<void> {
 		AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
 

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -1,6 +1,5 @@
 import { inject, injectable, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
-import { Utils as AppUtils } from "@mainsail/kernel";
 
 @injectable()
 export class Mempool implements Contracts.TransactionPool.Mempool {

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -111,7 +111,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 			return [];
 		}
 
-		const transactions = await senderMempool.removeTransaction(id);
+		const transactions = senderMempool.removeTransaction(id);
 
 		if (transactions.length > 0 && !(await this.#removeDisposableMempool(senderPublicKey))) {
 			this.#sendersForReadd.add(senderPublicKey);
@@ -126,7 +126,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 			return [];
 		}
 
-		const transaction = await senderMempool.removeForgedTransaction(id);
+		const transaction = senderMempool.removeForgedTransaction(id);
 
 		if (!transaction) {
 			this.#sendersForReadd.add(senderPublicKey);

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -36,24 +36,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		return this.#senderMempools.values();
 	}
 
-	public async commit(
-		block: Contracts.Crypto.Block,
-		failedTransactions: Contracts.Crypto.Transaction[],
-	): Promise<Contracts.Crypto.Transaction[]> {
-		for (const transaction of block.transactions) {
-			await this.removeForgedTransaction(transaction.data.senderPublicKey, transaction.id);
-		}
-
-		const removedTransactions: Contracts.Crypto.Transaction[] = [];
-		for (const failedTransaction of failedTransactions) {
-			removedTransactions.push(
-				...(await this.removeTransaction(failedTransaction.data.senderPublicKey, failedTransaction.id)),
-			);
-		}
-
-		return [...removedTransactions, ...(await this.fixInvalidStates())];
-	}
-
 	public async fixInvalidStates(): Promise<Contracts.Crypto.Transaction[]> {
 		const removedTransactions: Contracts.Crypto.Transaction[] = [];
 

--- a/packages/transaction-pool-service/source/sender-mempool.test.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.test.ts
@@ -1,11 +1,11 @@
 import { Container } from "@mainsail/container";
 import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
 
-import { describe } from "../../test-framework/source";
+import { describeSkip } from "../../test-framework/source";
 import { BigNumber } from "../../utils/source/big-number";
 import { SenderMempool } from ".";
 
-describe<{
+describeSkip<{
 	container: Container;
 	configuration: any;
 	senderState: any;

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -66,32 +66,30 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 	}
 
 	public async removeTransaction(id: string): Promise<Contracts.Crypto.Transaction[]> {
-		try {
-			this.#concurrency++;
-
-			return await this.#lock.runExclusive(async () => {
-				const index = this.#transactions.findIndex((t) => t.id === id);
-				if (index === -1) {
-					return [];
-				}
-
-				const removedTransactions: Contracts.Crypto.Transaction[] = this.#transactions
-					.splice(index, this.#transactions.length - index)
-					.reverse();
-
-				try {
-					for (const removedTransaction of removedTransactions) {
-						await this.senderState.revert(removedTransaction);
-					}
-					return removedTransactions;
-				} catch {
-					const otherRemovedTransactions = this.#transactions.splice(0, this.#transactions.length).reverse();
-					return [...removedTransactions, ...otherRemovedTransactions];
-				}
-			});
-		} finally {
-			this.#concurrency--;
-		}
+		return [];
+		// try {
+		// 	this.#concurrency++;
+		// 	return await this.#lock.runExclusive(async () => {
+		// 		const index = this.#transactions.findIndex((t) => t.id === id);
+		// 		if (index === -1) {
+		// 			return [];
+		// 		}
+		// 		const removedTransactions: Contracts.Crypto.Transaction[] = this.#transactions
+		// 			.splice(index, this.#transactions.length - index)
+		// 			.reverse();
+		// 		try {
+		// 			for (const removedTransaction of removedTransactions) {
+		// 				await this.senderState.revert(removedTransaction);
+		// 			}
+		// 			return removedTransactions;
+		// 		} catch {
+		// 			const otherRemovedTransactions = this.#transactions.splice(0, this.#transactions.length).reverse();
+		// 			return [...removedTransactions, ...otherRemovedTransactions];
+		// 		}
+		// 	});
+		// } finally {
+		// 	this.#concurrency--;
+		// }
 	}
 
 	public async removeForgedTransaction(id: string): Promise<Contracts.Crypto.Transaction[]> {

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -66,37 +66,23 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 	}
 
 	public async removeTransaction(id: string): Promise<Contracts.Crypto.Transaction[]> {
-		return [];
-		// try {
-		// 	this.#concurrency++;
-		// 	return await this.#lock.runExclusive(async () => {
-		// 		const index = this.#transactions.findIndex((t) => t.id === id);
-		// 		if (index === -1) {
-		// 			return [];
-		// 		}
-		// 		const removedTransactions: Contracts.Crypto.Transaction[] = this.#transactions
-		// 			.splice(index, this.#transactions.length - index)
-		// 			.reverse();
-		// 		try {
-		// 			for (const removedTransaction of removedTransactions) {
-		// 				await this.senderState.revert(removedTransaction);
-		// 			}
-		// 			return removedTransactions;
-		// 		} catch {
-		// 			const otherRemovedTransactions = this.#transactions.splice(0, this.#transactions.length).reverse();
-		// 			return [...removedTransactions, ...otherRemovedTransactions];
-		// 		}
-		// 	});
-		// } finally {
-		// 	this.#concurrency--;
-		// }
+		try {
+			this.#concurrency++;
+			const index = this.#transactions.findIndex((t) => t.id === id);
+			if (index === -1) {
+				return [];
+			}
+			return this.#transactions.splice(index, this.#transactions.length - index).reverse();
+		} finally {
+			this.#concurrency--;
+		}
 	}
 
 	public async removeForgedTransaction(id: string): Promise<boolean> {
 		try {
 			this.#concurrency++;
 
-			if (!this.#transactions.length) {
+			if (this.#transactions.length === 0) {
 				throw new Error("No transactions in sender mempool");
 			}
 

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -43,8 +43,6 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 			this.#concurrency++;
 
 			await this.#lock.runExclusive(async () => {
-				AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
-
 				const maxTransactionsPerSender: number =
 					this.configuration.getRequired<number>("maxTransactionsPerSender");
 				if (this.#transactions.length >= maxTransactionsPerSender) {

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -65,34 +65,23 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		}
 	}
 
-	public async removeTransaction(id: string): Promise<Contracts.Crypto.Transaction[]> {
-		try {
-			this.#concurrency++;
-			const index = this.#transactions.findIndex((t) => t.id === id);
-			if (index === -1) {
-				return [];
-			}
-			return this.#transactions.splice(index, this.#transactions.length - index).reverse();
-		} finally {
-			this.#concurrency--;
+	public removeTransaction(id: string): Contracts.Crypto.Transaction[] {
+		const index = this.#transactions.findIndex((t) => t.id === id);
+		if (index === -1) {
+			return [];
 		}
+		return this.#transactions.splice(index, this.#transactions.length - index).reverse();
 	}
 
-	public async removeForgedTransaction(id: string): Promise<Contracts.Crypto.Transaction | undefined> {
-		try {
-			this.#concurrency++;
-
-			if (this.#transactions.length === 0) {
-				throw new Error("No transactions in sender mempool");
-			}
-
-			if (this.#transactions[0].id === id) {
-				return this.#transactions.shift();
-			}
-
-			return undefined;
-		} finally {
-			this.#concurrency--;
+	public removeForgedTransaction(id: string): Contracts.Crypto.Transaction | undefined {
+		if (this.#transactions.length === 0) {
+			throw new Error("No transactions in sender mempool");
 		}
+
+		if (this.#transactions[0].id === id) {
+			return this.#transactions.shift();
+		}
+
+		return undefined;
 	}
 }

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -92,17 +92,20 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		// }
 	}
 
-	public async removeForgedTransaction(id: string): Promise<Contracts.Crypto.Transaction[]> {
+	public async removeForgedTransaction(id: string): Promise<boolean> {
 		try {
 			this.#concurrency++;
 
-			const index: number = this.#transactions.findIndex((t) => t.id === id);
-
-			if (index !== -1) {
-				return this.#transactions.splice(0, index + 1);
-			} else {
-				return []; // TODO: implement this.reboot();
+			if (!this.#transactions.length) {
+				throw new Error("No transactions in sender mempool");
 			}
+
+			if (this.#transactions[0].id === id) {
+				this.#transactions.shift();
+				return true;
+			}
+
+			return false;
 		} finally {
 			this.#concurrency--;
 		}

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -78,7 +78,7 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		}
 	}
 
-	public async removeForgedTransaction(id: string): Promise<boolean> {
+	public async removeForgedTransaction(id: string): Promise<Contracts.Crypto.Transaction | undefined> {
 		try {
 			this.#concurrency++;
 
@@ -87,11 +87,10 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 			}
 
 			if (this.#transactions[0].id === id) {
-				this.#transactions.shift();
-				return true;
+				return this.#transactions.shift();
 			}
 
-			return false;
+			return undefined;
 		} finally {
 			this.#concurrency--;
 		}

--- a/packages/transaction-pool-service/source/sender-state.ts
+++ b/packages/transaction-pool-service/source/sender-state.ts
@@ -86,20 +86,4 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 			throw new Exceptions.TransactionFailedToVerifyError(transaction);
 		}
 	}
-
-	public async revert(transaction: Contracts.Crypto.Transaction): Promise<void> {
-		try {
-			// TODO: Implement transaction revert
-			// const handler: Contracts.Transactions.ITransactionHandler =
-			// 	await this.handlerRegistry.getActivatedHandlerForData(transaction.data);
-			// await this.triggers.call("revertTransaction", {
-			// 	handler,
-			// 	transaction,
-			// 	walletRepository: this.walletRepository,
-			// });
-		} catch (error) {
-			this.#corrupt = true;
-			throw error;
-		}
-	}
 }

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -184,37 +184,6 @@ export class Service implements Contracts.TransactionPool.Service {
 		});
 	}
 
-	public async removeForgedTransaction(transaction: Contracts.Crypto.Transaction): Promise<void> {
-		await this.#lock.runNonExclusive(async () => {
-			if (this.#disposed) {
-				return;
-			}
-
-			AppUtils.assert.defined<string>(transaction.id);
-			AppUtils.assert.defined<string>(transaction.data.senderPublicKey);
-
-			if (this.storage.hasTransaction(transaction.id) === false) {
-				return;
-			}
-
-			const removedTransactions = await this.mempool.removeForgedTransaction(
-				transaction.data.senderPublicKey,
-				transaction.id,
-			);
-
-			for (const removedTransaction of removedTransactions) {
-				AppUtils.assert.defined<string>(removedTransaction.id);
-				this.storage.removeTransaction(removedTransaction.id);
-				this.logger.debug(`Removed forged tx ${removedTransaction.id}`);
-			}
-
-			if (!removedTransactions.some((t) => t.id === transaction.id)) {
-				this.storage.removeTransaction(transaction.id);
-				this.logger.error(`Removed forged tx ${transaction.id} from storage`);
-			}
-		});
-	}
-
 	public async cleanUp(): Promise<void> {
 		await this.#lock.runNonExclusive(async () => {
 			if (this.#disposed) {

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -74,7 +74,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 				for (const forgedTransaction of transactions) {
 					this.storage.removeTransaction(transaction.id);
-					this.logger.info(`Removed forged tx ${transaction.id}`);
+					this.logger.debug(`Removed forged tx ${transaction.id}`);
 					void this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, forgedTransaction.data);
 				}
 			}
@@ -87,7 +87,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 				for (const forgedTransaction of transactions) {
 					this.storage.removeTransaction(transaction.id);
-					this.logger.info(`Removed tx ${transaction.id}`);
+					this.logger.debug(`Removed tx ${transaction.id}`);
 					void this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, forgedTransaction.data);
 				}
 			}
@@ -213,7 +213,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 			for (const removedTransaction of removedTransactions) {
 				this.storage.removeTransaction(removedTransaction.id);
-				this.logger.info(`Removed old tx ${removedTransaction.id}`);
+				this.logger.debug(`Removed old tx ${removedTransaction.id}`);
 
 				void this.events.dispatch(Enums.TransactionEvent.Expired, removedTransaction.data);
 			}
@@ -230,7 +230,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 				for (const removedTransaction of removedTransactions) {
 					this.storage.removeTransaction(removedTransaction.id);
-					this.logger.info(`Removed expired tx ${removedTransaction.id}`);
+					this.logger.debug(`Removed expired tx ${removedTransaction.id}`);
 					void this.events.dispatch(Enums.TransactionEvent.Expired, removedTransaction.data);
 				}
 			}
@@ -251,7 +251,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 		for (const removedTransaction of removedTransactions) {
 			this.storage.removeTransaction(removedTransaction.id);
-			this.logger.info(`Removed lowest priority tx ${removedTransaction.id}`);
+			this.logger.debug(`Removed lowest priority tx ${removedTransaction.id}`);
 			void this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, removedTransaction.data);
 		}
 	}
@@ -269,7 +269,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 		for (const transaction of transactions) {
 			this.storage.removeTransaction(transaction.id);
-			this.logger.info(`Removed invalid tx ${transaction.id}`);
+			this.logger.debug(`Removed invalid tx ${transaction.id}`);
 
 			void this.events.dispatch(Enums.TransactionEvent.RemovedFromPool, transaction.data);
 		}

--- a/packages/transaction-pool-worker/source/handlers/get-transactions.ts
+++ b/packages/transaction-pool-worker/source/handlers/get-transactions.ts
@@ -1,19 +1,10 @@
 import { inject, injectable } from "@mainsail/container";
-import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
+import { Contracts, Identifiers } from "@mainsail/contracts";
 
 @injectable()
 export class GetTransactionsHandler {
-	@inject(Identifiers.TransactionPool.Service)
-	private readonly pool!: Contracts.TransactionPool.Service;
-
-	@inject(Identifiers.TransactionPool.ExpirationService)
-	private readonly expirationService!: Contracts.TransactionPool.ExpirationService;
-
 	@inject(Identifiers.TransactionPool.Query)
 	private readonly poolQuery!: Contracts.TransactionPool.Query;
-
-	@inject(Identifiers.Services.Log.Service)
-	private readonly logger!: Contracts.Kernel.Logger;
 
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration!: Contracts.Crypto.Configuration;
@@ -26,39 +17,20 @@ export class GetTransactionsHandler {
 		let bytesLeft: number = milestone.block.maxPayload - this.blockSerializer.headerSize();
 
 		const candidateTransactions: Contracts.Crypto.Transaction[] = [];
-		const failedTransactions: Contracts.Crypto.Transaction[] = [];
 
 		for (const transaction of await this.poolQuery.getFromHighestPriority().all()) {
 			if (candidateTransactions.length === milestone.block.maxTransactions) {
 				break;
 			}
 
-			if (failedTransactions.some((t) => t.data.senderPublicKey === transaction.data.senderPublicKey)) {
-				continue;
+			if (bytesLeft - 4 - transaction.serialized.length < 0) {
+				break;
 			}
 
-			try {
-				if (await this.expirationService.isExpired(transaction)) {
-					const expirationHeight: number = await this.expirationService.getExpirationHeight(transaction);
-					throw new Exceptions.TransactionHasExpiredError(transaction, expirationHeight);
-				}
+			candidateTransactions.push(transaction);
 
-				if (bytesLeft - 4 - transaction.serialized.length < 0) {
-					break;
-				}
-
-				candidateTransactions.push(transaction);
-
-				bytesLeft -= 4;
-				bytesLeft -= transaction.serialized.length;
-			} catch (error) {
-				this.logger.warning(`${transaction.id} failed to collate: ${error.message}`);
-				failedTransactions.push(transaction);
-			}
-
-			for (const failedTransaction of failedTransactions) {
-				await this.pool.removeTransaction(failedTransaction);
-			}
+			bytesLeft -= 4;
+			bytesLeft -= transaction.serialized.length;
 		}
 
 		return candidateTransactions.map((transaction) => transaction.serialized.toString("hex"));


### PR DESCRIPTION
## Summary

Re add transactions:
- forged transaction is not same as first transaction
- transaction is removed because: old, expired or low priority
- discard removeTransaction method, service is self sustainable

## Checklist

- [x] Ready to be merged
