### PR TITLE
fix(api-common): use `rcpResponseHandler` only on RCP route

### DIFF
--- a/packages/api-common/source/plugins/rpc-response-handler.ts
+++ b/packages/api-common/source/plugins/rpc-response-handler.ts
@@ -13,7 +13,7 @@ export const rpcResponseHandler = {
 			method(request, h) {
 				const response = request.response;
 
-				if (responseIsBoom(response)) {
+				if (responseIsBoom(response) && request.method === "post" && request.path === "") {
 					return h.response(
 						Utils.prepareRcpError(
 							Utils.getRcpId(request),


### PR DESCRIPTION
## Summary

Respond with normal HTTP errors when non RCP route is used

## Checklist

- [x] Ready to be merged
