### PR TITLE
fix(p2p): use `skipPeerStateVerification` on TX pool verifier

### DIFF
--- a/packages/p2p/source/defaults.ts
+++ b/packages/p2p/source/defaults.ts
@@ -25,6 +25,7 @@ export const defaults = {
 		logLevel: Environment.get(Constants.EnvironmentVariables.MAINSAIL_NETWORK_NAME) === "devnet" ? 1 : 0,
 		port: Environment.get(Constants.EnvironmentVariables.MAINSAIL_P2P_PORT, 4002),
 	},
+	skipPeerStateVerification: Environment.isTrue(Constants.EnvironmentVariables.MAINSAIL_SKIP_PEER_STATE_VERIFICATION),
 	txPoolPort: Environment.get(Constants.EnvironmentVariables.MAINSAIL_API_TRANSACTION_POOL_PORT, 4007),
 	verifyTimeout: 60_000,
 	whitelist: ["*"],

--- a/packages/p2p/source/peer-verifier.ts
+++ b/packages/p2p/source/peer-verifier.ts
@@ -1,5 +1,6 @@
-import { inject, injectable } from "@mainsail/container";
-import { Constants, Contracts, Identifiers } from "@mainsail/contracts";
+import { inject, injectable, tagged } from "@mainsail/container";
+import { Contracts, Identifiers } from "@mainsail/contracts";
+import { Providers } from "@mainsail/kernel";
 import { assert } from "@mainsail/utils";
 import dayjs from "dayjs";
 
@@ -31,8 +32,12 @@ export class PeerVerifier implements Contracts.P2P.PeerVerifier {
 	@inject(Identifiers.P2P.Logger)
 	private readonly logger!: Contracts.P2P.Logger;
 
+	@inject(Identifiers.ServiceProvider.Configuration)
+	@tagged("plugin", "p2p")
+	private readonly configuration!: Providers.PluginConfiguration;
+
 	public async verify(peer: Contracts.P2P.Peer): Promise<boolean> {
-		if (process.env[Constants.EnvironmentVariables.MAINSAIL_SKIP_PEER_STATE_VERIFICATION] === "true") {
+		if (this.configuration.getRequired<boolean>("skipPeerStateVerification")) {
 			return true;
 		}
 

--- a/packages/p2p/source/service-provider.ts
+++ b/packages/p2p/source/service-provider.ts
@@ -92,6 +92,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 				port: Joi.number().integer().min(1).max(65_535).required(), // TODO: Check
 			}).required(),
 			skipDiscovery: Joi.bool(),
+			skipPeerStateVerification: Joi.bool(),
 			txPoolPort: Joi.number().integer().min(0).required(),
 			verifyTimeout: Joi.number().integer().min(0).required(),
 			whitelist: Joi.array().items(Joi.string()).required(),

--- a/packages/p2p/source/tx-pool-node-verifier.ts
+++ b/packages/p2p/source/tx-pool-node-verifier.ts
@@ -1,5 +1,6 @@
-import { inject, injectable } from "@mainsail/container";
+import { inject, injectable, tagged } from "@mainsail/container";
 import { Constants, Contracts, Identifiers } from "@mainsail/contracts";
+import { Providers } from "@mainsail/kernel";
 import { http, HttpResponse } from "@mainsail/utils";
 
 const helloWorld = { data: "Hello World from Transaction Pool API!" };
@@ -10,7 +11,15 @@ export class TxPoolNodeVerifier implements Contracts.P2P.TxPoolNodeVerifier {
 	@inject(Identifiers.P2P.Logger)
 	private readonly logger!: Contracts.P2P.Logger;
 
+	@inject(Identifiers.ServiceProvider.Configuration)
+	@tagged("plugin", "p2p")
+	private readonly configuration!: Providers.PluginConfiguration;
+
 	public async verify(node: Contracts.P2P.TxPoolNode): Promise<boolean> {
+		if (this.configuration.getRequired<boolean>("skipPeerStateVerification")) {
+			return true;
+		}
+
 		try {
 			const response = await http.get(node.url, {
 				headers: {},


### PR DESCRIPTION
## Summary

Add skipPeerStateVerification to defaults and use it in TX pool verifier.  

## Checklist

- [x] Ready to be merged
