### PR TITLE
fix(api-evm): schemas

### DIFF
--- a/packages/api-evm/package.json
+++ b/packages/api-evm/package.json
@@ -29,6 +29,7 @@
 		"@mainsail/contracts": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
 		"@mainsail/utils": "workspace:*",
+		"ajv": "8.12.0",
 		"dayjs": "1.11.10",
 		"ethers": "6.11.0",
 		"joi": "17.12.2"

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -32,7 +32,7 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "prefixedHex" },
+					data: { $ref: "prefixedNullableHex" },
 					from: { $ref: "address" },
 					gas: { $ref: "prefixedHex" },
 					gasPrice: { $ref: "prefixedHex" },

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -25,8 +25,8 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 	public readonly schema = {
 		$id: `jsonRpc_${this.name}`,
 
-		maxItems: 2,
-		minItems: 2,
+		maxItems: 1,
+		minItems: 1,
 
 		prefixItems: [
 			{
@@ -42,13 +42,12 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 				required: ["from", "to"],
 				type: "object",
 			},
-			{ $ref: "blockTag" },
 		],
 
 		type: "array",
 	};
 
-	public async handle(parameters: [TxData, Contracts.Crypto.BlockTag]): Promise<any> {
+	public async handle(parameters: [TxData]): Promise<any> {
 		try {
 			const [data] = parameters;
 

--- a/packages/api-evm/source/actions/eth-get-balance.test.ts
+++ b/packages/api-evm/source/actions/eth-get-balance.test.ts
@@ -1,9 +1,10 @@
 import { Identifiers } from "@mainsail/contracts";
 import { schemas as keccak256Schemas } from "@mainsail/crypto-address-keccak256";
-import { schemas as blockSchemas } from "@mainsail/crypto-block";
+import { schemas as validationSchemas } from "@mainsail/crypto-validation";
 import { Validator } from "@mainsail/validation";
 
 import { describe, Sandbox } from "../../../test-framework/source";
+import { schemas } from "../validation/index.js";
 import { EthGetBalanceAction } from "./index.js";
 
 describe<{
@@ -37,7 +38,8 @@ describe<{
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(blockSchemas.blockTag);
+		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 
 		assert.undefined(

--- a/packages/api-evm/source/actions/eth-get-block-by-number.ts
+++ b/packages/api-evm/source/actions/eth-get-block-by-number.ts
@@ -22,7 +22,7 @@ export class EthGetBlockByNumberAction implements Contracts.Api.RPC.Action {
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ oneOf: [{ $ref: "prefixedHex" }, { $ref: "blockTag" }] }, { type: "boolean" }],
+		prefixItems: [{ $ref: "blockTag" }, { type: "boolean" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-code.test.ts
+++ b/packages/api-evm/source/actions/eth-get-code.test.ts
@@ -1,9 +1,10 @@
 import { Identifiers } from "@mainsail/contracts";
 import { schemas as keccak256Schemas } from "@mainsail/crypto-address-keccak256";
-import { schemas as blockSchemas } from "@mainsail/crypto-block";
+import { schemas as validationSchemas } from "@mainsail/crypto-validation";
 import { Validator } from "@mainsail/validation";
 
 import { describe, Sandbox } from "../../../test-framework/source";
+import { schemas } from "../validation/index.js";
 import { EthGetCodeAction } from "./index.js";
 
 describe<{
@@ -31,7 +32,8 @@ describe<{
 
 	it("schema should be ok", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(blockSchemas.blockTag);
+		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 
 		assert.undefined(

--- a/packages/api-evm/source/actions/eth-get-storage-at.test.ts
+++ b/packages/api-evm/source/actions/eth-get-storage-at.test.ts
@@ -1,10 +1,10 @@
 import { Identifiers } from "@mainsail/contracts";
 import { schemas as keccak256Schemas } from "@mainsail/crypto-address-keccak256";
-import { schemas as blockSchemas } from "@mainsail/crypto-block";
-import { schemas as cryptoValidationSchemas } from "@mainsail/crypto-validation";
+import { schemas as validationSchemas } from "@mainsail/crypto-validation";
 import { Validator } from "@mainsail/validation";
 
 import { describe, Sandbox } from "../../../test-framework/source";
+import { schemas } from "../validation/index.js";
 import { EthGetStorageAtAction } from "./index.js";
 
 describe<{
@@ -32,8 +32,8 @@ describe<{
 
 	it("schema should be ok", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(cryptoValidationSchemas.prefixedHex);
-		validator.addSchema(blockSchemas.blockTag);
+		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 
 		assert.undefined(

--- a/packages/api-evm/source/actions/eth-get-transaction-count.test.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-count.test.ts
@@ -1,9 +1,10 @@
 import { Identifiers } from "@mainsail/contracts";
 import { schemas as keccak256Schemas } from "@mainsail/crypto-address-keccak256";
-import { schemas as blockSchemas } from "@mainsail/crypto-block";
+import { schemas as validationSchemas } from "@mainsail/crypto-validation";
 import { Validator } from "@mainsail/validation";
 
 import { describe, Sandbox } from "../../../test-framework/source";
+import { schemas } from "../validation/index.js";
 import { EthGetTransactionCount } from "./index.js";
 
 describe<{
@@ -37,7 +38,8 @@ describe<{
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(blockSchemas.blockTag);
+		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 
 		assert.undefined(

--- a/packages/api-evm/source/actions/net-version.ts
+++ b/packages/api-evm/source/actions/net-version.ts
@@ -15,6 +15,6 @@ export class NetVersion implements Contracts.Api.RPC.Action {
 	};
 
 	public async handle(parameters: []): Promise<string> {
-		return this.configuration.get<string>("network.nethash");
+		return this.configuration.get<number>("network.chainId").toString();
 	}
 }

--- a/packages/api-evm/source/resources/block.ts
+++ b/packages/api-evm/source/resources/block.ts
@@ -30,6 +30,7 @@ export class BlockResource {
 			miner: blockData.generatorAddress,
 			difficulty: "0x0",
 			totalDifficulty: "0x0",
+			baseFeePerGas: "0x0",
 			extraData: "0x",
 			size: `0x${blockData.payloadLength.toString(16)}`, // TODO: Implement block size
 			gasLimit: `0x${milestone.block.maxGasLimit.toString(16)}`,

--- a/packages/api-evm/source/service-provider.ts
+++ b/packages/api-evm/source/service-provider.ts
@@ -33,10 +33,16 @@ import {
 } from "./actions/index.js";
 import Handlers from "./handlers.js";
 import { Server } from "./server.js";
-import { schemas } from "./validation/index.js";
+import { makeKeywords, schemas } from "./validation/index.js";
 
 export class ServiceProvider extends AbstractServiceProvider<Server> {
 	public async register(): Promise<void> {
+		for (const keyword of Object.values(
+			makeKeywords(this.app.get<Contracts.State.Store>(Identifiers.State.Store)),
+		)) {
+			this.app.get<Contracts.Crypto.Validator>(Identifiers.Cryptography.Validator).addKeyword(keyword);
+		}
+
 		for (const schema of Object.values(schemas)) {
 			this.app.get<Contracts.Crypto.Validator>(Identifiers.Cryptography.Validator).addSchema(schema);
 		}

--- a/packages/api-evm/source/service-provider.ts
+++ b/packages/api-evm/source/service-provider.ts
@@ -33,8 +33,17 @@ import {
 } from "./actions/index.js";
 import Handlers from "./handlers.js";
 import { Server } from "./server.js";
+import { schemas } from "./validation/index.js";
 
 export class ServiceProvider extends AbstractServiceProvider<Server> {
+	public async register(): Promise<void> {
+		for (const schema of Object.values(schemas)) {
+			this.app.get<Contracts.Crypto.Validator>(Identifiers.Cryptography.Validator).addSchema(schema);
+		}
+
+		await super.register();
+	}
+
 	protected httpIdentifier(): symbol {
 		return Identifiers.Evm.API.HTTP;
 	}

--- a/packages/api-evm/source/validation/index.ts
+++ b/packages/api-evm/source/validation/index.ts
@@ -1,0 +1,1 @@
+export * from "./schemas.js";

--- a/packages/api-evm/source/validation/index.ts
+++ b/packages/api-evm/source/validation/index.ts
@@ -1,1 +1,2 @@
+export * from "./keywords.js";
 export * from "./schemas.js";

--- a/packages/api-evm/source/validation/keywords.ts
+++ b/packages/api-evm/source/validation/keywords.ts
@@ -1,0 +1,15 @@
+import { Contracts } from "@mainsail/contracts";
+import { FuncKeywordDefinition } from "ajv";
+
+export const makeKeywords = (stateStore: Contracts.State.Store) => {
+	const currentHeight: FuncKeywordDefinition = {
+		compile: (schema) => (data) => Number(data) === stateStore.getHeight(),
+		errors: false,
+		keyword: "currentHeightHex",
+		metaSchema: {
+			type: "boolean",
+		},
+	};
+
+	return { currentHeight };
+};

--- a/packages/api-evm/source/validation/schemas.ts
+++ b/packages/api-evm/source/validation/schemas.ts
@@ -1,0 +1,16 @@
+import { AnySchemaObject } from "ajv";
+
+export const schemas: Record<"blockTag", AnySchemaObject> = {
+	blockTag: {
+		$id: "blockTag",
+		anyOf: [
+			{
+				enum: ["latest", "finalized", "safe"],
+				type: "string",
+			},
+			{
+				$ref: "prefixedHex",
+			},
+		],
+	},
+};

--- a/packages/api-evm/source/validation/schemas.ts
+++ b/packages/api-evm/source/validation/schemas.ts
@@ -10,6 +10,7 @@ export const schemas: Record<"blockTag", AnySchemaObject> = {
 			},
 			{
 				$ref: "prefixedHex",
+				currentHeightHex: true,
 			},
 		],
 	},

--- a/packages/api-evm/source/validation/schemas.ts
+++ b/packages/api-evm/source/validation/schemas.ts
@@ -10,7 +10,7 @@ export const schemas: Record<"blockTag", AnySchemaObject> = {
 			},
 			{
 				$ref: "prefixedHex",
-				currentHeightHex: true,
+				// currentHeightHex: true, // TODO: Implement historical data and enable later
 			},
 		],
 	},

--- a/packages/crypto-block/source/schemas.ts
+++ b/packages/crypto-block/source/schemas.ts
@@ -59,8 +59,15 @@ export const schemas: Record<"block" | "blockId" | "prefixedBlockId" | "blockTag
 	},
 	blockTag: {
 		$id: "blockTag",
-		enum: ["latest", "finalized", "safe"],
-		type: "string",
+		anyOf: [
+			{
+				enum: ["latest", "finalized", "safe"],
+				type: "string",
+			},
+			{
+				$ref: "prefixedHex",
+			},
+		],
 	},
 	prefixedBlockId: {
 		$id: "prefixedBlockId",

--- a/packages/crypto-block/source/schemas.ts
+++ b/packages/crypto-block/source/schemas.ts
@@ -1,6 +1,6 @@
 import { AnySchemaObject } from "ajv";
 
-export const schemas: Record<"block" | "blockId" | "prefixedBlockId" | "blockTag" | "blockHeader", AnySchemaObject> = {
+export const schemas: Record<"block" | "blockId" | "prefixedBlockId" | "blockHeader", AnySchemaObject> = {
 	block: {
 		$id: "block",
 		$ref: "blockHeader",
@@ -56,18 +56,6 @@ export const schemas: Record<"block" | "blockId" | "prefixedBlockId" | "blockTag
 			},
 		],
 		type: "string",
-	},
-	blockTag: {
-		$id: "blockTag",
-		anyOf: [
-			{
-				enum: ["latest", "finalized", "safe"],
-				type: "string",
-			},
-			{
-				$ref: "prefixedHex",
-			},
-		],
 	},
 	prefixedBlockId: {
 		$id: "prefixedBlockId",

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -46,7 +46,7 @@ export const transactionBaseSchema: SchemaObject = {
 
 		senderAddress: { $ref: "address" },
 
-		senderLegacyAddress: { $ref: "legacyAddress" },
+		senderLegacyAddress: { type: "string" },
 
 		senderPublicKey: { $ref: "publicKey" },
 

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -1,6 +1,6 @@
 import { SchemaObject } from "ajv";
 
-export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex", SchemaObject> = {
+export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "prefixedNullableHex", SchemaObject> = {
 	alphanumeric: {
 		$id: "alphanumeric",
 		pattern: "^[a-z0-9]+$",
@@ -14,6 +14,11 @@ export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex", SchemaObjec
 	prefixedHex: {
 		$id: "prefixedHex",
 		pattern: "^0x[0-9a-f]+$",
+		type: "string",
+	},
+	prefixedNullableHex: {
+		$id: "prefixedNullableHex",
+		pattern: "^0x[0-9a-f]*$",
 		type: "string",
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@mainsail/utils':
         specifier: workspace:*
         version: link:../utils
+      ajv:
+        specifier: 8.12.0
+        version: 8.12.0
       dayjs:
         specifier: 1.11.10
         version: 1.11.10


### PR DESCRIPTION
## Summary

- add prefixedNullableHex
- move blockTag to api-evm from crypto-block
- add baseFeePerGas to blockResource (for MetaMask)
- allow passing block number as block tag (for MetaMask)
- senderLegacyAddress as string (doesn't require crypto-address-base58 plugin)

## Checklist

- [x] Ready to be merged
