### PR TITLE
feat(api): support retrieval of multiple wallets via `?address=` param

### DIFF
--- a/packages/api-common/source/schemas.ts
+++ b/packages/api-common/source/schemas.ts
@@ -100,3 +100,17 @@ export const pagination = Joi.object({
 	offset: Joi.number().integer().min(0),
 	page: Joi.number().integer().positive().default(1),
 });
+
+export const equalCriteria = (value: any) => value;
+export const numericCriteria = (value: any) =>
+	Joi.alternatives().try(
+		value,
+		Joi.object().keys({ from: value }),
+		Joi.object().keys({ to: value }),
+		Joi.object().keys({ from: value, to: value }),
+	);
+export const containsCriteria = (value: any) => value;
+export const orCriteria = (criteria: any) => Joi.alternatives().try(criteria, Joi.array().items(criteria));
+export const orEqualCriteria = (value: any) => orCriteria(equalCriteria(value));
+export const orNumericCriteria = (value: any) => orCriteria(numericCriteria(value));
+export const orContainsCriteria = (value: any) => orCriteria(containsCriteria(value));

--- a/packages/api-http/source/schemas/delegates.ts
+++ b/packages/api-http/source/schemas/delegates.ts
@@ -2,10 +2,10 @@ import { Schemas } from "@mainsail/api-common";
 import Joi from "joi";
 
 import { blockCriteriaSchemaObject } from "./blocks.js";
