### PR TITLE
refactor(kernel): remove force termination

### DIFF
--- a/packages/kernel/source/application.ts
+++ b/packages/kernel/source/application.ts
@@ -162,10 +162,7 @@ export class Application implements Contracts.Kernel.Application {
 		this.#booted = false;
 
 		if (this.#terminating) {
-			this.get<Contracts.Kernel.Logger>(Identifiers.Services.Log.Service).warning(
-				"Force application termination. Graceful shutdown was interrupted.",
-			);
-			exit(1);
+			return new Promise(() => {});
 		}
 		this.#terminating = true;
 


### PR DESCRIPTION
## Summary

Remove force termination with double SIGINT interruptions. PNPM and NPM are triggering double SIGINT on Ctrl + C and is causing instant force termination of the Mainsail process. 

## Checklist

- [x] Ready to be merged
