### PR TITLE
fix(api-sync): deduplicate wallets before upsert

### DIFF
--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -235,8 +235,10 @@ export class Sync implements Contracts.ApiSync.Service {
 		// The block validator/dirty validators might not be part of the account updates if no rewards have been distributed,
 		// thus ensure they are manually inserted.
 		for (const validatorAddress of [
-			header.generatorAddress,
-			...Object.values<Contracts.State.ValidatorWallet>(dirtyValidators).map((v) => v.address),
+			...new Set([
+				header.generatorAddress,
+				...Object.values<Contracts.State.ValidatorWallet>(dirtyValidators).map((v) => v.address),
+			]),
 		]) {
 			if (!accountUpdates[validatorAddress]) {
 				wallets.push([


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
It can happen that the same address ends up getting upserted multiple times which is not allowed. Use a set to deduplicate and prevent the `ON CONFLICT DO UPDATE command cannot affect row a second time.` exception from happening.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
