### PR TITLE
feat(evm-api): implements `web3_clientVersion` action

### DIFF
--- a/packages/api-evm/package.json
+++ b/packages/api-evm/package.json
@@ -32,6 +32,7 @@
 		"joi": "17.12.2"
 	},
 	"devDependencies": {
+		"@mainsail/validation": "workspace:*",
 		"@types/semver": "7.5.8",
 		"uvu": "^0.5.6"
 	},

--- a/packages/api-evm/source/actions/index.ts
+++ b/packages/api-evm/source/actions/index.ts
@@ -1,1 +1,2 @@
 export * from "./call.js";
+export * from "./web3-client-version.js";

--- a/packages/api-evm/source/actions/web3-client-version.test.ts
+++ b/packages/api-evm/source/actions/web3-client-version.test.ts
@@ -1,4 +1,5 @@
 import { Identifiers } from "@mainsail/contracts";
+import { Validator } from "@mainsail/validation";
 
 import { describe, Sandbox } from "../../../test-framework/source";
 import { Web3ClientVersionAction } from "./index.js";
@@ -6,27 +7,35 @@ import { Web3ClientVersionAction } from "./index.js";
 describe<{
 	sandbox: Sandbox;
 	action: Web3ClientVersionAction;
+	validator: Validator;
 }>("Web3ClientVersionAction", ({ beforeEach, it, assert }) => {
 	const version = "0.0.1";
 
-	beforeEach((context) => {
+	beforeEach(async (context) => {
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Application.Version).toConstantValue(version);
 
 		context.action = context.sandbox.app.resolve(Web3ClientVersionAction);
+		context.validator = context.sandbox.app.resolve(Validator);
 	});
 
 	it("should have a name", ({ action }) => {
 		assert.equal(action.name, "web3_clientVersion");
 	});
 
-	it("schema should be array with 0 parameters", ({ action }) => {
+	it("schema should be array with 0 parameters", ({ action, validator }) => {
 		assert.equal(action.schema, {
 			$id: "jsonRpc_web3_clientVersion",
 			maxItems: 0,
 			type: "array",
 		});
+
+		validator.addSchema(action.schema);
+
+		assert.undefined(validator.validate("jsonRpc_web3_clientVersion", []).errors);
+		assert.defined(validator.validate("jsonRpc_web3_clientVersion", [1]).errors);
+		assert.defined(validator.validate("jsonRpc_web3_clientVersion", {}).errors);
 	});
 
 	it("should return the web3 client version", async ({ action }) => {

--- a/packages/api-evm/source/actions/web3-client-version.test.ts
+++ b/packages/api-evm/source/actions/web3-client-version.test.ts
@@ -1,0 +1,38 @@
+import { Identifiers } from "@mainsail/contracts";
+
+import { describe, Sandbox } from "../../../test-framework/source";
+import { Web3ClientVersionAction } from "./index.js";
+
+describe<{
+	sandbox: Sandbox;
+	action: Web3ClientVersionAction;
+}>("Web3ClientVersionAction", ({ beforeEach, it, assert }) => {
+	const version = "0.0.1";
+
+	beforeEach((context) => {
+		context.sandbox = new Sandbox();
+
+		context.sandbox.app.bind(Identifiers.Application.Version).toConstantValue(version);
+
+		context.action = context.sandbox.app.resolve(Web3ClientVersionAction);
+	});
+
+	it("should have a name", ({ action }) => {
+		assert.equal(action.name, "web3_clientVersion");
+	});
+
+	it("schema should be array with 0 parameters", ({ action }) => {
+		assert.equal(action.schema, {
+			$id: "jsonRpc_web3_clientVersion",
+			maxItems: 0,
+			type: "array",
+		});
+	});
+
+	it("should return the web3 client version", async ({ action }) => {
+		assert.equal(
+			await action.handle([]),
+			`@mainsail/core/${version}/${process.platform}-${process.arch}/node-${process.version}`,
+		);
+	});
+});

--- a/packages/api-evm/source/actions/web3-client-version.ts
+++ b/packages/api-evm/source/actions/web3-client-version.ts
@@ -15,6 +15,6 @@ export class Web3ClientVersionAction implements Contracts.Api.RPC.Action {
 	};
 
 	public async handle(parameters: []): Promise<string> {
-		return `@mainsail/core/${this.version}`;
+		return `@mainsail/core/${this.version}/${process.platform}-${process.arch}/node-${process.version}`;
 	}
 }

--- a/packages/api-evm/source/actions/web3-client-version.ts
+++ b/packages/api-evm/source/actions/web3-client-version.ts
@@ -1,0 +1,20 @@
+import { inject, injectable } from "@mainsail/container";
+import { Contracts, Identifiers } from "@mainsail/contracts";
+
+@injectable()
+export class Web3ClientVersionAction implements Contracts.Api.RPC.Action {
+	@inject(Identifiers.Application.Version)
+	private readonly version!: string;
+
+	public readonly name: string = "web3_clientVersion";
+
+	public readonly schema = {
+		$id: `jsonRpc_${this.name}`,
+		maxItems: 0,
+		type: "array",
+	};
+
+	public async handle(parameters: []): Promise<string> {
+		return `@mainsail/core/${this.version}`;
+	}
+}

--- a/packages/api-evm/source/service-provider.ts
+++ b/packages/api-evm/source/service-provider.ts
@@ -2,7 +2,7 @@ import { AbstractServiceProvider, Plugins, ServerConstructor } from "@mainsail/a
 import { Contracts } from "@mainsail/contracts";
 import Joi from "joi";
 
-import { CallAction } from "./actions/index.js";
+import { CallAction, Web3ClientVersionAction } from "./actions/index.js";
 import Handlers from "./handlers.js";
 import { Identifiers as ApiIdentifiers } from "./identifiers.js";
 import { Server } from "./server.js";
@@ -50,7 +50,7 @@ export class ServiceProvider extends AbstractServiceProvider<Server> {
 	}
 
 	protected getActions(): Contracts.Api.RPC.Action[] {
-		return [this.app.resolve(CallAction)];
+		return [this.app.resolve(CallAction), this.app.resolve(Web3ClientVersionAction)];
 	}
 
 	public configSchema(): Joi.ObjectSchema {

--- a/packages/validation/source/index.ts
+++ b/packages/validation/source/index.ts
@@ -2,6 +2,7 @@ import { Identifiers } from "@mainsail/contracts";
 import { Providers } from "@mainsail/kernel";
 
 import { Validator } from "./validator.js";
+export { Validator } from "./validator.js";
 
 export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
         specifier: 17.12.2
         version: 17.12.2
     devDependencies:
+      '@mainsail/validation':
+        specifier: workspace:*
+        version: link:../validation
       '@types/semver':
         specifier: 7.5.8
         version: 7.5.8


### PR DESCRIPTION
## Summary

Implements `web3_clientVersion` action. [Specification](https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion).



## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged