### PR TITLE
refactor(api-evm): rename schemas 

### DIFF
--- a/packages/api-evm/source/actions/eth-call.ts
+++ b/packages/api-evm/source/actions/eth-call.ts
@@ -27,12 +27,12 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "prefixedHex" },
+					data: { $ref: "quantityHex" },
 					from: { $ref: "address" },
-					gas: { $ref: "prefixedHex" },
-					gasPrice: { $ref: "prefixedHex" },
+					gas: { $ref: "quantityHex" },
+					gasPrice: { $ref: "quantityHex" },
 					to: { $ref: "address" },
-					value: { $ref: "prefixedHex" },
+					value: { $ref: "quantityHex" },
 				},
 				required: ["to", "data"],
 				type: "object",

--- a/packages/api-evm/source/actions/eth-call.ts
+++ b/packages/api-evm/source/actions/eth-call.ts
@@ -27,12 +27,12 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "quantityHex" },
+					data: { $ref: "prefixedQuantityHex" },
 					from: { $ref: "address" },
-					gas: { $ref: "quantityHex" },
-					gasPrice: { $ref: "quantityHex" },
+					gas: { $ref: "prefixedQuantityHex" },
+					gasPrice: { $ref: "prefixedQuantityHex" },
 					to: { $ref: "address" },
-					value: { $ref: "quantityHex" },
+					value: { $ref: "prefixedQuantityHex" },
 				},
 				required: ["to", "data"],
 				type: "object",

--- a/packages/api-evm/source/actions/eth-call.ts
+++ b/packages/api-evm/source/actions/eth-call.ts
@@ -27,7 +27,7 @@ export class CallAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "prefixedQuantityHex" },
+					data: { $ref: "prefixedDataHex" },
 					from: { $ref: "address" },
 					gas: { $ref: "prefixedQuantityHex" },
 					gasPrice: { $ref: "prefixedQuantityHex" },

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -39,12 +39,12 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "dataHex" },
+					data: { $ref: "prefixedDataHex" },
 					from: { $ref: "address" },
-					gas: { $ref: "quantityHex" },
-					gasPrice: { $ref: "quantityHex" },
+					gas: { $ref: "prefixedQuantityHex" },
+					gasPrice: { $ref: "prefixedQuantityHex" },
 					to: { $ref: "address" },
-					value: { $ref: "quantityHex" },
+					value: { $ref: "prefixedQuantityHex" },
 				},
 				required: ["from", "to"],
 				type: "object",

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -41,10 +41,10 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 				properties: {
 					data: { $ref: "dataHex" },
 					from: { $ref: "address" },
-					gas: { $ref: "prefixedHex" },
-					gasPrice: { $ref: "prefixedHex" },
+					gas: { $ref: "quantityHex" },
+					gasPrice: { $ref: "quantityHex" },
 					to: { $ref: "address" },
-					value: { $ref: "prefixedHex" },
+					value: { $ref: "quantityHex" },
 				},
 				required: ["from", "to"],
 				type: "object",

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -12,6 +12,12 @@ type TxData = {
 	value?: string;
 };
 
+interface EstimateOutcome {
+	receipt?: Contracts.Evm.TransactionReceipt;
+	success: boolean;
+	executionError?: string;
+}
+
 @injectable()
 export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 	@inject(Identifiers.Evm.Instance)
@@ -169,10 +175,4 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 			return { executionError: error.message, success: false };
 		}
 	}
-}
-
-interface EstimateOutcome {
-	receipt?: Contracts.Evm.TransactionReceipt;
-	success: boolean;
-	executionError?: string;
 }