-import { walletCriteriaSchemaObject } from "./wallets.js";
+import { walletAddressSchema, walletCriteriaSchemaObject } from "./wallets.js";
 
 export const delegateCriteriaSchemaObject = {
-	address: walletCriteriaSchemaObject.address,
+	address: Schemas.orEqualCriteria(walletAddressSchema),
 	attributes: Joi.object(),
 	blocks: {
 		last: {
@@ -29,5 +29,15 @@ export const delegateCriteriaSchemaObject = {
 	votes: Schemas.createRangeCriteriaSchema(Joi.number().integer().positive()),
 };
 
-export const delegateCriteriaSchema = Schemas.createCriteriaSchema(delegateCriteriaSchemaObject);
-export const delegateSortingSchema = Schemas.createSortingSchema(delegateCriteriaSchemaObject, ["attributes"], false);
+export const delegateCriteriaSchema = Schemas.createCriteriaSchema({
+	...delegateCriteriaSchemaObject,
+	address: walletAddressSchema,
+});
+export const delegateSortingSchema = Schemas.createSortingSchema(
+	{
+		...delegateCriteriaSchemaObject,
+		address: walletAddressSchema,
+	},
+	["attributes"],
+	false,
+);

--- a/packages/api-http/source/schemas/schemas.ts
+++ b/packages/api-http/source/schemas/schemas.ts
@@ -1,5 +1,6 @@
 import Joi from "joi";
 
+import { Schemas } from "@mainsail/api-common";
 import { walletAddressSchema } from "./wallets.js";
 
 // Old
@@ -47,52 +48,38 @@ export const numberFixedOrBetween = Joi.alternatives().try(
 export const blocksOrderBy = orderBy.default("height:desc");
 export const transactionsOrderBy = orderBy.default(["timestamp:desc", "sequence:desc"]);
 
-const equalCriteria = (value: any) => value;
-const numericCriteria = (value: any) =>
-	Joi.alternatives().try(
-		value,
-		Joi.object().keys({ from: value }),
-		Joi.object().keys({ to: value }),
-		Joi.object().keys({ from: value, to: value }),
-	);
-const containsCriteria = (value: any) => value;
-const orCriteria = (criteria: any) => Joi.alternatives().try(criteria, Joi.array().items(criteria));
-const orEqualCriteria = (value: any) => orCriteria(equalCriteria(value));
-const orNumericCriteria = (value: any) => orCriteria(numericCriteria(value));
-const orContainsCriteria = (value: any) => orCriteria(containsCriteria(value));
-
 export const blockCriteriaSchemas = {
-	blockSignature: orEqualCriteria(Joi.string().hex()),
-	generatorAddress: orEqualCriteria(Joi.string().hex().length(66)),
-	height: orNumericCriteria(Joi.number().integer().min(0)),
-	id: orEqualCriteria(blockId),
-	numberOfTransactions: orNumericCriteria(Joi.number().integer().min(0)),
-	payloadHash: orEqualCriteria(Joi.string().hex()),
-	payloadLength: orNumericCriteria(Joi.number().integer().min(0)),
-	previousBlock: orEqualCriteria(blockId),
-	reward: orNumericCriteria(Joi.number().integer().min(0)),
-	round: orNumericCriteria(Joi.number().integer().min(0)),
-	timestamp: orNumericCriteria(Joi.number().integer().min(0)),
-	totalAmount: orNumericCriteria(Joi.number().integer().min(0)),
-	totalFee: orNumericCriteria(Joi.number().integer().min(0)),
-	version: orEqualCriteria(Joi.number().integer().min(0)),
+	blockSignature: Schemas.orEqualCriteria(Joi.string().hex()),
+	generatorAddress: Schemas.orEqualCriteria(Joi.string().hex().length(66)),
+	height: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	id: Schemas.orEqualCriteria(blockId),
+	numberOfTransactions: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	payloadHash: Schemas.orEqualCriteria(Joi.string().hex()),
+	payloadLength: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	previousBlock: Schemas.orEqualCriteria(blockId),
+	reward: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	round: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	timestamp: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	totalAmount: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	totalFee: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	version: Schemas.orEqualCriteria(Joi.number().integer().min(0)),
 };
 
 export const transactionCriteriaSchemas = {
-	address: orEqualCriteria(address),
-	amount: orNumericCriteria(Joi.number().integer().min(0)),
-	asset: orContainsCriteria(Joi.object()),
-	blockId: orEqualCriteria(blockId),
-	data: orEqualCriteria(
+	address: Schemas.orEqualCriteria(address),
+	amount: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	asset: Schemas.orContainsCriteria(Joi.object()),
+	blockId: Schemas.orEqualCriteria(blockId),
+	data: Schemas.orEqualCriteria(
 		Joi.alternatives().try(Joi.string().valid("", "0x"), Joi.string().hex({ prefix: "optional" }).max(10)),
 	),
-	gasPrice: orNumericCriteria(Joi.number().integer().min(0)),
-	id: orEqualCriteria(Joi.string().hex().length(64)),
-	nonce: orNumericCriteria(Joi.number().integer().positive()),
-	recipientId: orEqualCriteria(address),
-	senderAddress: orEqualCriteria(address),
-	senderId: orEqualCriteria(address),
-	senderPublicKey: orEqualCriteria(Joi.string().hex().length(66)),
-	sequence: orNumericCriteria(Joi.number().integer().positive()),
-	timestamp: orNumericCriteria(Joi.number().integer().min(0)),
+	gasPrice: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
+	id: Schemas.orEqualCriteria(Joi.string().hex().length(64)),
+	nonce: Schemas.orNumericCriteria(Joi.number().integer().positive()),
+	recipientId: Schemas.orEqualCriteria(address),
+	senderAddress: Schemas.orEqualCriteria(address),
+	senderId: Schemas.orEqualCriteria(address),
+	senderPublicKey: Schemas.orEqualCriteria(Joi.string().hex().length(66)),
+	sequence: Schemas.orNumericCriteria(Joi.number().integer().positive()),
+	timestamp: Schemas.orNumericCriteria(Joi.number().integer().min(0)),
 };

--- a/packages/api-http/source/schemas/schemas.ts
+++ b/packages/api-http/source/schemas/schemas.ts
@@ -1,6 +1,6 @@
+import { Schemas } from "@mainsail/api-common";
 import Joi from "joi";
 
-import { Schemas } from "@mainsail/api-common";
 import { walletAddressSchema } from "./wallets.js";
 
 // Old

--- a/packages/api-http/source/schemas/wallets.ts
+++ b/packages/api-http/source/schemas/wallets.ts
@@ -15,12 +15,7 @@ export const walletId = Joi.alternatives().try(
 );
 
 export const walletCriteriaSchemaObject = {
-	address: Joi.alternatives(
-		walletAddressSchema,
-		Joi.string()
-			.regex(/^[\d%A-Za-z]{1,34}$/)
-			.regex(/%/),
-	),
+	address: Schemas.orEqualCriteria(walletAddressSchema),
 	attributes: Joi.object(),
 	balance: Schemas.createRangeCriteriaSchema(Joi.number().integer().positive()),
 	nonce: Schemas.createRangeCriteriaSchema(Joi.number().integer().min(0)),
@@ -33,5 +28,12 @@ export const walletCriteriaSchemaObject = {
 };
 
 export const walletParamSchema = Joi.alternatives(walletAddressSchema, walletPublicKeySchema, walletUsernameSchema);
-export const walletCriteriaSchema = Schemas.createCriteriaSchema(walletCriteriaSchemaObject);
-export const walletSortingSchema = Schemas.createSortingSchema(walletCriteriaSchemaObject, ["attributes"], false);
+export const walletCriteriaSchema = Schemas.createCriteriaSchema({
+	...walletCriteriaSchemaObject,
+	address: walletAddressSchema,
+});
+export const walletSortingSchema = Schemas.createSortingSchema(
+	{ ...walletCriteriaSchemaObject, address: walletAddressSchema },
+	["attributes"],
+	false,
+);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

`/wallets?address=` now accepts a comma-separated list of addresses, similar to how `/transactions?address=` already works.

For example:

```
http://localhost:4003/api/wallets?address=0x0462B637d49Aa7e44D2141BbD273FFD5df90FCD8,0x07CDD5CB29a70ad52ba6F4ad9fb94d397a26486e
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
