### PR TITLE
feat(transaction-pool-service): calculate sender state on transaction removal

### DIFF
--- a/packages/api-development/source/controllers/node.ts
+++ b/packages/api-development/source/controllers/node.ts
@@ -30,7 +30,7 @@ export class NodeController extends Controller {
 
 		return {
 			data: {
-				constants: this.configuration.getMilestone(this.stateStore.getLastHeight()),
+				constants: this.configuration.getMilestone(this.stateStore.getHeight()),
 				core: {
 					version: this.app.version(),
 				},

--- a/packages/api-development/source/controllers/round.ts
+++ b/packages/api-development/source/controllers/round.ts
@@ -24,7 +24,7 @@ export class RoundController extends Controller {
 			(_, index) => activeValidators[this.proposerSelector.getValidatorIndex(index)],
 		);
 
-		const height = this.stateStore.getLastHeight();
+		const height = this.stateStore.getHeight();
 
 		return {
 			height,

--- a/packages/api-evm/source/actions/eth-block-number.test.ts
+++ b/packages/api-evm/source/actions/eth-block-number.test.ts
@@ -14,7 +14,7 @@ describe<{
 
 	beforeEach(async (context) => {
 		context.store = {
-			getLastHeight() {
+			getHeight() {
 				return height;
 			},
 		};

--- a/packages/api-evm/source/actions/eth-block-number.ts
+++ b/packages/api-evm/source/actions/eth-block-number.ts
@@ -15,6 +15,6 @@ export class EthBlockNumberAction implements Contracts.Api.RPC.Action {
 	};
 
 	public async handle(parameters: []): Promise<string> {
-		return `0x${this.stateStore.getLastHeight().toString(16)}`;
+		return `0x${this.stateStore.getHeight().toString(16)}`;
 	}
 }

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -136,10 +136,10 @@ export class Bootstrapper {
 			this.stateStore.getLastHeight() + 1,
 			lastCommit.block.data.height,
 		)) {
-			totalRound += commit.block.data.round + 1;
+			totalRound += commit.proof.round + 1;
 		}
 
-		this.stateStore.setTotalRoundAndHeight(totalRound, lastCommit.block.data.height);
+		this.stateStore.setTotalRound(totalRound);
 		this.configuration.setHeight(lastCommit.block.data.height + 1);
 
 		console.log("Total round", totalRound, "Last height", lastCommit.block.data.height);

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -141,8 +141,6 @@ export class Bootstrapper {
 
 		this.stateStore.setTotalRound(totalRound);
 		this.configuration.setHeight(lastCommit.block.data.height + 1);
-
-		console.log("Total round", totalRound, "Last height", lastCommit.block.data.height);
 	}
 
 	async #processCommit(commit: Contracts.Crypto.Commit): Promise<void> {

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -111,12 +111,13 @@ export class Bootstrapper {
 	async #initState(): Promise<void> {
 		if (this.databaseService.isEmpty()) {
 			await this.#processGenesisBlock();
+		} else {
+			await this.#processBlocks();
+
+			const commit = await this.databaseService.getLastCommit();
+			this.stateStore.setLastBlock(commit.block);
 		}
 
-		await this.#processBlocks();
-
-		const commit = await this.databaseService.getLastCommit();
-		this.stateStore.setLastBlock(commit.block);
 		await this.validatorSet.restore();
 	}
 

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -141,7 +141,6 @@ export class Bootstrapper {
 		}
 
 		this.stateStore.setTotalRound(totalRound);
-		this.configuration.setHeight(lastCommit.block.data.height + 1);
 	}
 
 	async #processCommit(commit: Contracts.Crypto.Commit): Promise<void> {

--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -134,7 +134,7 @@ export class Bootstrapper {
 		let totalRound = 0;
 
 		for await (const commit of this.databaseService.readCommits(
-			this.stateStore.getLastHeight() + 1,
+			this.stateStore.getHeight() + 1,
 			lastCommit.block.data.height,
 		)) {
 			totalRound += commit.proof.round + 1;

--- a/packages/contracts/source/contracts/evm/worker.ts
+++ b/packages/contracts/source/contracts/evm/worker.ts
@@ -8,7 +8,7 @@ export interface WorkerFlags extends KeyValuePair {}
 export interface WorkerScriptHandler {
 	boot(flags: WorkerFlags): Promise<void>;
 	setPeerCount(peerCount: number): Promise<void>;
-	commit(data: { block: string }): Promise<void>;
+	commit(height: number): Promise<void>;
 }
 
 export type WorkerFactory = () => Worker;

--- a/packages/contracts/source/contracts/evm/worker.ts
+++ b/packages/contracts/source/contracts/evm/worker.ts
@@ -17,7 +17,7 @@ export type WorkerSubprocess = Subprocess<WorkerScriptHandler>;
 
 export type WorkerSubprocessFactory = () => WorkerSubprocess;
 
-export interface Worker extends WorkerScriptHandler, CommitHandler, EventListener {
+export interface Worker extends Omit<WorkerScriptHandler, "commit">, CommitHandler, EventListener {
 	getQueueSize(): number;
 	kill(): Promise<number>;
 }

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -8,7 +8,7 @@ export interface Store extends CommitHandler {
 	getLastBlock(): Block;
 	setLastBlock(block: Block): void;
 
-	setTotalRoundAndHeight(totalRound: number, height: number): void;
+	setTotalRound(totalRound: number): void;
 	getTotalRound(): number;
 }
 

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -4,9 +4,11 @@ export interface Store extends CommitHandler {
 	getGenesisCommit(): Commit;
 	setGenesisCommit(block: Commit): void;
 
-	getHeight(): number;
 	getLastBlock(): Block;
 	setLastBlock(block: Block): void;
+
+	setHeight(height: number): void;
+	getHeight(): number;
 
 	setTotalRound(totalRound: number): void;
 	getTotalRound(): number;

--- a/packages/contracts/source/contracts/state/store.ts
+++ b/packages/contracts/source/contracts/state/store.ts
@@ -4,7 +4,7 @@ export interface Store extends CommitHandler {
 	getGenesisCommit(): Commit;
 	setGenesisCommit(block: Commit): void;
 
-	getLastHeight(): number;
+	getHeight(): number;
 	getLastBlock(): Block;
 	setLastBlock(block: Block): void;
 

--- a/packages/contracts/source/contracts/transaction-pool/client.ts
+++ b/packages/contracts/source/contracts/transaction-pool/client.ts
@@ -2,7 +2,5 @@ import { CommitHandler, Transaction } from "../crypto/index.js";
 export interface Client extends CommitHandler {
 	setFailedTransactions(transactions: Transaction[]): void;
 	getTransactionBytes(): Promise<Buffer[]>;
-	listSnapshots(): Promise<number[]>;
-	importSnapshot(height: number): Promise<void>;
 	getStatus(): Promise<{ height: number; version: string }>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/client.ts
+++ b/packages/contracts/source/contracts/transaction-pool/client.ts
@@ -1,6 +1,5 @@
-import { CommitHandler, Transaction } from "../crypto/index.js";
+import { CommitHandler } from "../crypto/index.js";
 export interface Client extends CommitHandler {
-	setFailedTransactions(transactions: Transaction[]): void;
 	getTransactionBytes(): Promise<Buffer[]>;
 	getStatus(): Promise<{ height: number; version: string }>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -10,7 +10,6 @@ export interface Mempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(address: string, id: string): Promise<Transaction[]>;
-	removeForgedTransaction(address: string, id: string): Promise<Transaction[]>;
 	reAddTransactions(addresses: string[]): Promise<Transaction[]>;
 
 	fixInvalidStates(): Promise<Transaction[]>;

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -12,7 +12,5 @@ export interface Mempool {
 	removeTransaction(address: string, id: string): Promise<Transaction[]>;
 	reAddTransactions(addresses: string[]): Promise<Transaction[]>;
 
-	fixInvalidStates(): Promise<Transaction[]>;
-
 	flush(): void;
 }

--- a/packages/contracts/source/contracts/transaction-pool/mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/mempool.ts
@@ -11,6 +11,7 @@ export interface Mempool {
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(address: string, id: string): Promise<Transaction[]>;
 	removeForgedTransaction(address: string, id: string): Promise<Transaction[]>;
+	reAddTransactions(addresses: string[]): Promise<Transaction[]>;
 
 	fixInvalidStates(): Promise<Transaction[]>;
 

--- a/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
@@ -10,6 +10,7 @@ export interface SenderMempool {
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(id: string): Transaction[];
 	removeForgedTransaction(id: string): Transaction | undefined;
+	reAddTransactions(): Promise<Transaction[]>;
 }
 
 export type SenderMempoolFactory = (address: string) => Promise<SenderMempool>;

--- a/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-mempool.ts
@@ -9,7 +9,6 @@ export interface SenderMempool {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	removeTransaction(id: string): Transaction[];
-	removeForgedTransaction(id: string): Transaction | undefined;
 	reAddTransactions(): Promise<Transaction[]>;
 }
 

--- a/packages/contracts/source/contracts/transaction-pool/sender-state.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-state.ts
@@ -2,5 +2,6 @@ import { Transaction } from "../crypto/transactions.js";
 
 export interface SenderState {
 	configure(address: string): Promise<SenderState>;
+	reset(): Promise<void>;
 	apply(transaction: Transaction): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/sender-state.ts
+++ b/packages/contracts/source/contracts/transaction-pool/sender-state.ts
@@ -4,4 +4,5 @@ export interface SenderState {
 	configure(address: string): Promise<SenderState>;
 	reset(): Promise<void>;
 	apply(transaction: Transaction): Promise<void>;
+	revert(transaction: Transaction): void;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -5,6 +5,6 @@ export interface Service {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
-	commit(transactions: {transaction: Transaction, gasUsed: number}[], failedTransactionIds: string[]): Promise<void>;
+	commit(transactions: {transaction: Transaction, gasUsed: number}[]): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -1,10 +1,10 @@
-import { Block, Transaction } from "../crypto/index.js";
+import { Transaction } from "../crypto/index.js";
 
 export interface Service {
 	getPoolSize(): number;
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
-	commit(block: Block, failedTransactionIds: string[]): Promise<void>;
+	commit(transactions: {transaction: Transaction, gasUsed: number}[], failedTransactionIds: string[]): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/service.ts
+++ b/packages/contracts/source/contracts/transaction-pool/service.ts
@@ -5,6 +5,6 @@ export interface Service {
 
 	addTransaction(transaction: Transaction): Promise<void>;
 	reAddTransactions(): Promise<void>;
-	commit(transactions: {transaction: Transaction, gasUsed: number}[]): Promise<void>;
+	commit(sendersAddresses: string[]): Promise<void>;
 	flush(): Promise<void>;
 }

--- a/packages/contracts/source/contracts/transaction-pool/worker.ts
+++ b/packages/contracts/source/contracts/transaction-pool/worker.ts
@@ -1,4 +1,4 @@
-import { CommitHandler, Transaction } from "../crypto/index.js";
+import { CommitHandler } from "../crypto/index.js";
 import { EventListener } from "../kernel/index.js";
 import { EventCallback, Subprocess } from "../kernel/ipc.js";
 import { KeyValuePair } from "../types/index.js";
@@ -8,7 +8,7 @@ export interface WorkerFlags extends KeyValuePair {}
 export interface WorkerScriptHandler {
 	boot(flags: WorkerFlags): Promise<void>;
 	getTransactions(): Promise<string[]>;
-	commit(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[]): Promise<void>;
+	commit(height: number, transactions: {transaction: string, gasUsed: number}[]): Promise<void>;
 	setPeer(ip: string): Promise<void>;
 	forgetPeer(ip: string): Promise<void>;
 	start(): Promise<void>;
@@ -24,7 +24,6 @@ export type WorkerSubprocessFactory = () => WorkerSubprocess;
 export interface Worker extends Omit<WorkerScriptHandler, "commit" | "getTransactions">, CommitHandler, EventListener {
 	getQueueSize(): number;
 	kill(): Promise<number>;
-	setFailedTransactions(transactions: Transaction[]): void;
 	getTransactionBytes(): Promise<Buffer[]>;
 	registerEventHandler(event: string, callback: EventCallback<any>): void;
 }

--- a/packages/contracts/source/contracts/transaction-pool/worker.ts
+++ b/packages/contracts/source/contracts/transaction-pool/worker.ts
@@ -8,7 +8,7 @@ export interface WorkerFlags extends KeyValuePair {}
 export interface WorkerScriptHandler {
 	boot(flags: WorkerFlags): Promise<void>;
 	getTransactions(): Promise<string[]>;
-	commit(data: { block: string; failedTransactions: string[] }): Promise<void>;
+	commit(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[]): Promise<void>;
 	setPeer(ip: string): Promise<void>;
 	forgetPeer(ip: string): Promise<void>;
 	start(): Promise<void>;

--- a/packages/contracts/source/contracts/transaction-pool/worker.ts
+++ b/packages/contracts/source/contracts/transaction-pool/worker.ts
@@ -8,7 +8,7 @@ export interface WorkerFlags extends KeyValuePair {}
 export interface WorkerScriptHandler {
 	boot(flags: WorkerFlags): Promise<void>;
 	getTransactions(): Promise<string[]>;
-	commit(height: number, transactions: {transaction: string, gasUsed: number}[]): Promise<void>;
+	commit(height: number, sendersAddresses: string[]): Promise<void>;
 	setPeer(ip: string): Promise<void>;
 	forgetPeer(ip: string): Promise<void>;
 	start(): Promise<void>;

--- a/packages/crypto-config/source/configuration.ts
+++ b/packages/crypto-config/source/configuration.ts
@@ -1,5 +1,5 @@
-import { inject,injectable } from "@mainsail/container";
-import { Contracts, Events,Exceptions, Identifiers } from "@mainsail/contracts";
+import {injectable } from "@mainsail/container";
+import { Contracts,Exceptions } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 import deepmerge from "deepmerge";
 import clone from "lodash.clone";
@@ -7,12 +7,6 @@ import get from "lodash.get";
 import set from "lodash.set";
 @injectable()
 export class Configuration implements Contracts.Crypto.Configuration {
-	@inject(Identifiers.Services.EventDispatcher.Service)
-	private readonly events!: Contracts.Kernel.EventDispatcher;
-
-	@inject(Identifiers.Services.Log.Service)
-	private readonly logger!: Contracts.Kernel.Logger;
-
 	#config: Contracts.Crypto.NetworkConfig | undefined;
 	#milestone: { data: Contracts.Crypto.Milestone; index: number } | undefined;
 	#milestones: Contracts.Crypto.Milestone[] | undefined;
@@ -69,12 +63,6 @@ export class Configuration implements Contracts.Crypto.Configuration {
 
 	public setHeight(value: number): void {
 		this.#height = value;
-
-		if (this.isNewMilestone()) {
-			this.logger.notice(`Milestone change: ${JSON.stringify(this.getMilestoneDiff())}`);
-
-			void this.events.dispatch(Events.CryptoEvent.MilestoneChanged);
-		}
 	}
 
 	public getHeight(): number {

--- a/packages/crypto-config/source/configuration.ts
+++ b/packages/crypto-config/source/configuration.ts
@@ -1,5 +1,5 @@
-import {injectable } from "@mainsail/container";
-import { Contracts,Exceptions } from "@mainsail/contracts";
+import { injectable } from "@mainsail/container";
+import { Contracts, Exceptions } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 import deepmerge from "deepmerge";
 import clone from "lodash.clone";

--- a/packages/crypto-config/source/configuration.ts
+++ b/packages/crypto-config/source/configuration.ts
@@ -71,8 +71,6 @@ export class Configuration implements Contracts.Crypto.Configuration {
 		this.#height = value;
 
 		if (this.isNewMilestone()) {
-			console.trace();
-
 			this.logger.notice(`Milestone change: ${JSON.stringify(this.getMilestoneDiff())}`);
 
 			void this.events.dispatch(Events.CryptoEvent.MilestoneChanged);

--- a/packages/evm-api-worker/source/handlers/commit.ts
+++ b/packages/evm-api-worker/source/handlers/commit.ts
@@ -6,14 +6,10 @@ export class CommitHandler {
 	@inject(Identifiers.State.Store)
 	protected readonly stateStore!: Contracts.State.Store;
 
-	@inject(Identifiers.Cryptography.Configuration)
-	private readonly configuration!: Contracts.Crypto.Configuration;
-
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
 	public async handle(height: number): Promise<void> {
 		this.stateStore.setHeight(height);
-		this.configuration.setHeight(height + 1);
 	}
 }

--- a/packages/evm-api-worker/source/handlers/commit.ts
+++ b/packages/evm-api-worker/source/handlers/commit.ts
@@ -9,19 +9,11 @@ export class CommitHandler {
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration!: Contracts.Crypto.Configuration;
 
-	@inject(Identifiers.Cryptography.Block.Factory)
-	private readonly blockFactory!: Contracts.Crypto.BlockFactory;
-
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
-	public async handle(data: { block: string }): Promise<void> {
-		try {
-			const block = await this.blockFactory.fromHex(data.block);
-			this.stateStore.setLastBlock(block);
-			this.configuration.setHeight(block.data.height + 1);
-		} catch (error) {
-			throw new Error(`Failed to commit block: ${error.message}`);
-		}
+	public async handle(height: number): Promise<void> {
+		this.stateStore.setHeight(height);
+		this.configuration.setHeight(height + 1);
 	}
 }

--- a/packages/evm-api-worker/source/handlers/commit.ts
+++ b/packages/evm-api-worker/source/handlers/commit.ts
@@ -17,11 +17,9 @@ export class CommitHandler {
 
 	public async handle(data: { block: string }): Promise<void> {
 		try {
-			// TODO: Set height
-			this.configuration.setHeight(1);
-
 			const block = await this.blockFactory.fromHex(data.block);
 			this.stateStore.setLastBlock(block);
+			this.configuration.setHeight(block.data.height + 1);
 		} catch (error) {
 			throw new Error(`Failed to commit block: ${error.message}`);
 		}

--- a/packages/evm-api-worker/source/worker-handler.ts
+++ b/packages/evm-api-worker/source/worker-handler.ts
@@ -24,7 +24,7 @@ export class WorkerScriptHandler implements Contracts.Evm.WorkerScriptHandler {
 		await this.#app.resolve(SetPeerCountHandler).handle(peerCount);
 	}
 
-	public async commit(data: { block: string; failedTransactions: string[] }): Promise<void> {
-		await this.#app.resolve(CommitHandler).handle(data);
+	public async commit(height: number): Promise<void> {
+		await this.#app.resolve(CommitHandler).handle(height);
 	}
 }

--- a/packages/evm-api-worker/source/worker.ts
+++ b/packages/evm-api-worker/source/worker.ts
@@ -50,9 +50,7 @@ export class Worker implements Contracts.Evm.Worker {
 	}
 
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
-		await this.ipcSubprocess.sendRequest("commit", {
-			block: unit.getBlock().serialized,
-		});
+		await this.ipcSubprocess.sendRequest("commit", unit.height);
 	}
 
 	public async setPeerCount(peerCount: number): Promise<void> {
@@ -63,7 +61,7 @@ export class Worker implements Contracts.Evm.Worker {
 		await this.ipcSubprocess.sendRequest("importSnapshot", height);
 	}
 
-	public async commit(data: { block: string }): Promise<void> {
-		await this.ipcSubprocess.sendRequest("commit", data);
+	public async commit(height: number): Promise<void> {
+		await this.ipcSubprocess.sendRequest("commit", height);
 	}
 }

--- a/packages/evm-api-worker/source/worker.ts
+++ b/packages/evm-api-worker/source/worker.ts
@@ -56,8 +56,4 @@ export class Worker implements Contracts.Evm.Worker {
 	public async setPeerCount(peerCount: number): Promise<void> {
 		await this.ipcSubprocess.sendRequest("setPeerCount", peerCount);
 	}
-
-	public async importSnapshot(height: number): Promise<void> {
-		await this.ipcSubprocess.sendRequest("importSnapshot", height);
-	}
 }

--- a/packages/evm-api-worker/source/worker.ts
+++ b/packages/evm-api-worker/source/worker.ts
@@ -60,8 +60,4 @@ export class Worker implements Contracts.Evm.Worker {
 	public async importSnapshot(height: number): Promise<void> {
 		await this.ipcSubprocess.sendRequest("importSnapshot", height);
 	}
-
-	public async commit(height: number): Promise<void> {
-		await this.ipcSubprocess.sendRequest("commit", height);
-	}
 }

--- a/packages/evm-consensus/source/validator-set.ts
+++ b/packages/evm-consensus/source/validator-set.ts
@@ -100,9 +100,6 @@ export class ValidatorSet implements Contracts.ValidatorSet.Service {
 			validatorWallets.push(validatorWallet);
 		}
 
-		console.log("Getting active validators", validatorWallets);
-		console.log(validatorWallets.map((v) => v));
-
 		return validatorWallets;
 	}
 }

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -94,7 +94,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 	#getLastRequestedBlockHeight(): number {
 		const latestJob = this.#downloadJobs.at(-1);
 		if (latestJob === undefined) {
-			return this.stateStore.getLastHeight();
+			return this.stateStore.getHeight();
 		}
 
 		return latestJob.heightTo;
@@ -213,7 +213,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 	}
 
 	#handleMissingBlocks(job: DownloadJob): void {
-		const configuration = this.configuration.getMilestone(this.stateStore.getLastHeight() + 1);
+		const configuration = this.configuration.getMilestone(this.stateStore.getHeight() + 1);
 
 		const size = job.blocks.reduce((size, block) => size + block.length, 0);
 
@@ -244,7 +244,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		const newJob: DownloadJob = {
 			blocks: [],
-			heightFrom: index === 0 ? this.stateStore.getLastHeight() + 1 : job.heightFrom,
+			heightFrom: index === 0 ? this.stateStore.getHeight() + 1 : job.heightFrom,
 			heightTo: this.#downloadJobs.length === 1 ? this.#calculateHeightTo(peer) : job.heightTo,
 			peer,
 			peerHeight: peer.header.height - 1,

--- a/packages/p2p/source/downloader/message-downloader.ts
+++ b/packages/p2p/source/downloader/message-downloader.ts
@@ -70,8 +70,8 @@ export class MessageDownloader implements Contracts.P2P.Downloader {
 	public initialize(): void {
 		this.events.listen(Events.BlockEvent.Applied, {
 			handle: () => {
-				this.#downloadsByHeight.delete(this.stateStore.getLastHeight());
-				this.#fullDownloadsByHeight.delete(this.stateStore.getLastHeight());
+				this.#downloadsByHeight.delete(this.stateStore.getHeight());
+				this.#fullDownloadsByHeight.delete(this.stateStore.getHeight());
 			},
 		});
 	}

--- a/packages/p2p/source/socket-server/controllers/get-api-nodes.test.ts
+++ b/packages/p2p/source/socket-server/controllers/get-api-nodes.test.ts
@@ -11,7 +11,7 @@ describe<{
 	const database = { findCommitBuffers: () => {} };
 	const store = {
 		getLastDownloadedBlock: () => {},
-		getLastHeight: () => {},
+		getHeight: () => {},
 	};
 
 	beforeEach((context) => {

--- a/packages/p2p/source/socket-server/controllers/get-blocks.test.ts
+++ b/packages/p2p/source/socket-server/controllers/get-blocks.test.ts
@@ -11,7 +11,7 @@ describe<{
 	const database = { findCommitBuffers: () => {} };
 	const store = {
 		getLastDownloadedBlock: () => {},
-		getLastHeight: () => {},
+		getHeight: () => {},
 	};
 
 	beforeEach((context) => {

--- a/packages/p2p/source/socket-server/controllers/get-blocks.ts
+++ b/packages/p2p/source/socket-server/controllers/get-blocks.ts
@@ -24,7 +24,7 @@ export class GetBlocksController implements Contracts.P2P.Controller {
 		const requestBlockHeight: number = request.payload.fromHeight;
 		const requestBlockLimit: number = request.payload.limit;
 
-		const lastHeight: number = this.stateStore.getLastHeight();
+		const lastHeight: number = this.stateStore.getHeight();
 		if (requestBlockHeight > lastHeight) {
 			return { blocks: [] };
 		}

--- a/packages/p2p/source/socket-server/utils/get-headers.test.ts
+++ b/packages/p2p/source/socket-server/utils/get-headers.test.ts
@@ -7,7 +7,7 @@ describe("getHeaders", ({ it, assert }) => {
 	let port = 4007;
 	const version = "3.0.9";
 	const height = 387;
-	const store = { getLastHeight: () => height, isStarted: () => true };
+	const store = { getHeight: () => height, isStarted: () => true };
 	const appGet = {
 		[Identifiers.State.Store]: store,
 	};

--- a/packages/p2p/source/socket-server/utils/get-headers.ts
+++ b/packages/p2p/source/socket-server/utils/get-headers.ts
@@ -16,7 +16,7 @@ export const getHeaders = (app: Contracts.Kernel.Application) => {
 		version: app.version(),
 	};
 
-	headers.height = app.get<Contracts.State.Store>(Identifiers.State.Store).getLastHeight();
+	headers.height = app.get<Contracts.State.Store>(Identifiers.State.Store).getHeight();
 
 	return headers;
 };

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -151,12 +151,6 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 	#setConfigurationHeight(unit: Contracts.Processor.ProcessableUnit): void {
 		// NOTE: The configuration is always set to the next height. To height which is going to be proposed.
 		this.configuration.setHeight(unit.height + 1);
-
-		if (this.configuration.isNewMilestone()) {
-			this.logger.notice(`Milestone change: ${JSON.stringify(this.configuration.getMilestoneDiff())}`);
-
-			void this.#emit(Events.CryptoEvent.MilestoneChanged);
-		}
 	}
 
 	#consumeGas(

--- a/packages/processor/source/block-processor.ts
+++ b/packages/processor/source/block-processor.ts
@@ -104,7 +104,6 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 			}
 		}
 
-		this.#setConfigurationHeight(unit);
 		await this.evm.onCommit(unit);
 		await this.validatorSet.onCommit(unit);
 		await this.proposerSelector.onCommit(unit);
@@ -146,11 +145,6 @@ export class BlockProcessor implements Contracts.Processor.BlockProcessor {
 				);
 			}
 		}
-	}
-
-	#setConfigurationHeight(unit: Contracts.Processor.ProcessableUnit): void {
-		// NOTE: The configuration is always set to the next height. To height which is going to be proposed.
-		this.configuration.setHeight(unit.height + 1);
 	}
 
 	#consumeGas(

--- a/packages/state/source/store.test.ts
+++ b/packages/state/source/store.test.ts
@@ -7,11 +7,16 @@ describe<{
 	sandbox: Sandbox;
 	store: Store;
 	logger: any;
+	eventDispatcher: any;
 	cryptoConfiguration: any;
 }>("Store", ({ it, beforeEach, assert, spy, stub }) => {
 	beforeEach(async (context) => {
 		context.logger = {
 			notice: () => {},
+		};
+
+		context.eventDispatcher = {
+			dispatch: () => {},
 		};
 
 		context.cryptoConfiguration = {
@@ -23,6 +28,7 @@ describe<{
 		context.sandbox = new Sandbox();
 
 		context.sandbox.app.bind(Identifiers.Services.Log.Service).toConstantValue(context.logger);
+		context.sandbox.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue(context.eventDispatcher);
 		context.sandbox.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(context.cryptoConfiguration);
 		context.sandbox.app.bind(Identifiers.ServiceProvider.Configuration).toConstantValue({
 			getRequired: () => false, //snapshots.skipUnknownAttributes
@@ -32,7 +38,7 @@ describe<{
 	});
 
 	it("#initialize - should set height and totalRound", ({ store }) => {
-		assert.equal(store.getLastHeight(), 0);
+		assert.equal(store.getHeight(), 0);
 		assert.equal(store.getTotalRound(), 0);
 	});
 

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -1,4 +1,4 @@
-import { inject,injectable } from "@mainsail/container";
+import { inject, injectable } from "@mainsail/container";
 import { Contracts, Events, Identifiers } from "@mainsail/contracts";
 import { Utils } from "@mainsail/kernel";
 

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -29,6 +29,11 @@ export class Store implements Contracts.State.Store {
 		return this.#lastBlock;
 	}
 
+	// Set height is used on workers, because last block is not transferred
+	public setHeight(height: number): void {
+		this.#height = height;
+	}
+
 	public getHeight(): number {
 		return this.#height;
 	}

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -9,23 +9,24 @@ export class Store implements Contracts.State.Store {
 	#height = 0;
 	#totalRound = 0;
 
+	public setGenesisCommit(block: Contracts.Crypto.Commit): void {
+		this.#genesisBlock = block;
+	}
+
 	public getGenesisCommit(): Contracts.Crypto.Commit {
 		Utils.assert.defined<Contracts.Crypto.Commit>(this.#genesisBlock);
 
 		return this.#genesisBlock;
 	}
 
-	public setGenesisCommit(block: Contracts.Crypto.Commit): void {
-		this.#genesisBlock = block;
+	public setLastBlock(block: Contracts.Crypto.Block): void {
+		this.#height = block.data.height;
+		this.#lastBlock = block;
 	}
 
 	public getLastBlock(): Contracts.Crypto.Block {
 		Utils.assert.defined<Contracts.Crypto.Block>(this.#lastBlock);
 		return this.#lastBlock;
-	}
-
-	public setLastBlock(block: Contracts.Crypto.Block): void {
-		this.#lastBlock = block;
 	}
 
 	public getLastHeight(): number {
@@ -43,7 +44,6 @@ export class Store implements Contracts.State.Store {
 
 	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		this.setLastBlock(unit.getBlock());
-		this.#height = unit.height;
 		this.#totalRound += unit.round + 1;
 	}
 }

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -29,7 +29,7 @@ export class Store implements Contracts.State.Store {
 		return this.#lastBlock;
 	}
 
-	public getLastHeight(): number {
+	public getHeight(): number {
 		return this.#height;
 	}
 

--- a/packages/state/source/store.ts
+++ b/packages/state/source/store.ts
@@ -33,9 +33,8 @@ export class Store implements Contracts.State.Store {
 		return this.#height;
 	}
 
-	public setTotalRoundAndHeight(totalRound: number, height: number): void {
+	public setTotalRound(totalRound: number): void {
 		this.#totalRound = totalRound;
-		this.#height = height;
 	}
 
 	public getTotalRound(): number {

--- a/packages/test-framework/source/utils/generic.ts
+++ b/packages/test-framework/source/utils/generic.ts
@@ -13,7 +13,7 @@ export const injectMilestone = (
 	});
 
 export const getLastHeight = (app: Contracts.Kernel.Application): number =>
-	app.get<Contracts.State.Store>(Identifiers.State.Store).getLastHeight();
+	app.get<Contracts.State.Store>(Identifiers.State.Store).getHeight();
 
 export const getWalletNonce = async (app: Contracts.Kernel.Application, publicKey: string): Promise<BigNumber> =>
 	BigNumber.ZERO;

--- a/packages/test-transaction-builders/source/utils.bkp
+++ b/packages/test-transaction-builders/source/utils.bkp
@@ -150,12 +150,12 @@ export const addTransactionsToPool = async (
 export const waitBlock = async (sandbox: Sandbox, count: number = 1) => {
 	const state = sandbox.app.get<Contracts.State.Service>(Identifiers.State.Service);
 
-	let currentHeight = state.getStore().getLastHeight();
+	let currentHeight = state.getStore().getHeight();
 	const targetHeight = currentHeight + count;
 
 	do {
 		await sleep(200);
-		currentHeight = state.getStore().getLastHeight();
+		currentHeight = state.getStore().getHeight();
 	} while (currentHeight < targetHeight);
 };
 

--- a/packages/transaction-pool-service/source/expiration-service.test.ts
+++ b/packages/transaction-pool-service/source/expiration-service.test.ts
@@ -15,7 +15,7 @@ describe<{
 }>("ExpirationService", ({ it, assert, stub, beforeAll }) => {
 	beforeAll((context) => {
 		context.configuration = { getRequired: () => {} };
-		context.store = { getLastHeight: () => {} };
+		context.store = { getHeight: () => {} };
 		context.app = { get: () => {} };
 
 		context.container = new Container();
@@ -60,7 +60,7 @@ describe<{
 	});
 
 	it("isExpired - should return true if transaction expired when checking v2 transaction with expiration field", async (context) => {
-		stub(context.store, "getLastHeight").returnValue(100);
+		stub(context.store, "getHeight").returnValue(100);
 
 		const transaction = { data: { expiration: 50 } } as Contracts.Crypto.Transaction;
 		const expirationService = context.container.resolve(ExpirationService);
@@ -70,7 +70,7 @@ describe<{
 	});
 
 	it("isExpired - should return false if transaction not expired when checking v2 transaction with expiration field", async (context) => {
-		stub(context.store, "getLastHeight").returnValue(100);
+		stub(context.store, "getHeight").returnValue(100);
 
 		const transaction = { data: { expiration: 150 } } as Contracts.Crypto.Transaction;
 		const expirationService = context.container.resolve(ExpirationService);
@@ -80,7 +80,7 @@ describe<{
 	});
 
 	it("isExpired - should return true if transaction expires in next block when checking v2 transaciton with expiration field", async (context) => {
-		stub(context.store, "getLastHeight").returnValue(100);
+		stub(context.store, "getHeight").returnValue(100);
 
 		const transaction = { data: { expiration: 101 } } as Contracts.Crypto.Transaction;
 		const expirationService = context.container.resolve(ExpirationService);

--- a/packages/transaction-pool-service/source/expiration-service.ts
+++ b/packages/transaction-pool-service/source/expiration-service.ts
@@ -16,7 +16,7 @@ export class ExpirationService implements Contracts.TransactionPool.ExpirationSe
 
 	public async isExpired(transaction: Contracts.Crypto.Transaction): Promise<boolean> {
 		if (this.canExpire(transaction)) {
-			return (await this.getExpirationHeight(transaction)) <= this.stateStore.getLastHeight() + 1;
+			return (await this.getExpirationHeight(transaction)) <= this.stateStore.getHeight() + 1;
 		}
 
 		return false;

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -14,7 +14,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 	private readonly addressFactory!: Contracts.Crypto.AddressFactory;
 
 	readonly #senderMempools = new Map<string, Contracts.TransactionPool.SenderMempool>();
-	readonly #brokenSenders = new Set<string>();
 
 	public getSize(): number {
 		return [...this.#senderMempools.values()].reduce((sum, p) => sum + p.getSize(), 0);
@@ -36,37 +35,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		return this.#senderMempools.values();
 	}
 
-	public async fixInvalidStates(): Promise<Contracts.Crypto.Transaction[]> {
-		const removedTransactions: Contracts.Crypto.Transaction[] = [];
-
-		for (const address of this.#brokenSenders) {
-			const transactionsForReadd = [...this.getSenderMempool(address).getFromEarliest()];
-
-			const newSenderMempool = await this.createSenderMempool.call(this, address);
-
-			for (let index = 0; index < transactionsForReadd.length; index++) {
-				const transaction = transactionsForReadd[index];
-
-				try {
-					await newSenderMempool.addTransaction(transaction);
-				} catch {
-					transactionsForReadd.slice(index).map((tx) => {
-						removedTransactions.push(tx);
-					});
-					break;
-				}
-			}
-
-			this.#senderMempools.delete(address);
-			if (newSenderMempool.getSize()) {
-				this.#senderMempools.set(address, newSenderMempool);
-			}
-		}
-
-		this.#brokenSenders.clear();
-		return removedTransactions;
-	}
-
 	public async addTransaction(transaction: Contracts.Crypto.Transaction): Promise<void> {
 		const address = await this.addressFactory.fromPublicKey(transaction.data.senderPublicKey);
 
@@ -80,7 +48,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		try {
 			await senderMempool.addTransaction(transaction);
 		} finally {
-			await this.#removeDisposableMempool(address);
+			this.#removeDisposableMempool(address);
 		}
 	}
 
@@ -91,10 +59,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		}
 
 		const transactions = senderMempool.removeTransaction(id);
-
-		if (transactions.length > 0 && !(await this.#removeDisposableMempool(address))) {
-			this.#brokenSenders.add(address);
-		}
+		this.#removeDisposableMempool(address)
 
 		return transactions;
 	}
@@ -118,7 +83,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		this.#senderMempools.clear();
 	}
 
-	async #removeDisposableMempool(address: string): Promise<boolean> {
+	#removeDisposableMempool(address: string): boolean {
 		const senderMempool = this.#senderMempools.get(address);
 
 		if (senderMempool && senderMempool.isDisposable()) {

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -117,6 +117,21 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		return [transaction];
 	}
 
+	public async reAddTransactions(addresses: string[]): Promise<Contracts.Crypto.Transaction[]> {
+		const removedTransactions: Contracts.Crypto.Transaction[] = [];
+
+		for (const address of addresses) {
+			const senderMempool = this.#senderMempools.get(address);
+			if (!senderMempool) {
+				continue;
+			}
+
+			removedTransactions.push(...await senderMempool.reAddTransactions());
+		}
+
+		return removedTransactions;
+	}
+
 	public flush(): void {
 		this.#senderMempools.clear();
 	}

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -59,7 +59,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		}
 
 		const transactions = senderMempool.removeTransaction(id);
-		this.#removeDisposableMempool(address)
+		this.#removeDisposableMempool(address);
 
 		return transactions;
 	}
@@ -73,7 +73,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 				continue;
 			}
 
-			removedTransactions.push(...await senderMempool.reAddTransactions());
+			removedTransactions.push(...(await senderMempool.reAddTransactions()));
 		}
 
 		return removedTransactions;

--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -99,24 +99,6 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		return transactions;
 	}
 
-	public async removeForgedTransaction(address: string, id: string): Promise<Contracts.Crypto.Transaction[]> {
-		const senderMempool = this.#senderMempools.get(address);
-		if (!senderMempool) {
-			return [];
-		}
-
-		const transaction = senderMempool.removeForgedTransaction(id);
-
-		if (!transaction) {
-			this.#brokenSenders.add(address);
-			return [];
-		}
-
-		await this.#removeDisposableMempool(address);
-
-		return [transaction];
-	}
-
 	public async reAddTransactions(addresses: string[]): Promise<Contracts.Crypto.Transaction[]> {
 		const removedTransactions: Contracts.Crypto.Transaction[] = [];
 

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -78,7 +78,7 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		}
 		const transactions = this.#transactions.splice(index, this.#transactions.length - index).reverse();
 
-		for(const transaction of transactions) {
+		for (const transaction of transactions) {
 			this.senderState.revert(transaction);
 		}
 
@@ -94,7 +94,7 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		for (const transaction of transactions) {
 			try {
 				await this.addTransaction(transaction);
-			}  catch {
+			} catch {
 				removedTransactions.push(transaction);
 			}
 		}

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -76,7 +76,13 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		if (index === -1) {
 			return [];
 		}
-		return this.#transactions.splice(index, this.#transactions.length - index).reverse();
+		const transactions = this.#transactions.splice(index, this.#transactions.length - index).reverse();
+
+		for(const transaction of transactions) {
+			this.senderState.revert(transaction);
+		}
+
+		return transactions;
 	}
 
 	public async reAddTransactions(): Promise<Contracts.Crypto.Transaction[]> {

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -79,18 +79,6 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 		return this.#transactions.splice(index, this.#transactions.length - index).reverse();
 	}
 
-	public removeForgedTransaction(id: string): Contracts.Crypto.Transaction | undefined {
-		if (this.#transactions.length === 0) {
-			throw new Error("No transactions in sender mempool");
-		}
-
-		if (this.#transactions[0].id === id) {
-			return this.#transactions.shift();
-		}
-
-		return undefined;
-	}
-
 	public async reAddTransactions(): Promise<Contracts.Crypto.Transaction[]> {
 		await this.senderState.reset();
 

--- a/packages/transaction-pool-service/source/sender-mempool.ts
+++ b/packages/transaction-pool-service/source/sender-mempool.ts
@@ -90,4 +90,21 @@ export class SenderMempool implements Contracts.TransactionPool.SenderMempool {
 
 		return undefined;
 	}
+
+	public async reAddTransactions(): Promise<Contracts.Crypto.Transaction[]> {
+		await this.senderState.reset();
+
+		const removedTransactions: Contracts.Crypto.Transaction[] = [];
+
+		const transactions = this.#transactions.splice(0, this.#transactions.length);
+		for (const transaction of transactions) {
+			try {
+				await this.addTransaction(transaction);
+			}  catch {
+				removedTransactions.push(transaction);
+			}
+		}
+
+		return removedTransactions;
+	}
 }

--- a/packages/transaction-pool-service/source/sender-state.ts
+++ b/packages/transaction-pool-service/source/sender-state.ts
@@ -35,8 +35,11 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 
 	public async configure(address: string): Promise<SenderState> {
 		this.#wallet = await this.app.resolve(Wallets.Wallet).init(address);
-
 		return this;
+	}
+
+	public async reset(): Promise<void> {
+		this.#wallet = await this.app.resolve(Wallets.Wallet).init(this.#wallet.getAddress());
 	}
 
 	public async apply(transaction: Contracts.Crypto.Transaction): Promise<void> {

--- a/packages/transaction-pool-service/source/sender-state.ts
+++ b/packages/transaction-pool-service/source/sender-state.ts
@@ -91,4 +91,9 @@ export class SenderState implements Contracts.TransactionPool.SenderState {
 			throw new Exceptions.TransactionFailedToVerifyError(transaction);
 		}
 	}
+
+	public revert(transaction: Contracts.Crypto.Transaction): void {
+		this.#wallet.decreaseNonce();
+		this.#wallet.increaseBalance(transaction.data.amount.plus(this.gasFeeCalculator.calculate(transaction)));
+	}
 }

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -108,7 +108,7 @@ export class Service implements Contracts.TransactionPool.Service {
 			}
 
 			this.storage.addTransaction({
-				height: this.stateStore.getLastHeight(),
+				height: this.stateStore.getHeight(),
 				id: transaction.id,
 				senderPublicKey: transaction.data.senderPublicKey,
 				serialized: transaction.serialized,
@@ -149,7 +149,7 @@ export class Service implements Contracts.TransactionPool.Service {
 			let previouslyStoredFailures = 0;
 
 			const maxTransactionAge: number = this.pluginConfiguration.getRequired<number>("maxTransactionAge");
-			const lastHeight: number = this.stateStore.getLastHeight();
+			const lastHeight: number = this.stateStore.getHeight();
 			const expiredHeight: number = lastHeight - maxTransactionAge;
 
 			for (const { height, id, serialized } of this.storage.getAllTransactions()) {
@@ -209,7 +209,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 	async #removeOldTransactions(): Promise<void> {
 		const maxTransactionAge: number = this.pluginConfiguration.getRequired<number>("maxTransactionAge");
-		const lastHeight: number = this.stateStore.getLastHeight();
+		const lastHeight: number = this.stateStore.getHeight();
 		const expiredHeight: number = lastHeight - maxTransactionAge;
 
 		for (const { senderPublicKey, id } of this.storage.getOldTransactions(expiredHeight)) {

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -184,7 +184,6 @@ export class Service implements Contracts.TransactionPool.Service {
 		await this.#removeOldTransactions();
 		await this.#removeExpiredTransactions();
 		await this.#removeLowestPriorityTransactions();
-		await this.#fixInvalidStates();
 	}
 
 	async #removeOldTransactions(): Promise<void> {
@@ -251,17 +250,6 @@ export class Service implements Contracts.TransactionPool.Service {
 		}
 	}
 
-	async #fixInvalidStates(): Promise<void> {
-		const transactions = await this.mempool.fixInvalidStates();
-
-		for (const transaction of transactions) {
-			this.storage.removeTransaction(transaction.id);
-			this.logger.debug(`Removed invalid tx ${transaction.id}`);
-
-			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, transaction.data);
-		}
-	}
-
 	async #addTransactionToMempool(transaction: Contracts.Crypto.Transaction): Promise<void> {
 		const maxTransactionsInPool: number = this.pluginConfiguration.getRequired<number>("maxTransactionsInPool");
 
@@ -276,7 +264,6 @@ export class Service implements Contracts.TransactionPool.Service {
 			}
 
 			await this.#removeLowestPriorityTransaction();
-			await this.#fixInvalidStates();
 		}
 
 		await this.mempool.addTransaction(transaction);

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -72,8 +72,7 @@ export class Service implements Contracts.TransactionPool.Service {
 				void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, transaction.data);
 			}
 
-			// TODO: ENABLE
-			// await this.#cleanUp();
+			await this.#cleanUp();
 		});
 	}
 

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -68,7 +68,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 			for (const transaction of removedTransactions) {
 				this.storage.removeTransaction(transaction.id);
-				this.logger.debug(`Removed forged tx ${transaction.id}`);
+				this.logger.debug(`Removed tx ${transaction.id}`);
 				void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, transaction.data);
 			}
 

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -65,7 +65,6 @@ export class Service implements Contracts.TransactionPool.Service {
 
 			const removedTransactions = await this.mempool.reAddTransactions(sendersAddresses);
 
-
 			for (const transaction of removedTransactions) {
 				this.storage.removeTransaction(transaction.id);
 				this.logger.debug(`Removed tx ${transaction.id}`);

--- a/packages/transaction-pool-worker/source/handlers/commit.ts
+++ b/packages/transaction-pool-worker/source/handlers/commit.ts
@@ -20,11 +20,11 @@ export class CommitHandler {
 
 	public async handle(data: { block: string; failedTransactions: string[] }): Promise<void> {
 		try {
-			// TODO: Pass height
-			this.configuration.setHeight(1);
 
 			const block = await this.blockFactory.fromHex(data.block);
 			this.stateStore.setLastBlock(block);
+			this.configuration.setHeight(block.data.height + 1);
+
 
 			await this.transactionPoolService.commit(block, data.failedTransactions);
 

--- a/packages/transaction-pool-worker/source/handlers/commit.ts
+++ b/packages/transaction-pool-worker/source/handlers/commit.ts
@@ -15,7 +15,7 @@ export class CommitHandler {
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
-	public async handle(height: number, sendersAddresses: string[] ): Promise<void> {
+	public async handle(height: number, sendersAddresses: string[]): Promise<void> {
 		try {
 			this.stateStore.setHeight(height);
 

--- a/packages/transaction-pool-worker/source/handlers/commit.ts
+++ b/packages/transaction-pool-worker/source/handlers/commit.ts
@@ -18,7 +18,6 @@ export class CommitHandler {
 	public async handle(height: number, sendersAddresses: string[] ): Promise<void> {
 		try {
 			this.stateStore.setHeight(height);
-			this.configuration.setHeight(height + 1);
 
 			if (this.configuration.isNewMilestone()) {
 				void this.transactionPoolService.reAddTransactions();

--- a/packages/transaction-pool-worker/source/handlers/commit.ts
+++ b/packages/transaction-pool-worker/source/handlers/commit.ts
@@ -18,7 +18,7 @@ export class CommitHandler {
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
-	public async handle(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[] ): Promise<void> {
+	public async handle(height: number, transactions: {transaction: string, gasUsed: number}[] ): Promise<void> {
 		try {
 
 			this.stateStore.setHeight(height);
@@ -27,7 +27,7 @@ export class CommitHandler {
 			await this.transactionPoolService.commit(await Promise.all(transactions.map(async (data) => ({
 					gasUsed: data.gasUsed,
 					transaction: await this.transactionFactory.fromHex(data.transaction),
-				}))), failedTransactions);
+				}))));
 
 			if (this.configuration.isNewMilestone()) {
 				void this.transactionPoolService.reAddTransactions();

--- a/packages/transaction-pool-worker/source/handlers/commit.ts
+++ b/packages/transaction-pool-worker/source/handlers/commit.ts
@@ -12,21 +12,17 @@ export class CommitHandler {
 	@inject(Identifiers.TransactionPool.Service)
 	private readonly transactionPoolService!: Contracts.TransactionPool.Service;
 
-	@inject(Identifiers.Cryptography.Block.Factory)
-	private readonly blockFactory!: Contracts.Crypto.BlockFactory;
-
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
-	public async handle(data: { block: string; failedTransactions: string[] }): Promise<void> {
+	public async handle(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[] ): Promise<void> {
 		try {
 
-			const block = await this.blockFactory.fromHex(data.block);
-			this.stateStore.setLastBlock(block);
-			this.configuration.setHeight(block.data.height + 1);
+			this.stateStore.setHeight(height);
+			this.configuration.setHeight(height + 1);
 
 
-			await this.transactionPoolService.commit(block, data.failedTransactions);
+			// await this.transactionPoolService.commit(block, data.failedTransactions);
 
 			if (this.configuration.isNewMilestone()) {
 				void this.transactionPoolService.reAddTransactions();

--- a/packages/transaction-pool-worker/source/worker-handler.ts
+++ b/packages/transaction-pool-worker/source/worker-handler.ts
@@ -31,8 +31,8 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
 		await this.#app.resolve(StartHandler).handle();
 	}
 
-	public async commit(height: number, transactions: {transaction: string, gasUsed: number}[] ): Promise<void> {
-		await this.#app.resolve(CommitHandler).handle(height, transactions);
+	public async commit(height: number, sendersAddresses: string[]): Promise<void> {
+		await this.#app.resolve(CommitHandler).handle(height, sendersAddresses);
 	}
 
 	public async getTransactions(): Promise<string[]> {

--- a/packages/transaction-pool-worker/source/worker-handler.ts
+++ b/packages/transaction-pool-worker/source/worker-handler.ts
@@ -31,8 +31,8 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
 		await this.#app.resolve(StartHandler).handle();
 	}
 
-	public async commit(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[] ): Promise<void> {
-		await this.#app.resolve(CommitHandler).handle(height, transactions, failedTransactions);
+	public async commit(height: number, transactions: {transaction: string, gasUsed: number}[] ): Promise<void> {
+		await this.#app.resolve(CommitHandler).handle(height, transactions);
 	}
 
 	public async getTransactions(): Promise<string[]> {

--- a/packages/transaction-pool-worker/source/worker-handler.ts
+++ b/packages/transaction-pool-worker/source/worker-handler.ts
@@ -31,8 +31,8 @@ export class WorkerScriptHandler implements Contracts.TransactionPool.WorkerScri
 		await this.#app.resolve(StartHandler).handle();
 	}
 
-	public async commit(data: { block: string; failedTransactions: string[] }): Promise<void> {
-		await this.#app.resolve(CommitHandler).handle(data);
+	public async commit(height: number, transactions: {transaction: string, gasUsed: number}[], failedTransactions: string[] ): Promise<void> {
+		await this.#app.resolve(CommitHandler).handle(height, transactions, failedTransactions);
 	}
 
 	public async getTransactions(): Promise<string[]> {

--- a/packages/transaction-pool-worker/source/worker.ts
+++ b/packages/transaction-pool-worker/source/worker.ts
@@ -55,14 +55,15 @@ export class Worker implements Contracts.TransactionPool.Worker {
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		const receipts = unit.getProcessorResult().receipts;
 
-		await this.ipcSubprocess.sendRequest("commit", {
-			failedTransactions: this.#failedTransactions.map((transaction) => transaction.id),
-			height: unit.height,
-			transactions: unit.getBlock().transactions.map((transaction) => ({
+		await this.ipcSubprocess.sendRequest("commit",
+			unit.height,
+			unit.getBlock().transactions.map((transaction) => ({
 				gasUsed:  Number(receipts.get(transaction.id)!.gasUsed),
 				transaction: transaction.serialized.toString("hex"),
 			})),
-		});
+			this.#failedTransactions.map((transaction) => transaction.id),
+
+		);
 	}
 
 	public async start(): Promise<void> {

--- a/packages/transaction-pool-worker/source/worker.ts
+++ b/packages/transaction-pool-worker/source/worker.ts
@@ -63,10 +63,6 @@ export class Worker implements Contracts.TransactionPool.Worker {
 		await this.ipcSubprocess.sendRequest("start");
 	}
 
-	public async importSnapshot(height: number): Promise<void> {
-		await this.ipcSubprocess.sendRequest("importSnapshot", height);
-	}
-
 	public async getTransactionBytes(): Promise<Buffer[]> {
 		const response: string[] = await this.ipcSubprocess.sendRequest("getTransactions");
 		return response.map((transaction: string) => Buffer.from(transaction, "hex"));

--- a/packages/transaction-pool-worker/source/worker.ts
+++ b/packages/transaction-pool-worker/source/worker.ts
@@ -50,18 +50,14 @@ export class Worker implements Contracts.TransactionPool.Worker {
 		return this.ipcSubprocess.getQueueSize();
 	}
 
-
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		const sendersAddresses: Set<string> = new Set();
 
-		for(const transaction of unit.getBlock().transactions) {
+		for (const transaction of unit.getBlock().transactions) {
 			sendersAddresses.add(await this.addressFactory.fromPublicKey(transaction.data.senderPublicKey));
-		};
+		}
 
-		await this.ipcSubprocess.sendRequest("commit",
-			unit.height,
-			[...sendersAddresses.keys()],
-		);
+		await this.ipcSubprocess.sendRequest("commit", unit.height, [...sendersAddresses.keys()]);
 	}
 
 	public async start(): Promise<void> {

--- a/packages/transaction-pool-worker/source/worker.ts
+++ b/packages/transaction-pool-worker/source/worker.ts
@@ -12,7 +12,6 @@ export class Worker implements Contracts.TransactionPool.Worker {
 	private ipcSubprocess!: Contracts.TransactionPool.WorkerSubprocess;
 
 	#booted = false;
-	#failedTransactions: Contracts.Crypto.Transaction[] = [];
 
 	@postConstruct()
 	public initialize(): void {
@@ -48,9 +47,6 @@ export class Worker implements Contracts.TransactionPool.Worker {
 		return this.ipcSubprocess.getQueueSize();
 	}
 
-	public setFailedTransactions(transactions: Contracts.Crypto.Transaction[]): void {
-		this.#failedTransactions = [...this.#failedTransactions, ...transactions];
-	}
 
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		const receipts = unit.getProcessorResult().receipts;
@@ -61,8 +57,7 @@ export class Worker implements Contracts.TransactionPool.Worker {
 				gasUsed:  Number(receipts.get(transaction.id)!.gasUsed),
 				transaction: transaction.serialized.toString("hex"),
 			})),
-			this.#failedTransactions.map((transaction) => transaction.id),
-
+			[]
 		);
 	}
 

--- a/packages/transaction-pool-worker/source/worker.ts
+++ b/packages/transaction-pool-worker/source/worker.ts
@@ -53,9 +53,15 @@ export class Worker implements Contracts.TransactionPool.Worker {
 	}
 
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
+		const receipts = unit.getProcessorResult().receipts;
+
 		await this.ipcSubprocess.sendRequest("commit", {
-			block: unit.getBlock().serialized,
 			failedTransactions: this.#failedTransactions.map((transaction) => transaction.id),
+			height: unit.height,
+			transactions: unit.getBlock().transactions.map((transaction) => ({
+				gasUsed:  Number(receipts.get(transaction.id)!.gasUsed),
+				transaction: transaction.serialized.toString("hex"),
+			})),
 		});
 	}
 

--- a/packages/validator/source/validator.ts
+++ b/packages/validator/source/validator.ts
@@ -138,7 +138,7 @@ export class Validator implements Contracts.Validator.Validator {
 		await validator.getEvm().prepareNextCommit({ commitKey });
 
 		const candidateTransactions: Contracts.Crypto.Transaction[] = [];
-		const failedTransactions: Contracts.Crypto.Transaction[] = [];
+		const failedSenders: Set<string> = new Set();
 
 		const previousBlock = this.stateStore.getLastBlock();
 		const milestone = this.cryptoConfiguration.getMilestone();
@@ -157,7 +157,7 @@ export class Validator implements Contracts.Validator.Validator {
 			const transaction = await this.transactionFactory.fromBytes(bytes);
 			transaction.data.sequence = candidateTransactions.length;
 
-			if (failedTransactions.some((t) => t.data.senderPublicKey === transaction.data.senderPublicKey)) {
+			if (failedSenders.has(transaction.data.senderPublicKey)) {
 				continue;
 			}
 
@@ -179,7 +179,7 @@ export class Validator implements Contracts.Validator.Validator {
 				candidateTransactions.push(transaction);
 			} catch (error) {
 				this.logger.warning(`${transaction.id} failed to collate: ${error.message}`);
-				failedTransactions.push(transaction);
+				failedSenders.add(transaction.data.senderPublicKey);
 			}
 		}
 

--- a/packages/validator/source/validator.ts
+++ b/packages/validator/source/validator.ts
@@ -183,8 +183,6 @@ export class Validator implements Contracts.Validator.Validator {
 			}
 		}
 
-		this.txPoolWorker.setFailedTransactions(failedTransactions);
-
 		await validator.getEvm().updateRewardsAndVotes({
 			blockReward: Utils.BigNumber.make(milestone.reward).toBigInt(),
 			commitKey,

--- a/packages/validator/test/helpers/prepare-sandbox.ts
+++ b/packages/validator/test/helpers/prepare-sandbox.ts
@@ -63,7 +63,6 @@ export const prepareSandbox = async (context: { sandbox?: Sandbox }) => {
 
 	context.sandbox.app.bind(Identifiers.TransactionPool.Worker).toConstantValue({
 		getTransactionBytes: async () => [],
-		setFailedTransactions: async () => [],
 	});
 
 	const validator = {

--- a/tests/functional/consensus/source/setup.ts
+++ b/tests/functional/consensus/source/setup.ts
@@ -46,7 +46,6 @@ const setup = async (id: number, p2pRegistry: P2PRegistry, crypto: any, validato
 
 	sandbox.app.bind(Identifiers.TransactionPool.Worker).toConstantValue({
 		getTransactionBytes: async () => [],
-		setFailedTransactions: () => {},
 		onCommit: async () => {},
 	});
 	sandbox.app.bind(Identifiers.Evm.Worker).toConstantValue({

--- a/tests/functional/transaction-pool-api/source/pool-worker.ts
+++ b/tests/functional/transaction-pool-api/source/pool-worker.ts
@@ -45,7 +45,6 @@ export class PoolWorker implements Contracts.TransactionPool.Worker {
 		await this.transactionPoolMempool.fixInvalidStates();
 		this.#failedTransactions = [];
 	}
-	public async importSnapshot(height: number): Promise<void> {}
 
 	public async getTransactionBytes(): Promise<Buffer[]> {
 		const response: string[] = await this.app.resolve(GetTransactionsHandler).handle();

--- a/tests/functional/transaction-pool-api/source/pool-worker.ts
+++ b/tests/functional/transaction-pool-api/source/pool-worker.ts
@@ -10,11 +10,6 @@ export class PoolWorker implements Contracts.TransactionPool.Worker {
 	@inject(Identifiers.TransactionPool.Mempool)
 	private readonly transactionPoolMempool!: Contracts.TransactionPool.Mempool;
 
-	@inject(Identifiers.TransactionPool.Query)
-	private readonly transactionPoolQuery!: Contracts.TransactionPool.Query;
-
-	#failedTransactions: Contracts.Crypto.Transaction[] = [];
-
 	public async boot(flags: Contracts.TransactionPool.WorkerFlags): Promise<void> {}
 
 	public handle(): void {}
@@ -27,23 +22,13 @@ export class PoolWorker implements Contracts.TransactionPool.Worker {
 	public getQueueSize(): number {
 		return 0;
 	}
-	public setFailedTransactions(transactions: Contracts.Crypto.Transaction[]): void {
-		this.#failedTransactions = [...this.#failedTransactions, ...transactions];
-	}
 	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
 		const block = unit.getBlock();
 		for (const transaction of block.transactions) {
 			await this.transactionPoolMempool.removeForgedTransaction(transaction.data.senderPublicKey, transaction.id);
 		}
-		for (const transactionId of this.#failedTransactions.map((transaction) => transaction.id)) {
-			try {
-				const transaction = await this.transactionPoolQuery.getAll().whereId(transactionId).first();
-				await this.transactionPoolMempool.removeTransaction(transaction.data.senderPublicKey, transaction.id);
-			} catch {}
-		}
 
 		await this.transactionPoolMempool.fixInvalidStates();
-		this.#failedTransactions = [];
 	}
 
 	public async getTransactionBytes(): Promise<Buffer[]> {

--- a/tests/functional/transaction-pool-api/source/utils.ts
+++ b/tests/functional/transaction-pool-api/source/utils.ts
@@ -109,12 +109,12 @@ export const waitBlock = async ({ sandbox }: { sandbox: Sandbox }, count: number
 
 	let remainingTransactions = await query.getAll().all();
 
-	let currentHeight = state.getStore().getLastHeight();
+	let currentHeight = state.getStore().getHeight();
 	let targetHeight = currentHeight + count;
 
 	do {
 		await sleep(100);
-		currentHeight = state.getStore().getLastHeight();
+		currentHeight = state.getStore().getHeight();
 		remainingTransactions = await query.getAll().all();
 
 		if (remainingTransactions.length > 0) {
@@ -227,7 +227,7 @@ export const isTransactionCommitted = async (
 	{ id }: Contracts.Crypto.Transaction,
 ): Promise<boolean> => {
 	const state = sandbox.app.get<Contracts.State.Service>(Identifiers.State.Service);
-	const currentHeight = state.getStore().getLastHeight();
+	const currentHeight = state.getStore().getHeight();
 
 	const database = sandbox.app.get<Contracts.Database.DatabaseService>(Identifiers.Database.Service);
 	const forgedBlocks = await database.findBlocks(


### PR DESCRIPTION
## Summary

- rename Store.getLastHeight to Store.getHeight
- remove unused code in transaction pool service
- pass only heigh and affected senders to transaction pool
- update senders nonce and balance on tx removal
- re-apply transaction by sender when transaction is forged


## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged