### PR TITLE
feat(api-transaction-pool): add configuration route and remove transactionPool on `node/configuration` from public api

### DIFF
--- a/packages/api-http/source/controllers/node.ts
+++ b/packages/api-http/source/controllers/node.ts
@@ -102,9 +102,6 @@ export class NodeController extends Controller {
 				symbol: network.client.symbol,
 				token: network.client.token,
 				transactionPool: {
-					dynamicFees: transactionPoolConfiguration.dynamicFees?.enabled
-						? transactionPoolConfiguration.dynamicFees
-						: { enabled: false },
 					maxTransactionAge: transactionPoolConfiguration.maxTransactionAge,
 					maxTransactionBytes: transactionPoolConfiguration.maxTransactionBytes,
 					maxTransactionsInPool: transactionPoolConfiguration.maxTransactionsInPool,

--- a/packages/api-http/source/controllers/node.ts
+++ b/packages/api-http/source/controllers/node.ts
@@ -84,7 +84,6 @@ export class NodeController extends Controller {
 	public async configuration(request: Hapi.Request) {
 		const configuration = await this.getConfiguration();
 		const plugins = await this.getPlugins();
-		const transactionPoolConfiguration = plugins["@mainsail/transaction-pool"]?.configuration ?? {};
 
 		const cryptoConfiguration = configuration.cryptoConfiguration as Contracts.Crypto.NetworkConfig;
 		const network = cryptoConfiguration.network;
@@ -101,13 +100,6 @@ export class NodeController extends Controller {
 				slip44: network.slip44,
 				symbol: network.client.symbol,
 				token: network.client.token,
-				transactionPool: {
-					maxTransactionAge: transactionPoolConfiguration.maxTransactionAge,
-					maxTransactionBytes: transactionPoolConfiguration.maxTransactionBytes,
-					maxTransactionsInPool: transactionPoolConfiguration.maxTransactionsInPool,
-					maxTransactionsPerRequest: transactionPoolConfiguration.maxTransactionsPerRequest,
-					maxTransactionsPerSender: transactionPoolConfiguration.maxTransactionsPerSender,
-				},
 				version: network.pubKeyHash,
 				wif: network.wif,
 			},

--- a/packages/api-http/test/fixtures/node_configuration.json
+++ b/packages/api-http/test/fixtures/node_configuration.json
@@ -39,7 +39,6 @@
 	"slip44": 1,
 	"symbol": "TѦ",
 	"token": "ARK",
-	"transactionPool": {},
 	"version": 30,
 	"wif": 186
 }

--- a/packages/api-http/test/fixtures/node_configuration.json
+++ b/packages/api-http/test/fixtures/node_configuration.json
@@ -39,11 +39,7 @@
 	"slip44": 1,
 	"symbol": "TѦ",
 	"token": "ARK",
-	"transactionPool": {
-		"dynamicFees": {
-			"enabled": false
-		}
-	},
+	"transactionPool": {},
 	"version": 30,
 	"wif": 186
 }

--- a/packages/api-transaction-pool/source/controllers/configuration.ts
+++ b/packages/api-transaction-pool/source/controllers/configuration.ts
@@ -19,9 +19,9 @@ export class ConfigurationController extends AbstractController {
 		return {
 			data: {
 				// constants: configuration.activeMilestones,
-				// core: {
-				// 	version: configuration.version,
-				// },
+				core: {
+					version: this.app.version(),
+				},
 				// explorer: network.client.explorer,
 				// nethash: network.nethash,
 				// slip44: network.slip44,

--- a/packages/api-transaction-pool/source/controllers/configuration.ts
+++ b/packages/api-transaction-pool/source/controllers/configuration.ts
@@ -1,0 +1,42 @@
+import Hapi from "@hapi/hapi";
+import { AbstractController } from "@mainsail/api-common";
+import { inject, injectable, tagged } from "@mainsail/container";
+import { Identifiers } from "@mainsail/contracts";
+import { Providers } from "@mainsail/kernel";
+
+@injectable()
+export class ConfigurationController extends AbstractController {
+	@inject(Identifiers.ServiceProvider.Configuration)
+	@tagged("plugin", "transaction-pool-service")
+	private readonly pluginConfiguration!: Providers.PluginConfiguration;
+
+	public async configuration(request: Hapi.Request) {
+		// const configuration = await this.getConfiguration();
+
+		// const cryptoConfiguration = configuration.cryptoConfiguration as Contracts.Crypto.NetworkConfig;
+		// const network = cryptoConfiguration.network;
+
+		return {
+			data: {
+				// constants: configuration.activeMilestones,
+				// core: {
+				// 	version: configuration.version,
+				// },
+				// explorer: network.client.explorer,
+				// nethash: network.nethash,
+				// slip44: network.slip44,
+				// symbol: network.client.symbol,
+				// token: network.client.token,
+				transactionPool: {
+					maxTransactionAge: this.pluginConfiguration.get("maxTransactionAge"),
+					maxTransactionBytes: this.pluginConfiguration.get("maxTransactionBytes"),
+					maxTransactionsInPool: this.pluginConfiguration.get("maxTransactionsInPool"),
+					maxTransactionsPerRequest: this.pluginConfiguration.get("maxTransactionsPerRequest"),
+					maxTransactionsPerSender: this.pluginConfiguration.get("maxTransactionsPerSender"),
+				},
+				// version: network.pubKeyHash,
+				// wif: network.wif,
+			},
+		};
+	}
+}

--- a/packages/api-transaction-pool/source/controllers/configuration.ts
+++ b/packages/api-transaction-pool/source/controllers/configuration.ts
@@ -1,7 +1,7 @@
 import Hapi from "@hapi/hapi";
 import { AbstractController } from "@mainsail/api-common";
 import { inject, injectable, tagged } from "@mainsail/container";
-import { Identifiers } from "@mainsail/contracts";
+import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Providers } from "@mainsail/kernel";
 
 @injectable()
@@ -10,23 +10,16 @@ export class ConfigurationController extends AbstractController {
 	@tagged("plugin", "transaction-pool-service")
 	private readonly pluginConfiguration!: Providers.PluginConfiguration;
 
+	@inject(Identifiers.State.Store)
+	private readonly stateStore!: Contracts.State.Store;
+
 	public async configuration(request: Hapi.Request) {
-		// const configuration = await this.getConfiguration();
-
-		// const cryptoConfiguration = configuration.cryptoConfiguration as Contracts.Crypto.NetworkConfig;
-		// const network = cryptoConfiguration.network;
-
 		return {
 			data: {
-				// constants: configuration.activeMilestones,
 				core: {
 					version: this.app.version(),
 				},
-				// explorer: network.client.explorer,
-				// nethash: network.nethash,
-				// slip44: network.slip44,
-				// symbol: network.client.symbol,
-				// token: network.client.token,
+				height: this.stateStore.getHeight(),
 				transactionPool: {
 					maxTransactionAge: this.pluginConfiguration.get("maxTransactionAge"),
 					maxTransactionBytes: this.pluginConfiguration.get("maxTransactionBytes"),
@@ -34,8 +27,6 @@ export class ConfigurationController extends AbstractController {
 					maxTransactionsPerRequest: this.pluginConfiguration.get("maxTransactionsPerRequest"),
 					maxTransactionsPerSender: this.pluginConfiguration.get("maxTransactionsPerSender"),
 				},
-				// version: network.pubKeyHash,
-				// wif: network.wif,
 			},
 		};
 	}

--- a/packages/api-transaction-pool/source/handlers.ts
+++ b/packages/api-transaction-pool/source/handlers.ts
@@ -1,11 +1,12 @@
 import { Contracts } from "@mainsail/contracts";
 
+import * as Configuration from "./routes/configuration.js";
 import * as Transactions from "./routes/transactions.js";
 
 const config = {
 	name: "Transaction Pool API",
 	async register(server: Contracts.Api.ApiServer): Promise<void> {
-		const handlers = [Transactions];
+		const handlers = [Transactions, Configuration];
 
 		for (const handler of handlers) {
 			handler.register(server);

--- a/packages/api-transaction-pool/source/routes/configuration.ts
+++ b/packages/api-transaction-pool/source/routes/configuration.ts
@@ -1,0 +1,15 @@
+import Hapi from "@hapi/hapi";
+import { Contracts } from "@mainsail/contracts";
+
+import { ConfigurationController } from "../controllers/configuration.js";
+
+export const register = (server: Contracts.Api.ApiServer): void => {
+	const controller = server.app.app.resolve(ConfigurationController);
+	server.bind(controller);
+
+	server.route({
+		handler: (request: Hapi.Request) => controller.configuration(request),
+		method: "GET",
+		path: "/configuration",
+	});
+};


### PR DESCRIPTION
## Summary

Add configuration route with `/api/configuration` endpoint. Example of response:

 `{
    "data": {
        "core": {
            "version": "0.0.1-evm.6"
        },
        "height": 328,
        "transactionPool": {
            "maxTransactionAge": 2700,
            "maxTransactionBytes": 9000,
            "maxTransactionsInPool": 15000,
            "maxTransactionsPerRequest": 40,
            "maxTransactionsPerSender": 150
        }
    }
}`

Remove transactionPool property from data on `node/configuration` response. 

## Checklist

- [x] Ready to be merged


