### PR TITLE
fix(kernel): prevent stuck app on bootstrap failure

### DIFF
--- a/packages/bootstrap/source/bootstrapper.ts
+++ b/packages/bootstrap/source/bootstrapper.ts
@@ -6,9 +6,6 @@ export class Bootstrapper {
 	@inject(Identifiers.Application.Instance)
 	public readonly app!: Contracts.Kernel.Application;
 
-	@inject(Identifiers.Services.Log.Service)
-	private readonly logger!: Contracts.Kernel.Logger;
-
 	@inject(Identifiers.Consensus.Service)
 	private readonly consensus!: Contracts.Consensus.Service;
 
@@ -60,29 +57,25 @@ export class Bootstrapper {
 	private readonly evmWorker!: Contracts.Evm.Worker;
 
 	public async bootstrap(): Promise<void> {
-		try {
-			await this.#setGenesisCommit();
-			await this.#checkStoredGenesisCommit();
+		await this.#setGenesisCommit();
+		await this.#checkStoredGenesisCommit();
 
-			if (this.databaseService.isEmpty()) {
-				await this.#initGenesisState();
-			} else {
-				await this.#initPostGenesisState();
-			}
-
-			this.state.setBootstrap(false);
-
-			this.validatorRepository.printLoadedValidators();
-			await this.txPoolWorker.start(this.stateStore.getHeight());
-			await this.evmWorker.start(this.stateStore.getHeight());
-
-			void this.runConsensus();
-
-			await this.p2pServer.boot();
-			await this.p2pService.boot();
-		} catch (error) {
-			this.logger.error(error.stack);
+		if (this.databaseService.isEmpty()) {
+			await this.#initGenesisState();
+		} else {
+			await this.#initPostGenesisState();
 		}
+
+		this.state.setBootstrap(false);
+
+		this.validatorRepository.printLoadedValidators();
+		await this.txPoolWorker.start(this.stateStore.getHeight());
+		await this.evmWorker.start(this.stateStore.getHeight());
+
+		void this.runConsensus();
+
+		await this.p2pServer.boot();
+		await this.p2pService.boot();
 	}
 
 	async runConsensus(): Promise<void> {

--- a/packages/kernel/source/application.ts
+++ b/packages/kernel/source/application.ts
@@ -41,8 +41,8 @@ export class Application implements Contracts.Kernel.Application {
 		try {
 			await this.#bootstrapWith("serviceProviders");
 			this.#booted = true;
-		} catch (ex) {
-			await this.terminate(ex.name, ex);
+		} catch (error) {
+			await this.terminate(error.name, error);
 		}
 	}
 

--- a/packages/kernel/source/application.ts
+++ b/packages/kernel/source/application.ts
@@ -169,9 +169,10 @@ export class Application implements Contracts.Kernel.Application {
 		}
 		this.#terminating = true;
 
-		const message = `reason: ${reason} error: ${error?.message}`;
-		if (reason || error) {
-			this.get<Contracts.Kernel.Logger>(Identifiers.Services.Log.Service)[error ? "error" : "warning"](message);
+		if (reason) {
+			this.get<Contracts.Kernel.Logger>(Identifiers.Services.Log.Service)[error ? "error" : "warning"](
+				`Application shutdown: ${reason}`,
+			);
 		}
 
 		if (error) {

--- a/packages/kernel/source/application.ts
+++ b/packages/kernel/source/application.ts
@@ -38,9 +38,12 @@ export class Application implements Contracts.Kernel.Application {
 	}
 
 	public async boot(): Promise<void> {
-		await this.#bootstrapWith("serviceProviders");
-
-		this.#booted = true;
+		try {
+			await this.#bootstrapWith("serviceProviders");
+			this.#booted = true;
+		} catch (ex) {
+			await this.terminate(ex.name, ex);
+		}
 	}
 
 	public async reboot(): Promise<void> {

--- a/packages/kernel/source/bootstrap/boot-service-providers.ts
+++ b/packages/kernel/source/bootstrap/boot-service-providers.ts
@@ -31,11 +31,12 @@ export class BootServiceProviders implements Contracts.Kernel.Bootstrapper {
 				try {
 					await this.serviceProviders.boot(name);
 				} catch (error) {
-					this.logger.error(`${name}: ${error.stack}`);
 					const isRequired: boolean = await serviceProvider.required();
 
 					if (isRequired) {
 						throw new Exceptions.ServiceProviderCannotBeBooted(serviceProviderName, error.message);
+					} else {
+						this.logger.warning(`${name}: ${error.stack}`);
 					}
 
 					this.serviceProviders.fail(serviceProviderName);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
When a required service fails to load, the application simply hangs indefinitely. Instead, we need to call `terminate` to ensure already loaded services are properly unloaded so that the process can stop.

Also clean up logging to prevent overlay noisy and redundant error messages.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
