### PR TITLE
feat(evm): fix account state bootstrap

### DIFF
--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -75,13 +75,6 @@ impl EvmInner {
         &mut self,
         account_update_ctx: AccountUpdateContext,
     ) -> std::result::Result<(), EVMError<String>> {
-        if self
-            .persistent_db
-            .is_height_committed(account_update_ctx.commit_key.0)
-        {
-            return Ok(());
-        }
-
         // Drop pending state on key change
         if self
             .pending_commit
@@ -197,7 +190,7 @@ impl EvmInner {
 
     pub fn commit(&mut self, commit_key: CommitKey) -> std::result::Result<(), EVMError<String>> {
         if self.persistent_db.is_height_committed(commit_key.0) {
-            assert!(self.pending_commit.is_none());
+            self.drop_pending_commit();
             return Ok(());
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
On bootstrap account changes have to be applied (in-memory) and cannot be skipped regardless of commit status to ensure the state hash is properly computed. Without doing so a node is likely to get stuck during bootstrap on restart.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
