### PR TITLE
fix(evm): prevent opening same `heed::Env` multiple times to fix `EnvAlreadyOpened` error

### DIFF
--- a/packages/evm/Cargo.lock
+++ b/packages/evm/Cargo.lock
@@ -1926,8 +1926,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.20.5"
-source = "git+https://github.com/ArkEcosystem/heed.git?branch=mainsail#75ff3ac01fa861ba123266cfab28f182d3edf1b5"
+version = "0.22.0"
+source = "git+https://github.com/ArkEcosystem/heed.git?rev=83bdcc62631a12887fbc465c197423411a839a27#83bdcc62631a12887fbc465c197423411a839a27"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
@@ -1945,12 +1945,12 @@ dependencies = [
 [[package]]
 name = "heed-traits"
 version = "0.20.0"
-source = "git+https://github.com/ArkEcosystem/heed.git?branch=mainsail#75ff3ac01fa861ba123266cfab28f182d3edf1b5"
+source = "git+https://github.com/ArkEcosystem/heed.git?rev=83bdcc62631a12887fbc465c197423411a839a27#83bdcc62631a12887fbc465c197423411a839a27"
 
 [[package]]
 name = "heed-types"
-version = "0.20.1"
-source = "git+https://github.com/ArkEcosystem/heed.git?branch=mainsail#75ff3ac01fa861ba123266cfab28f182d3edf1b5"
+version = "0.21.0"
+source = "git+https://github.com/ArkEcosystem/heed.git?rev=83bdcc62631a12887fbc465c197423411a839a27#83bdcc62631a12887fbc465c197423411a839a27"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2487,8 +2487,8 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.4"
-source = "git+https://github.com/ArkEcosystem/heed.git?branch=mainsail#75ff3ac01fa861ba123266cfab28f182d3edf1b5"
+version = "0.2.5"
+source = "git+https://github.com/ArkEcosystem/heed.git?rev=83bdcc62631a12887fbc465c197423411a839a27#83bdcc62631a12887fbc465c197423411a839a27"
 dependencies = [
  "cc",
  "doxygen-rs",

--- a/packages/evm/core/Cargo.toml
+++ b/packages/evm/core/Cargo.toml
@@ -20,9 +20,9 @@ bincode = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 #heed = { version = "0.20.0", features = [] }
-heed = { path = "../../../../heed/heed", features = [] }
-# heed = { git = "https://github.com/ArkEcosystem/heed.git", branch = "mainsail", features = [
-# ] }
+#heed = { path = "../../../../heed/heed", features = [] }
+heed = { git = "https://github.com/ArkEcosystem/heed.git", rev = "83bdcc62631a12887fbc465c197423411a839a27", features = [
+] }
 rayon = "1.10.0"
 derive_more = { version = "2" }
 bytes = { version = "1.0" }

--- a/packages/evm/core/Cargo.toml
+++ b/packages/evm/core/Cargo.toml
@@ -20,9 +20,9 @@ bincode = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 #heed = { version = "0.20.0", features = [] }
-#heed = { path = "../../../../heed/heed", features = [] }
-heed = { git = "https://github.com/ArkEcosystem/heed.git", branch = "mainsail", features = [
-] }
+heed = { path = "../../../../heed/heed", features = [] }
+# heed = { git = "https://github.com/ArkEcosystem/heed.git", branch = "mainsail", features = [
+# ] }
 rayon = "1.10.0"
 derive_more = { version = "2" }
 bytes = { version = "1.0" }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
