### PR TITLE
deps(evm): use rust 1.75

### DIFF
--- a/packages/evm/Cargo.toml
+++ b/packages/evm/Cargo.toml
@@ -4,13 +4,13 @@ members = ["core", "bindings"]
 
 [workspace.package]
 version = "0.1.0"
-rust-version = "1.76"
+rust-version = "1.75"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = [""]
 
 [workspace.dependencies]
-anyhow = { version = "1.0.79" }
+anyhow = { version = "1.0.75" }
 ethers-contract = { version = "2.0.13" }
 ethers-core = { version = "2.0.13" }
 ethers-providers = { version = "2.0.13" }


### PR DESCRIPTION
## Summary

Rust 1.75 is default Ubuntu 22.04 version. 

## Checklist

- [x] Ready to be merged

