### PR TITLE
refactor(api-database): always enable when running in api process

### DIFF
--- a/packages/api-database/source/service-provider.ts
+++ b/packages/api-database/source/service-provider.ts
@@ -192,6 +192,9 @@ export class ServiceProvider extends Providers.ServiceProvider {
 	}
 
 	#isEnabled(): boolean {
-		return this.config().getRequired<boolean>("enabled") === true && !this.app.isWorker();
+		return (
+			this.app.name() === "api" ||
+			(this.config().getRequired<boolean>("enabled") === true && !this.app.isWorker())
+		);
 	}
 }

--- a/packages/api-http/test/helpers/prepare-sandbox.ts
+++ b/packages/api-http/test/helpers/prepare-sandbox.ts
@@ -6,8 +6,8 @@ import {
 import { Identifiers } from "@mainsail/contracts";
 import { Application, Providers } from "@mainsail/kernel";
 
-import { Sandbox } from "../../../test-framework/source";
-import { ServiceProvider as CoreApiHttp } from "../../source/service-provider";
+import { Sandbox } from "../../../test-framework/source/index.js";
+import { ServiceProvider as CoreApiHttp } from "../../source/service-provider.js";
 
 export class ApiContext {
 	public constructor(
@@ -99,6 +99,8 @@ export class ApiContext {
 
 export const prepareSandbox = async (context: { sandbox: Sandbox }): Promise<ApiContext> => {
 	context.sandbox = new Sandbox();
+
+	context.sandbox.app.bind(Identifiers.Application.Name).toConstantValue("api-http-integration");
 
 	context.sandbox.app
 		.bind(Identifiers.ServiceProvider.Configuration)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Removes the need to set `CORE_API_SYNC_ENABLED=` in the API env.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
