### PR TITLE
refactor(api-common): disable internal hapi debug logging

### DIFF
--- a/packages/api-common/source/server.ts
+++ b/packages/api-common/source/server.ts
@@ -127,6 +127,8 @@ export abstract class AbstractServer {
 			options.tls.cert = readFileSync(options.tls.cert).toString();
 		}
 
+		options.debug = false;
+
 		const defaultOptions = this.defaultOptions();
 		return merge(defaultOptions, options);
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
We are already logging errors in the `onPreResponse` handler and don't need the internal hapi debug logging. Disabling it reduces the noise in the logs and ensures everything goes through pino and ends up in the file logs too.

For quick testing this command can be used: `curl -X POST "http://localhost:4007/api/transactions" -d ''`

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
