### PR TITLE
fix(e2e): run nodes on Ubuntu 24.04 with glibc 2.38

### DIFF
--- a/tests/e2e/consensus/nodes/Dockerfile
+++ b/tests/e2e/consensus/nodes/Dockerfile
@@ -1,14 +1,23 @@
-FROM node:20
+FROM ubuntu:24.04
 
-WORKDIR /home/node
+ENV DEBIAN_FRONTEND=noninteractive
 
-ENV PNPM_HOME=/home/node/.pnpm/bin
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg \
+    build-essential \
+    libjemalloc2
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y nodejs
+
+WORKDIR /home/ubuntu
+
+ENV PNPM_HOME=/home/ubuntu/.pnpm/bin
 ENV PATH="${PATH}:${PNPM_HOME}"
 
-RUN apt-get update && apt-get install build-essential -y \
-    && apt-get install libjemalloc2 \
-    && npm install -g npm@latest \
-    && su node -c "npm install --prefix=/home/node/.pnpm -g pnpm" \
-    && su node -c "export PNPM_HOME=/home/node/.pnpm/bin"
+RUN npm install -g npm@latest \
+    && su ubuntu -c "npm install --prefix=/home/ubuntu/.pnpm -g pnpm" \
+    && su ubuntu -c "export PNPM_HOME=/home/ubuntu/.pnpm/bin"
 
-USER node
+USER ubuntu


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Fixes
```
Error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /mainsail/packages/evm/evm.linux-x64-gnu.node)
    at Module._extensions..node (node:internal/modules/cjs/loader:1586:18)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:1[9](https://github.com/ArkEcosystem/mainsail/actions/runs/12664247999/job/35292073361?pr=807#step:12:10))
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/mainsail/packages/evm/index.js:188:31)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:[10](https://github.com/ArkEcosystem/mainsail/actions/runs/12664247999/job/35292073361?pr=807#step:12:11))
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:[11](https://github.com/ArkEcosystem/mainsail/actions/runs/12664247999/job/35292073361?pr=807#step:12:12)04:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```

The runners changed overnight from:

```
Operating System
  Ubuntu
  22.04.5
  LTS
Runner Image
  Image: ubuntu-22.04
  Version: 20241215.1.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20241215.1/images/ubuntu/Ubuntu2204-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20241215.1
```

to

```
Operating System
  Ubuntu
  24.04.1
  LTS
Runner Image
  Image: ubuntu-24.04
  Version: 20241215.1.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20241215.1/images/ubuntu/Ubuntu2404-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20241215.1
```

Since we build mainsail on the host our e2e docker image must match and we can no longer use the default node image as it is still on glibc 2.31.


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