--- a/packages/api-evm/source/actions/eth-estimate-gas.ts
+++ b/packages/api-evm/source/actions/eth-estimate-gas.ts
@@ -39,7 +39,7 @@ export class EthEstimateGasAction implements Contracts.Api.RPC.Action {
 			{
 				additionalProperties: false,
 				properties: {
-					data: { $ref: "prefixedNullableHex" },
+					data: { $ref: "dataHex" },
 					from: { $ref: "address" },
 					gas: { $ref: "prefixedHex" },
 					gasPrice: { $ref: "prefixedHex" },

--- a/packages/api-evm/source/actions/eth-get-balance.test.ts
+++ b/packages/api-evm/source/actions/eth-get-balance.test.ts
@@ -38,7 +38,7 @@ describe<{
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(validationSchemas.prefixedQuantityHex);
 		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 

--- a/packages/api-evm/source/actions/eth-get-block-transaction-count-by-hash.test.ts
+++ b/packages/api-evm/source/actions/eth-get-block-transaction-count-by-hash.test.ts
@@ -30,7 +30,7 @@ describe<{
 	});
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
-		validator.addSchema(cryptoValidationSchemas.prefixedHex);
+		validator.addSchema(cryptoValidationSchemas.prefixedQuantityHex);
 		validator.addSchema(cryptoBlockSchemas.prefixedBlockHash);
 		validator.addSchema(action.schema);
 

--- a/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.test.ts
+++ b/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.test.ts
@@ -29,7 +29,7 @@ describe<{
 	});
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
-		validator.addSchema(cryptoValidationSchemas.prefixedHex);
+		validator.addSchema(cryptoValidationSchemas.prefixedQuantityHex);
 		validator.addSchema(action.schema);
 
 		assert.undefined(validator.validate("jsonRpc_eth_getBlockTransactionCountByNumber", ["0x0"]).errors);

--- a/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.ts
+++ b/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.ts
@@ -14,7 +14,7 @@ export class EthGetBlockTransactionCountByNumber implements Contracts.Api.RPC.Ac
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.ts
+++ b/packages/api-evm/source/actions/eth-get-block-transaction-count-by-number.ts
@@ -14,7 +14,7 @@ export class EthGetBlockTransactionCountByNumber implements Contracts.Api.RPC.Ac
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-code.test.ts
+++ b/packages/api-evm/source/actions/eth-get-code.test.ts
@@ -32,7 +32,7 @@ describe<{
 
 	it("schema should be ok", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(validationSchemas.prefixedQuantityHex);
 		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 

--- a/packages/api-evm/source/actions/eth-get-storage-at.test.ts
+++ b/packages/api-evm/source/actions/eth-get-storage-at.test.ts
@@ -32,7 +32,7 @@ describe<{
 
 	it("schema should be ok", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(validationSchemas.prefixedQuantityHex);
 		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 
@@ -50,7 +50,7 @@ describe<{
 				"0x0000000000000000000000000000000000000000",
 				"0x00000000000000000000000000000000000000000000000000000000000000000",
 				"latest",
-			]).errors[0].message,
+			]).errors![0].message,
 			"must NOT have more than 66 characters",
 		);
 	});

