### PR TITLE
perf(evm): get rid of unnecessary clones when calculating `state_hash` and `logs_bloom`

### DIFF
--- a/packages/evm-service/source/instances/evm.test.ts
+++ b/packages/evm-service/source/instances/evm.test.ts
@@ -713,15 +713,21 @@ describe<{
 	});
 
 	it("should return state hash", async ({ instance }) => {
+		const commitKey = { height: BigInt(0), round: BigInt(0) };
+		await instance.prepareNextCommit({ commitKey });
+
 		const hash = await instance.stateHash(
-			{ height: BigInt(0), round: BigInt(0) },
+			commitKey,
 			"0000000000000000000000000000000000000000000000000000000000000000",
 		);
 		assert.equal(hash, "0722d8002560934d7004b8b849101024bf7ec2aaa2c3396f7292d4ac8cdae5ab");
 	});
 
 	it("should return logs bloom", async ({ instance }) => {
-		const logsBloom = await instance.logsBloom({ height: BigInt(0), round: BigInt(0) });
+		const commitKey = { height: BigInt(0), round: BigInt(0) };
+		await instance.prepareNextCommit({ commitKey });
+
+		const logsBloom = await instance.logsBloom(commitKey);
 		assert.equal(logsBloom, "0".repeat(512));
 	});
 

--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -741,12 +741,8 @@ impl EvmInner {
     ) -> std::result::Result<String, EVMError<String>> {
         let pending_commit = self
             .pending_commits
-            .get(&commit_key)
-            .cloned() // TODO: try get rid of clone
-            .unwrap_or_else(|| PendingCommit {
-                key: commit_key,
-                ..Default::default()
-            });
+            .get_mut(&commit_key)
+            .expect("pending commit exists");
 
         let result = state_hash::calculate(&mut self.persistent_db, pending_commit, current_hash);
 
@@ -765,13 +761,9 @@ impl EvmInner {
         let pending_commit = self
             .pending_commits
             .get(&commit_key)
-            .cloned() // TODO: try get rid of clone
-            .unwrap_or_else(|| PendingCommit {
-                key: commit_key,
-                ..Default::default()
-            });
+            .expect("pending commit exists");
 
-        let result = logs_bloom::calculate(&pending_commit);
+        let result = logs_bloom::calculate(pending_commit);
 
         match result {
             Ok(result) => Ok(result.encode_hex()),

--- a/packages/evm/core/src/db.rs
+++ b/packages/evm/core/src/db.rs
@@ -194,7 +194,7 @@ pub struct CommitData {
     pub transactions: Vec<Bytes>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct PendingCommit {
     pub key: CommitKey,
     pub cache: CacheState,
@@ -212,6 +212,9 @@ pub struct PendingCommit {
     // The option indicates whether a corresponding cold wallet has been found and merged. To avoid
     // redundant lookups, any address present in the map is skipped when processing a transaction.
     pub merged_legacy_cold_wallets: BTreeMap<Address, Option<(B256, LegacyAddress)>>,
+
+    // Optimization to avoid unnecessary (deep) clones of commit data.
+    pub built_commit: Option<StateCommit>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -1096,6 +1099,7 @@ impl PendingCommit {
             legacy_attributes: Default::default(),
             legacy_cold_wallets: Default::default(),
             merged_legacy_cold_wallets: Default::default(),
+            built_commit: Default::default(),
         }
     }
 

--- a/packages/evm/core/src/logs_bloom.rs
+++ b/packages/evm/core/src/logs_bloom.rs
@@ -3,8 +3,12 @@ use revm::primitives::alloy_primitives::Bloom;
 use crate::db::PendingCommit;
 
 pub fn calculate(pending_commit: &PendingCommit) -> Result<Bloom, crate::db::Error> {
-    let receipt_blooms = pending_commit
-        .results
+    let results = match pending_commit.built_commit.as_ref() {
+        Some(commit) => &commit.results,
+        None => &pending_commit.results,
+    };
+
+    let receipt_blooms = results
         .values()
         .map(|r| Bloom::from_iter(r.logs()))
         .collect::<Vec<Bloom>>();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
