### PR TITLE
fix(database-service): use correct height key when fetching last commit

### DIFF
--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -209,8 +209,7 @@ export class DatabaseService implements Contracts.Database.DatabaseService {
 			return [...this.#commitCache.values()].pop()!;
 		}
 
-		const height = Number(this.commitStorage.getRange({ limit: 1, reverse: true }).asArray[0].key);
-		return await this.commitFactory.fromBytes(this.#readCommitBytes(height)!);
+		return await this.commitFactory.fromBytes(this.#readCommitBytes(this.#state.height)!);
 	}
 
 	public addCommit(commit: Contracts.Crypto.Commit): void {

--- a/packages/database/source/database-service.ts
+++ b/packages/database/source/database-service.ts
@@ -209,7 +209,7 @@ export class DatabaseService implements Contracts.Database.DatabaseService {
 			return [...this.#commitCache.values()].pop()!;
 		}
 
-		const height = this.blockIdStorage.getRange({ limit: 1, reverse: true }).asArray[0].value;
+		const height = Number(this.commitStorage.getRange({ limit: 1, reverse: true }).asArray[0].key);
 		return await this.commitFactory.fromBytes(this.#readCommitBytes(height)!);
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
The `blockIdStorage` is ordered by id (key) instead of height (value).

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