--- a/packages/api-evm/source/actions/eth-get-storage-at.ts
+++ b/packages/api-evm/source/actions/eth-get-storage-at.ts
@@ -17,7 +17,7 @@ export class EthGetStorageAtAction implements Contracts.Api.RPC.Action {
 
 		prefixItems: [
 			{ $ref: "address" },
-			{ allOf: [{ $ref: "prefixedHex" }, { maxLength: 66, type: "string" }] },
+			{ allOf: [{ $ref: "quantityHex" }, { maxLength: 66, type: "string" }] },
 			{ $ref: "blockTag" },
 		],
 		type: "array",

--- a/packages/api-evm/source/actions/eth-get-storage-at.ts
+++ b/packages/api-evm/source/actions/eth-get-storage-at.ts
@@ -17,7 +17,7 @@ export class EthGetStorageAtAction implements Contracts.Api.RPC.Action {
 
 		prefixItems: [
 			{ $ref: "address" },
-			{ allOf: [{ $ref: "quantityHex" }, { maxLength: 66, type: "string" }] },
+			{ allOf: [{ $ref: "prefixedQuantityHex" }, { maxLength: 66, type: "string" }] },
 			{ $ref: "blockTag" },
 		],
 		type: "array",

--- a/packages/api-evm/source/actions/eth-get-transaction-by-block-hash-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-by-block-hash-and-index.ts
@@ -19,7 +19,7 @@ export class EthGetTransactionByBlockHashAndIndex implements Contracts.Api.RPC.A
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-transaction-by-block-hash-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-by-block-hash-and-index.ts
@@ -19,7 +19,7 @@ export class EthGetTransactionByBlockHashAndIndex implements Contracts.Api.RPC.A
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-transaction-by-block-number-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-by-block-number-and-index.ts
@@ -19,7 +19,7 @@ export class EthGetTransactionByBlockNumberAndIndex implements Contracts.Api.RPC
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedHex" }, { $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }, { $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-transaction-by-block-number-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-by-block-number-and-index.ts
@@ -19,7 +19,7 @@ export class EthGetTransactionByBlockNumberAndIndex implements Contracts.Api.RPC
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "quantityHex" }, { $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }, { $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-transaction-count.test.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-count.test.ts
@@ -38,7 +38,7 @@ describe<{
 
 	it("schema should be array with 0 parameters", ({ action, validator }) => {
 		validator.addSchema(keccak256Schemas.address);
-		validator.addSchema(validationSchemas.prefixedHex);
+		validator.addSchema(validationSchemas.prefixedQuantityHex);
 		validator.addSchema(schemas.blockTag);
 		validator.addSchema(action.schema);
 

--- a/packages/api-evm/source/actions/eth-get-uncle-by-block-hash-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-by-block-hash-and-index.ts
@@ -13,7 +13,7 @@ export class EthGetUncleByBlockHashAndIndex implements Contracts.Api.RPC.Action 
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-uncle-by-block-hash-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-by-block-hash-and-index.ts
@@ -13,7 +13,7 @@ export class EthGetUncleByBlockHashAndIndex implements Contracts.Api.RPC.Action 
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "prefixedBlockHash" }, { $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-uncle-by-block-number-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-by-block-number-and-index.ts
@@ -13,7 +13,7 @@ export class EthGetUncleByBlockNumberAndIndex implements Contracts.Api.RPC.Actio
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "quantityHex" }, { $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }, { $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-uncle-by-block-number-and-index.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-by-block-number-and-index.ts
@@ -13,7 +13,7 @@ export class EthGetUncleByBlockNumberAndIndex implements Contracts.Api.RPC.Actio
 		maxItems: 2,
 		minItems: 2,
 
-		prefixItems: [{ $ref: "prefixedHex" }, { $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }, { $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-uncle-count-by-block-number.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-count-by-block-number.ts
@@ -13,7 +13,7 @@ export class EthGetUncleCountByBlockNumber implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-uncle-count-by-block-number.ts
+++ b/packages/api-evm/source/actions/eth-get-uncle-count-by-block-number.ts
@@ -13,7 +13,7 @@ export class EthGetUncleCountByBlockNumber implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-send-raw-transaction.ts
+++ b/packages/api-evm/source/actions/eth-send-raw-transaction.ts
@@ -15,7 +15,7 @@ export class EthSendRawTransactionAction implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-send-raw-transaction.ts
+++ b/packages/api-evm/source/actions/eth-send-raw-transaction.ts
@@ -15,7 +15,7 @@ export class EthSendRawTransactionAction implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/web3-sha3.test.ts
+++ b/packages/api-evm/source/actions/web3-sha3.test.ts
@@ -26,14 +26,14 @@ describe<{
 	});
 
 	it("schema should be ok", ({ action, validator }) => {
-		validator.addSchema(cryptoValidationSchemas.prefixedHex);
+		validator.addSchema(cryptoValidationSchemas.prefixedQuantityHex);
 
 		assert.equal(action.schema, {
 			$id: `jsonRpc_web3_sha3`,
 			maxItems: 1,
 			minItems: 1,
 
-			prefixItems: [{ $ref: "prefixedHex" }],
+			prefixItems: [{ $ref: "prefixedQuantityHex" }],
 			type: "array",
 		});
 

--- a/packages/api-evm/source/actions/web3-sha3.ts
+++ b/packages/api-evm/source/actions/web3-sha3.ts
@@ -11,7 +11,7 @@ export class Web3Sha3 implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "quantityHex" }],
+		prefixItems: [{ $ref: "prefixedQuantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/web3-sha3.ts
+++ b/packages/api-evm/source/actions/web3-sha3.ts
@@ -11,7 +11,7 @@ export class Web3Sha3 implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedHex" }],
+		prefixItems: [{ $ref: "quantityHex" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/validation/schemas.ts
+++ b/packages/api-evm/source/validation/schemas.ts
@@ -9,7 +9,7 @@ export const schemas: Record<"blockTag", AnySchemaObject> = {
 				type: "string",
 			},
 			{
-				$ref: "quantityHex",
+				$ref: "prefixedQuantityHex",
 				// currentHeightHex: true, // TODO: Implement historical data and enable later
 			},
 		],

--- a/packages/api-evm/source/validation/schemas.ts
+++ b/packages/api-evm/source/validation/schemas.ts
@@ -9,7 +9,7 @@ export const schemas: Record<"blockTag", AnySchemaObject> = {
 				type: "string",
 			},
 			{
-				$ref: "prefixedHex",
+				$ref: "quantityHex",
 				// currentHeightHex: true, // TODO: Implement historical data and enable later
 			},
 		],

--- a/packages/core/bin/config/testnet/core/app.json
+++ b/packages/core/bin/config/testnet/core/app.json
@@ -76,12 +76,6 @@
 			"package": "@mainsail/p2p"
 		},
 		{
-			"package": "@mainsail/api-database"
-		},
-		{
-			"package": "@mainsail/api-sync"
-		},
-		{
 			"package": "@mainsail/evm-api-worker"
 		},
 		{

--- a/packages/crypto-block/source/schemas.ts
+++ b/packages/crypto-block/source/schemas.ts
@@ -81,7 +81,7 @@ export const schemas: Record<
 		$id: "prefixedBlockHash",
 		allOf: [
 			{
-				$ref: "prefixedHex",
+				$ref: "quantityHex",
 				maxLength: 66,
 				minLength: 66,
 			},

--- a/packages/crypto-block/source/schemas.ts
+++ b/packages/crypto-block/source/schemas.ts
@@ -81,7 +81,7 @@ export const schemas: Record<
 		$id: "prefixedBlockHash",
 		allOf: [
 			{
-				$ref: "quantityHex",
+				$ref: "prefixedQuantityHex",
 				maxLength: 66,
 				minLength: 66,
 			},

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -8,7 +8,7 @@ const transactionId: SchemaObject = {
 
 const prefixedTransactionId: SchemaObject = {
 	$id: "prefixedTransactionId",
-	allOf: [{ maxLength: 66, minLength: 66 }, { $ref: "quantityHex" }],
+	allOf: [{ maxLength: 66, minLength: 66 }, { $ref: "prefixedQuantityHex" }],
 	type: "string",
 };
 

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -8,7 +8,7 @@ const transactionId: SchemaObject = {
 
 const prefixedTransactionId: SchemaObject = {
 	$id: "prefixedTransactionId",
-	allOf: [{ maxLength: 66, minLength: 66 }, { $ref: "prefixedHex" }],
+	allOf: [{ maxLength: 66, minLength: 66 }, { $ref: "quantityHex" }],
 	type: "string",
 };
 

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -1,9 +1,14 @@
 import { SchemaObject } from "ajv";
 
-export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "prefixedNullableHex", SchemaObject> = {
+export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "dataHex", SchemaObject> = {
 	alphanumeric: {
 		$id: "alphanumeric",
 		pattern: "^[a-z0-9]+$",
+		type: "string",
+	},
+	dataHex: {
+		$id: "dataHex",
+		pattern: "^0x[0-9a-f]*$",
 		type: "string",
 	},
 	hex: {
@@ -14,11 +19,6 @@ export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "prefixedN
 	prefixedHex: {
 		$id: "prefixedHex",
 		pattern: "^0x[0-9a-f]+$",
-		type: "string",
-	},
-	prefixedNullableHex: {
-		$id: "prefixedNullableHex",
-		pattern: "^0x[0-9a-f]*$",
 		type: "string",
 	},
 };

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -1,6 +1,6 @@
 import { SchemaObject } from "ajv";
 
-export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "dataHex", SchemaObject> = {
+export const schemas: Record<"alphanumeric" | "hex" | "quantityHex" | "dataHex", SchemaObject> = {
 	alphanumeric: {
 		$id: "alphanumeric",
 		pattern: "^[a-z0-9]+$",
@@ -16,8 +16,8 @@ export const schemas: Record<"alphanumeric" | "hex" | "prefixedHex" | "dataHex",
 		pattern: "^[0123456789a-f]+$",
 		type: "string",
 	},
-	prefixedHex: {
-		$id: "prefixedHex",
+	quantityHex: {
+		$id: "quantityHex",
 		pattern: "^0x[0-9a-f]+$",
 		type: "string",
 	},

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -6,14 +6,14 @@ export const schemas: Record<"alphanumeric" | "hex" | "prefixedQuantityHex" | "p
 		pattern: "^[a-z0-9]+$",
 		type: "string",
 	},
-	prefixedDataHex: {
-		$id: "prefixedDataHex",
-		pattern: "^0x[0-9a-f]*$",
-		type: "string",
-	},
 	hex: {
 		$id: "hex",
 		pattern: "^[0123456789a-f]+$",
+		type: "string",
+	},
+	prefixedDataHex: {
+		$id: "prefixedDataHex",
+		pattern: "^0x([0-9a-f]{2})*$",
 		type: "string",
 	},
 	prefixedQuantityHex: {

--- a/packages/crypto-validation/source/schemas.ts
+++ b/packages/crypto-validation/source/schemas.ts
@@ -1,13 +1,13 @@
 import { SchemaObject } from "ajv";
 
-export const schemas: Record<"alphanumeric" | "hex" | "quantityHex" | "dataHex", SchemaObject> = {
+export const schemas: Record<"alphanumeric" | "hex" | "prefixedQuantityHex" | "prefixedDataHex", SchemaObject> = {
 	alphanumeric: {
 		$id: "alphanumeric",
 		pattern: "^[a-z0-9]+$",
 		type: "string",
 	},
-	dataHex: {
-		$id: "dataHex",
+	prefixedDataHex: {
+		$id: "prefixedDataHex",
 		pattern: "^0x[0-9a-f]*$",
 		type: "string",
 	},
@@ -16,8 +16,8 @@ export const schemas: Record<"alphanumeric" | "hex" | "quantityHex" | "dataHex",
 		pattern: "^[0123456789a-f]+$",
 		type: "string",
 	},
-	quantityHex: {
-		$id: "quantityHex",
+	prefixedQuantityHex: {
+		$id: "prefixedQuantityHex",
 		pattern: "^0x[0-9a-f]+$",
 		type: "string",
 	},


### PR DESCRIPTION
## Summary

Rename schemas to match Ethereum API [convetions](https://ethereum.org/en/developers/docs/apis/json-rpc#conventions).
Require even number of character in **prefixedDataSchema** schema.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
