### PR TITLE
refactor(evm): get nonce for deployer transactions

### DIFF
--- a/packages/contracts/source/contracts/evm/evm.ts
+++ b/packages/contracts/source/contracts/evm/evm.ts
@@ -61,7 +61,7 @@ export interface TransactionContext {
 	readonly gasLimit: bigint;
 	readonly value: bigint;
 	readonly gasPrice?: bigint;
-	readonly nonce?: bigint;
+	readonly nonce: bigint;
 	readonly data: Buffer;
 	readonly blockContext: BlockContext;
 	readonly txHash: string;

--- a/packages/evm-consensus/source/deployer.ts
+++ b/packages/evm-consensus/source/deployer.ts
@@ -56,6 +56,8 @@ export class Deployer {
 		const activeValidaotrs = this.configuration.getMilestone(1).activeValidators; // TODO update on milestone change
 
 		const constructorArguments = new ethers.AbiCoder().encode(["uint8"], [activeValidaotrs]).slice(2);
+		const nonce = BigInt(this.#nonce);
+
 		const result = await this.evm.process({
 			blockContext,
 			caller: this.#deployerAddress,
@@ -64,6 +66,7 @@ export class Deployer {
 				Buffer.from(constructorArguments, "hex"),
 			]),
 			gasLimit: BigInt(10_000_000),
+			nonce,
 			specId: milestone.evmSpec,
 			txHash: this.#generateTxHash(),
 			value: 0n,

--- a/packages/evm-development/source/deployer.ts
+++ b/packages/evm-development/source/deployer.ts
@@ -38,11 +38,13 @@ export class Deployer {
 			validatorAddress: this.#deployerAddress,
 		};
 
+		const nonce = BigInt(this.#nonce);
 		const result = await this.evm.process({
 			blockContext,
 			caller: this.#deployerAddress,
 			data: Buffer.from(ethers.getBytes(ERC20.abi.bytecode)),
 			gasLimit: BigInt(2_000_000),
+			nonce,
 			specId: milestone.evmSpec,
 			txHash: this.#generateTxHash(),
 			value: 0n,
@@ -84,11 +86,14 @@ export class Deployer {
 		for (const recipient of recipients) {
 			const encodedCall = iface.encodeFunctionData("transfer", [recipient, amount]);
 
+			const nonce = BigInt(this.#nonce);
+
 			const { receipt } = await this.evm.process({
 				blockContext,
 				caller: this.#deployerAddress,
 				data: Buffer.from(ethers.getBytes(encodedCall)),
 				gasLimit: BigInt(100_000),
+				nonce,
 				recipient: erc20ContractAddress,
 				specId: milestone.evmSpec,
 				txHash: this.#generateTxHash(),

--- a/packages/evm-service/source/instances/evm.test.ts
+++ b/packages/evm-service/source/instances/evm.test.ts
@@ -44,6 +44,7 @@ describe<{
 		const { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash: getRandomTxHash(),
@@ -66,6 +67,7 @@ describe<{
 		let { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailGlobals.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash: getRandomTxHash(),
@@ -86,6 +88,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 1n,
 			data: Buffer.from(ethers.getBytes(encodedCall)),
 			recipient: "0x69230f08D82f095aCB9BE4B21043B502b712D3C1",
 			txHash: getRandomTxHash(),
@@ -124,6 +127,7 @@ describe<{
 		let { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			txHash: getRandomTxHash(),
 			blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
@@ -156,6 +160,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 1n,
 			data: Buffer.from(ethers.getBytes(transferEncodedCall)),
 			recipient: contractAddress,
 			txHash: getRandomTxHash(),
@@ -184,6 +189,7 @@ describe<{
 		let { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			txHash: getRandomTxHash(),
 			blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
@@ -196,6 +202,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 1n,
 			data: Buffer.from("0xdead", "hex"),
 			recipient: contractAddress,
 			txHash: getRandomTxHash(),
@@ -218,6 +225,7 @@ describe<{
 			blockContext: { ...blockContext, commitKey },
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			txHash: getRandomTxHash(),
 			...deployConfig,
@@ -246,6 +254,7 @@ describe<{
 			await instance.process({
 				blockContext: { ...blockContext, commitKey: commitKey1 },
 				value: 0n,
+				nonce: 1n,
 				caller: sender.address,
 				data: Buffer.from(
 					ethers.getBytes(iface.encodeFunctionData("transfer", [recipient.address, ethers.parseEther("1")])),
@@ -262,6 +271,7 @@ describe<{
 			await instance.process({
 				blockContext: { ...blockContext, commitKey: commitKey2 },
 				value: 0n,
+				nonce: 1n,
 				caller: sender.address,
 				data: Buffer.from(
 					ethers.getBytes(iface.encodeFunctionData("transfer", [recipient.address, ethers.parseEther("2")])),
@@ -317,6 +327,7 @@ describe<{
 				await instance.process({
 					caller: "badsender_",
 					value: 0n,
+					nonce: 0n,
 					data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 					blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
 					txHash: getRandomTxHash(),
@@ -333,6 +344,7 @@ describe<{
 		let { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash,
@@ -356,6 +368,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 1n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash,
@@ -377,6 +390,7 @@ describe<{
 		await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash,
@@ -396,6 +410,7 @@ describe<{
 			await instance.process({
 				caller: sender.address,
 				value: 0n,
+				nonce: 0n,
 				data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 				blockContext: { ...blockContext, commitKey },
 				txHash: randomTxHash,
@@ -410,6 +425,7 @@ describe<{
 		let { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
 			txHash: getRandomTxHash(),
@@ -438,6 +454,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 1n,
 			data: Buffer.from(ethers.getBytes(transferEncodedCall)),
 			recipient: contractAddress,
 			blockContext: { ...blockContext, commitKey: { height: BigInt(1), round: BigInt(0) } },
@@ -448,6 +465,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 2n,
 			data: Buffer.from(ethers.getBytes(transferEncodedCall)),
 			recipient: contractAddress,
 			blockContext: { ...blockContext, commitKey: { height: BigInt(1), round: BigInt(0) } },
@@ -458,6 +476,7 @@ describe<{
 		({ receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 3n,
 			data: Buffer.from(ethers.getBytes(transferEncodedCall)),
 			recipient: contractAddress,
 			blockContext: { ...blockContext, commitKey: { height: BigInt(1), round: BigInt(0) } },
@@ -489,6 +508,7 @@ describe<{
 		const { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			blockContext: { ...blockContext, commitKey },
 			txHash: getRandomTxHash(),
@@ -508,6 +528,7 @@ describe<{
 				instance.process({
 					caller: sender.address,
 					value: 0n,
+					nonce: 0n,
 					data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 					blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
 					txHash: getRandomTxHash(),
@@ -541,6 +562,7 @@ describe<{
 		const { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			txHash: getRandomTxHash(),
 			blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
@@ -567,12 +589,52 @@ describe<{
 				await instance.process({
 					caller: sender.address,
 					value: 2n,
+					nonce: 0n,
 					data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 					txHash: getRandomTxHash(),
 					blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
 					...deployConfig,
 				}),
 			"Panic in async function",
+		);
+	});
+
+	it("should throw when nonce is wrong", async ({ instance }) => {
+		const [sender] = wallets;
+
+		await assert.resolves(
+			async () =>
+				await instance.process({
+					caller: sender.address,
+					value: 0n,
+					nonce: 0n,
+					data: Buffer.from("00", "hex"),
+					txHash: getRandomTxHash(),
+					blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },
+					...deployConfig,
+				}),
+		);
+
+		await instance.onCommit({
+			height: BigInt(0),
+			round: BigInt(0),
+			getBlock: () => ({
+				data: { height: BigInt(0), round: BigInt(0) },
+			}),
+		} as any);
+
+		await assert.rejects(
+			async () =>
+				await instance.process({
+					caller: sender.address,
+					value: 0n,
+					nonce: 2n, // should be 1
+					data: Buffer.from("00", "hex"),
+					txHash: getRandomTxHash(),
+					blockContext: { ...blockContext, commitKey: { height: BigInt(1), round: BigInt(0) } },
+					...deployConfig,
+				}),
+			"transaction validation error: nonce 2 too high, expected 1",
 		);
 	});
 
@@ -587,6 +649,7 @@ describe<{
 		const { receipt } = await instance.process({
 			caller: sender.address,
 			value: 0n,
+			nonce: 0n,
 			data: Buffer.from(MainsailERC20.bytecode.slice(2), "hex"),
 			txHash: getRandomTxHash(),
 			blockContext: { ...blockContext, commitKey: { height: BigInt(0), round: BigInt(0) } },

--- a/packages/evm/bindings/src/ctx.rs
+++ b/packages/evm/bindings/src/ctx.rs
@@ -15,7 +15,7 @@ pub struct JsTransactionContext {
     pub gas_limit: JsBigInt,
     pub gas_price: Option<JsBigInt>,
     pub value: JsBigInt,
-    pub nonce: Option<JsBigInt>,
+    pub nonce: JsBigInt,
     pub data: JsBuffer,
     pub tx_hash: JsString,
     pub block_context: JsBlockContext,
@@ -88,7 +88,7 @@ pub struct TxContext {
     pub gas_limit: u64,
     pub gas_price: Option<U256>,
     pub value: U256,
-    pub nonce: Option<u64>,
+    pub nonce: u64,
     pub data: Bytes,
     pub tx_hash: B256,
     pub block_context: BlockContext,
@@ -176,7 +176,7 @@ impl From<TxContext> for ExecutionContext {
             gas_limit: Some(value.gas_limit),
             gas_price: value.gas_price,
             value: value.value,
-            nonce: value.nonce,
+            nonce: Some(value.nonce),
             data: value.data,
             tx_hash: Some(value.tx_hash),
             block_context: Some(value.block_context),
@@ -231,12 +231,6 @@ impl TryFrom<JsTransactionContext> for TxContext {
             None
         };
 
-        let nonce = if let Some(nonce) = value.nonce {
-            Some(nonce.get_u64()?.0)
-        } else {
-            None
-        };
-
         let gas_price = if let Some(gas_price) = value.gas_price {
             Some(utils::convert_bigint_to_u256(gas_price)?)
         } else {
@@ -249,7 +243,7 @@ impl TryFrom<JsTransactionContext> for TxContext {
             gas_price,
             caller: utils::create_address_from_js_string(value.caller)?,
             value: utils::convert_bigint_to_u256(value.value)?,
-            nonce,
+            nonce: value.nonce.get_u64()?.0,
             data: Bytes::from(buf.as_ref().to_owned()),
             tx_hash: B256::try_from(
                 &Bytes::from_str(value.tx_hash.into_utf8()?.as_str()?)?.as_ref()[..],

--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -351,6 +351,10 @@ impl EvmInner {
                                     ..Default::default()
                                 });
                             }
+                            revm::primitives::InvalidTransaction::NonceTooHigh { .. }
+                            | revm::primitives::InvalidTransaction::NonceTooLow { .. } => {
+                                return Err(EVMError::Transaction(err));
+                            }
                             revm::primitives::InvalidTransaction::LackOfFundForMaxFee {
                                 fee,
                                 balance,
@@ -363,8 +367,6 @@ impl EvmInner {
                             // revm::primitives::InvalidTransaction::RejectCallerWithCode => todo!(),
                             // revm::primitives::InvalidTransaction::OverflowPaymentInTransaction => todo!(),
                             // revm::primitives::InvalidTransaction::NonceOverflowInTransaction => todo!(),
-                            // revm::primitives::InvalidTransaction::NonceTooHigh { tx, state } => todo!(),
-                            // revm::primitives::InvalidTransaction::NonceTooLow { tx, state } => todo!(),
                             // revm::primitives::InvalidTransaction::CreateInitCodeSizeLimit => todo!(),
                             // revm::primitives::InvalidTransaction::InvalidChainId => todo!(),
                             // revm::primitives::InvalidTransaction::AccessListNotSupported => todo!(),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- nonce field is mandatory
- deployer nonce is retrieved from evm state

## Checklist

- [x] Ready to be merged


