### PR TITLE
perf(crypto-block): use workers to deserialize transactions

### DIFF
--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -75,6 +75,14 @@ export interface SerializeOptions {
 	// TODO: consider passing pre-allocated buffer
 }
 
+export interface TransactionCryptoData {
+	readonly hash: string;
+	readonly publicKey: string;
+	readonly address: string;
+	readonly legacyAddress?: string;
+	readonly schemaError?: any;
+}
+
 export interface TransactionServiceProvider {
 	register(): Promise<void>;
 }
@@ -108,6 +116,8 @@ export interface TransactionFactory {
 	fromJson(json: TransactionJson): Promise<Transaction>;
 
 	fromData(data: TransactionData, strict?: boolean): Promise<Transaction>;
+
+	computeCryptoData(data: TransactionData): Promise<TransactionCryptoData>;
 }
 
 export type TransactionConstructor = any;

--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -97,7 +97,7 @@ export interface TransactionSerializer {
 }
 
 export interface TransactionDeserializer {
-	deserialize(serialized: string | Buffer): Promise<Transaction>;
+	deserialize(serialized: Buffer): Promise<Transaction>;
 }
 
 export interface TransactionFactory {

--- a/packages/crypto-block/source/deserializer.ts
+++ b/packages/crypto-block/source/deserializer.ts
@@ -142,6 +142,9 @@ export class Deserializer implements Contracts.Crypto.BlockDeserializer {
 					throw new Exceptions.TransactionSchemaError(computed.schemaError);
 				}
 
+				transaction.data.data = transaction.data.data.startsWith("0x")
+					? transaction.data.data.slice(2)
+					: transaction.data.data;
 				transaction.data.hash = computed.hash;
 				transaction.data.from = computed.address;
 				transaction.data.senderPublicKey = computed.publicKey;

--- a/packages/crypto-block/source/deserializer.ts
+++ b/packages/crypto-block/source/deserializer.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
-import { inject, injectable } from "@mainsail/container";
-import { Contracts, Identifiers, Utils } from "@mainsail/contracts";
+import { inject, injectable, optional } from "@mainsail/container";
+import { Contracts, Exceptions, Identifiers, Utils } from "@mainsail/contracts";
 import { TransactionFactory } from "@mainsail/crypto-transaction";
 import { ByteBuffer, sleep } from "@mainsail/utils";
 
@@ -14,11 +14,18 @@ export class Deserializer implements Contracts.Crypto.BlockDeserializer {
 	@inject(Identifiers.Cryptography.Transaction.Factory)
 	private readonly transactionFactory!: TransactionFactory;
 
+	@inject(Identifiers.Cryptography.Transaction.Deserializer)
+	private readonly transactionDeserializer!: Contracts.Crypto.TransactionDeserializer;
+
 	@inject(Identifiers.Cryptography.Serializer)
 	private readonly serializer!: Contracts.Serializer.Serializer;
 
 	@inject(Identifiers.Cryptography.Block.HeaderSize)
 	private readonly headerSize!: () => number;
+
+	@inject(Identifiers.CryptoWorker.WorkerPool)
+	@optional()
+	private readonly workerPool: Contracts.Crypto.WorkerPool | undefined;
 
 	public async deserializeHeader(serialized: Buffer): Promise<Contracts.Crypto.BlockHeader> {
 		const buffer: ByteBuffer = ByteBuffer.fromBuffer(serialized);
@@ -120,20 +127,42 @@ export class Deserializer implements Contracts.Crypto.BlockDeserializer {
 		 * We keep this behaviour out of the (de)serialiser because it
 		 * is very specific to this bit of code in this specific class.
 		 */
-		const transactions: Contracts.Crypto.Transaction[] = [];
+		const transactions: Contracts.Crypto.Transaction[] = new Array(block.transactionsCount);
 
-		for (let index = 0; index < block.transactions.length; index++) {
-			if (index % 20 === 0) {
-				await sleep(0);
-			}
+		await Promise.all(
+			block.transactions.map(async (serialized, index) => {
+				const transaction = await this.transactionDeserializer.deserialize(serialized as any);
 
-			const transaction = await this.transactionFactory.fromBytes(block.transactions[index] as any);
+				if (index % 20 === 0) {
+					await sleep(0);
+				}
 
-			transactions.push(transaction);
+				const computed = await this.#computeCryptoData(transaction.data);
+				if (computed.schemaError) {
+					throw new Exceptions.TransactionSchemaError(computed.schemaError);
+				}
 
-			block.transactions[index] = transaction.data;
-		}
+				transaction.data.hash = computed.hash;
+				transaction.data.from = computed.address;
+				transaction.data.senderPublicKey = computed.publicKey;
+				transaction.data.senderLegacyAddress = computed.legacyAddress;
+
+				transactions[index] = transaction;
+				block.transactions[index] = transaction.data;
+			}),
+		);
 
 		return transactions;
+	}
+
+	async #computeCryptoData(
+		transaction: Contracts.Crypto.TransactionData,
+	): Promise<Contracts.Crypto.TransactionCryptoData> {
+		if (this.workerPool) {
+			const worker = await this.workerPool.getWorker();
+			return worker.transactionFactory("computeCryptoData", transaction);
+		}
+
+		return this.transactionFactory.computeCryptoData(transaction);
 	}
 }

--- a/packages/crypto-block/source/factory.ts
+++ b/packages/crypto-block/source/factory.ts
@@ -98,12 +98,11 @@ export class BlockFactory implements Contracts.Crypto.BlockFactory {
 			if (match === null) {
 				fatal = true;
 			} else {
-				const txIndex = match[1];
-
 				if (data.transactions) {
+					const txIndex = Number(match[1]);
 					const tx = data.transactions[txIndex];
 
-					if (tx.id === undefined) {
+					if (tx.hash === undefined) {
 						fatal = true;
 					}
 				}

--- a/packages/crypto-messages/source/factory.test.ts
+++ b/packages/crypto-messages/source/factory.test.ts
@@ -45,6 +45,11 @@ describe<{
 						context.sandbox.app
 							.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
 							[method](message, privateKey),
+					// @ts-ignore
+					transactionFactory: (method, message, privateKey) =>
+						context.sandbox.app
+							.get(Identifiers.Cryptography.Transaction.Factory)!
+							[method](message, privateKey),
 				};
 			},
 		};

--- a/packages/crypto-messages/source/proposal.test.ts
+++ b/packages/crypto-messages/source/proposal.test.ts
@@ -30,6 +30,9 @@ describe<{
 					context.sandbox.app
 						.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
 						[method](message, privateKey),
+				// @ts-ignore
+				transactionFactory: (method, message, privateKey) =>
+					context.sandbox.app.get(Identifiers.Cryptography.Transaction.Factory)![method](message, privateKey),
 			}),
 		};
 

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { BigNumber } from "@mainsail/utils";
-import { fromRlp, getAddress, Hex, hexToBigInt } from "viem";
+import { ByteArray, fromRlp, getAddress, Hex, hexToBigInt } from "viem";
 
 @injectable()
 export class Deserializer implements Contracts.Crypto.TransactionDeserializer {
@@ -11,10 +11,10 @@ export class Deserializer implements Contracts.Crypto.TransactionDeserializer {
 	@inject(Identifiers.Cryptography.Configuration)
 	private readonly configuration!: Contracts.Crypto.Configuration;
 
-	public async deserialize(serialized: Buffer | string): Promise<Contracts.Crypto.Transaction> {
+	public async deserialize(serialized: Buffer): Promise<Contracts.Crypto.Transaction> {
 		const data = {} as Contracts.Crypto.TransactionData;
 
-		const encodedRlp = ("0x" + (typeof serialized === "string" ? serialized : serialized.toString("hex"))) as Hex;
+		const encodedRlp = serialized as ByteArray;
 		const decoded = fromRlp(encodedRlp);
 		const recipientAddressRaw = this.#parseAddress(decoded[3].toString());
 
@@ -48,7 +48,7 @@ export class Deserializer implements Contracts.Crypto.TransactionDeserializer {
 
 		const instance: Contracts.Crypto.Transaction = this.transactionTypeFactory.create(data);
 
-		instance.serialized = Buffer.from(`${encodedRlp.slice(2)}`, "hex");
+		instance.serialized = serialized;
 
 		return instance;
 	}

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -34,11 +34,11 @@ export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
 	private readonly transactionTypeFactory!: Contracts.Transactions.TransactionTypeFactory;
 
 	public async fromHex(hex: string): Promise<Contracts.Crypto.Transaction> {
-		return this.#fromSerialized(hex);
+		return this.#fromSerialized(Buffer.from(hex, "hex"));
 	}
 
 	public async fromBytes(buff: Buffer, strict = true): Promise<Contracts.Crypto.Transaction> {
-		return this.#fromSerialized(buff.toString("hex"), strict);
+		return this.#fromSerialized(buff, strict);
 	}
 
 	public async fromJson(json: Contracts.Crypto.TransactionJson): Promise<Contracts.Crypto.Transaction> {
@@ -62,7 +62,7 @@ export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
 		return this.fromBytes(transaction.serialized, strict);
 	}
 
-	async #fromSerialized(serialized: string, strict = true): Promise<Contracts.Crypto.Transaction> {
+	async #fromSerialized(serialized: Buffer, strict = true): Promise<Contracts.Crypto.Transaction> {
 		try {
 			const transaction = await this.deserializer.deserialize(serialized);
 

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, optional, tagged } from "@mainsail/container";
 import { Contracts, Exceptions, Identifiers } from "@mainsail/contracts";
-import { assert } from "@mainsail/utils";
+import { assert, BigNumber } from "@mainsail/utils";
 
 @injectable()
 export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
@@ -62,38 +62,66 @@ export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
 		return this.fromBytes(transaction.serialized, strict);
 	}
 
+	public async computeCryptoData(
+		data: Contracts.Crypto.TransactionData,
+		strict = true,
+	): Promise<Contracts.Crypto.TransactionCryptoData> {
+		assert.number(data.v);
+		assert.string(data.r);
+		assert.string(data.s);
+
+		// Passing via IPC converts BigNumber to '{ value: bigint }'
+		if ("value" in data.value) {
+			data.value = BigNumber.make(data.value["value"]);
+		}
+
+		if ("value" in data.nonce) {
+			data.nonce = BigNumber.make(data.nonce["value"]);
+		}
+
+		const hash = await this.utils.toHash(data, {
+			excludeSignature: true,
+		});
+
+		const publicKey = this.signatureSerializer.recoverPublicKey(hash, {
+			r: data.r,
+			s: data.s,
+			v: data.v,
+		});
+
+		const address = await this.addressFactory.fromPublicKey(publicKey);
+
+		let legacyAddress: string | undefined;
+		if (this.legacyAddressFactory) {
+			legacyAddress = await this.legacyAddressFactory.fromPublicKey(publicKey);
+		}
+
+		const signedHash = await this.utils.toHash(data, {
+			excludeSignature: false,
+		});
+
+		// Assign to pass schema check
+		data.hash = signedHash.toString("hex");
+		data.from = address;
+		data.senderPublicKey = publicKey;
+		data.senderLegacyAddress = legacyAddress;
+
+		const { error } = await this.verifier.verifySchema(data, strict);
+
+		return {
+			hash: data.hash,
+			publicKey,
+			address,
+			legacyAddress,
+			schemaError: error,
+		};
+	}
+
 	async #fromSerialized(serialized: Buffer, strict = true): Promise<Contracts.Crypto.Transaction> {
 		try {
 			const transaction = await this.deserializer.deserialize(serialized);
 
-			assert.number(transaction.data.v);
-			assert.string(transaction.data.r);
-			assert.string(transaction.data.s);
-
-			const hash = await this.utils.toHash(transaction.data, {
-				excludeSignature: true,
-			});
-
-			transaction.data.senderPublicKey = this.signatureSerializer.recoverPublicKey(hash, {
-				r: transaction.data.r,
-				s: transaction.data.s,
-				v: transaction.data.v,
-			});
-			transaction.data.from = await this.addressFactory.fromPublicKey(transaction.data.senderPublicKey);
-
-			if (this.legacyAddressFactory) {
-				transaction.data.senderLegacyAddress = await this.legacyAddressFactory.fromPublicKey(
-					transaction.data.senderPublicKey,
-				);
-			}
-
-			transaction.data.hash = await this.utils.getHash(transaction);
-
-			const { error } = await this.verifier.verifySchema(transaction.data, strict);
-
-			if (error) {
-				throw new Exceptions.TransactionSchemaError(error);
-			}
+			await this.computeCryptoData(transaction.data, strict);
 
 			return transaction;
 		} catch (error) {

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -109,10 +109,10 @@ export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
 		const { error } = await this.verifier.verifySchema(data, strict);
 
 		return {
-			hash: data.hash,
-			publicKey,
 			address,
+			hash: data.hash,
 			legacyAddress,
+			publicKey,
 			schemaError: error,
 		};
 	}

--- a/tests/functional/transaction-pool-api/source/worker.ts
+++ b/tests/functional/transaction-pool-api/source/worker.ts
@@ -6,8 +6,8 @@ export class Worker implements Contracts.Crypto.WorkerScriptHandler {
 	// @inject(Identifiers.Cryptography.Block.Factory)
 	// private readonly blockFactoryImp!: Contracts.Crypto.BlockFactory;
 
-	// @inject(Identifiers.Cryptography.Transaction.Factory)
-	// private readonly transactionFactoryImp!: Contracts.Crypto.TransactionFactory;
+	@inject(Identifiers.Cryptography.Transaction.Factory)
+	private readonly transactionFactoryImp!: Contracts.Crypto.TransactionFactory;
 
 	@inject(Identifiers.Cryptography.Signature.Instance)
 	@tagged("type", "consensus")
@@ -50,7 +50,7 @@ export class Worker implements Contracts.Crypto.WorkerScriptHandler {
 		method: K,
 		...arguments_: Parameters<Contracts.Crypto.TransactionFactory[K]>
 	): Promise<ReturnType<Contracts.Crypto.TransactionFactory[K]>> {
-		throw new Error("Method transactionFactory not implemented.");
+		return this.#call(this.transactionFactoryImp, method, arguments_);
 	}
 
 	public async publicKeyFactory<K extends Contracts.Kernel.IPC.Requests<Contracts.Crypto.PublicKeyFactory>>(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Improve full block deserialization performance by offloading the expensive cryptographic operations to workers.

<details>

Below numbers should give an idea on what to expect, even though they are a bit noisy.

Deserializing batches in block downloader:

```
Blocks: 53, Txs: 966

0 workers
batch-commits: 241.341ms

2 workers
batch-commits: 145.752ms

4 workers
batch-commits: 94.221ms

8 workers
batch-commits: 81.81ms
```

Deserializing singe  blocks:

```
0 workers:
block-with-txs-71: 14.091ms
block-with-txs-71: 17.147ms
block-with-txs-70: 20.133ms
block-with-txs-70: 16.625ms
block-with-txs-70: 13.686ms
block-with-txs-70: 16.349ms

2 Workers
block-with-txs-71: 9.336ms
block-with-txs-71: 6.765ms
block-with-txs-70: 7.461ms
block-with-txs-70: 7.157ms
block-with-txs-70: 6.303ms
block-with-txs-70: 6.466ms

4 workers
block-with-txs-71: 8.375ms
block-with-txs-71: 4.612ms
block-with-txs-70: 4.57ms
block-with-txs-70: 6.01ms
block-with-txs-70: 6.728ms
block-with-txs-70: 4.877ms

8 workers
block-with-txs-71: 8.057ms
block-with-txs-71: 6.056ms
block-with-txs-70: 6.472ms
block-with-txs-70: 6.323ms
block-with-txs-70: 5.078ms
block-with-txs-70: 6.673ms
```
</details>

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
