### PR TITLE
perf(api-sync): read usernames from snapshot and receipts

### DIFF
--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -220,11 +220,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         _verifyAndRegisterBlsPublicKey(blsPublicKey);
 
         ValidatorData memory validator = ValidatorData({
-            votersCount: 0,
-            voteBalance: 0,
-            fee: uint128(msg.value),
-            isResigned: false,
-            blsPublicKey: blsPublicKey
+            votersCount: 0, voteBalance: 0, fee: uint128(msg.value), isResigned: false, blsPublicKey: blsPublicKey
         });
 
         _hasValidator[msg.sender] = true;
@@ -371,9 +367,9 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
 
             ValidatorData storage headData = _validatorsData[_roundValidatorsHead];
 
-            if (
-                _isGreater(Validator({addr: addr, data: data}), Validator({addr: _roundValidatorsHead, data: headData}))
-            ) {
+            if (_isGreater(
+                    Validator({addr: addr, data: data}), Validator({addr: _roundValidatorsHead, data: headData})
+                )) {
                 _insertValidator(addr, top);
             }
         }
@@ -534,7 +530,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             /* Swap example
             i = 0; j = 2;
 
-    		Initial state
+            Initial state
             A B C
             A:0 B:1 C:2
 
@@ -590,12 +586,10 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
     function _insertValidator(address addr, uint8 top) internal {
         ValidatorData memory data = _validatorsData[addr];
 
-        if (
-            _isGreater(
+        if (_isGreater(
                 Validator({addr: _roundValidatorsHead, data: _validatorsData[_roundValidatorsHead]}),
                 Validator({addr: addr, data: data})
-            )
-        ) {
+            )) {
             _insertHead(addr);
         } else {
             address current = _roundValidatorsMap[_roundValidatorsHead];
@@ -607,11 +601,9 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
                     break;
                 }
 
-                if (
-                    _isGreater(
+                if (_isGreater(
                         Validator({addr: current, data: _validatorsData[current]}), Validator({addr: addr, data: data})
-                    )
-                ) {
+                    )) {
                     _insertAfter(previous, addr);
                     break;
                 }

--- a/packages/api-sync/source/parsers/index.ts
+++ b/packages/api-sync/source/parsers/index.ts
@@ -1,3 +1,3 @@
 export * from "./multi-payment.js";
-export * from "./username.js";
 export * from "./transaction-error.js";
+export * from "./username.js";

--- a/packages/api-sync/source/parsers/index.ts
+++ b/packages/api-sync/source/parsers/index.ts
@@ -1,2 +1,3 @@
 export * from "./multi-payment.js";
+export * from "./username.js";
 export * from "./transaction-error.js";

--- a/packages/api-sync/source/parsers/username.ts
+++ b/packages/api-sync/source/parsers/username.ts
@@ -1,0 +1,35 @@
+import { Contracts } from "@mainsail/contracts";
+import { parseAbi, parseEventLogs } from "viem";
+
+const paymentAbi = parseAbi([
+	"event UsernameRegistered(address addr, string username, string previousUsername)",
+	"event UsernameResigned(address addr, string username)",
+] as const);
+
+export function parseUsernames(
+	usernamesContractAddress: string,
+	transaction: Contracts.Crypto.Transaction,
+	receipt: Contracts.Evm.TransactionReceipt,
+): { address: string; username: string | undefined }[] {
+	if (transaction.data.to !== usernamesContractAddress) {
+		return [];
+	}
+
+	const logs = parseEventLogs({
+		abi: paymentAbi,
+		//eventName: "UsernameRegistered",
+		logs: receipt.logs ?? [],
+	});
+
+	return logs.map((l) => {
+		switch (l.eventName) {
+			case "UsernameRegistered": {
+				return { address: l.args.addr, username: l.args.username };
+			}
+
+			case "UsernameResigned": {
+				return { address: l.args.addr, username: undefined };
+			}
+		}
+	});
+}

--- a/packages/api-sync/source/restore.ts
+++ b/packages/api-sync/source/restore.ts
@@ -9,7 +9,7 @@ import { Deployer, Identifiers as EvmConsensusIdentifiers } from "@mainsail/evm-
 import { assert, BigNumber, chunk, formatEcdsaSignature, validatorSetPack } from "@mainsail/utils";
 import { performance } from "perf_hooks";
 
-import { parseUsernames, parseMultiPayments, parseTransactionError } from "./parsers/index.js";
+import { parseMultiPayments, parseTransactionError, parseUsernames } from "./parsers/index.js";
 
 interface RestoreContext {
 	readonly entityManager: ApiDatabaseContracts.RepositoryDataSource;

--- a/packages/api-sync/source/restore.ts
+++ b/packages/api-sync/source/restore.ts
@@ -6,13 +6,10 @@ import {
 import { inject, injectable, optional, tagged } from "@mainsail/container";
 import { Contracts, Identifiers } from "@mainsail/contracts";
 import { Deployer, Identifiers as EvmConsensusIdentifiers } from "@mainsail/evm-consensus";
-import { UsernamesAbi } from "@mainsail/evm-contracts";
 import { assert, BigNumber, chunk, formatEcdsaSignature, validatorSetPack } from "@mainsail/utils";
 import { performance } from "perf_hooks";
-import { decodeFunctionResult, encodeFunctionData, toHex } from "viem";
 
-import { parseMultiPayments } from "./parsers/multi-payment.js";
-import { parseTransactionError } from "./parsers/transaction-error.js";
+import { parseUsernames, parseMultiPayments, parseTransactionError } from "./parsers/index.js";
 
 interface RestoreContext {
 	readonly entityManager: ApiDatabaseContracts.RepositoryDataSource;
@@ -55,6 +52,8 @@ interface ValidatorAttributes {
 }
 
 interface UserAttributes {
+	username?: string;
+	usernameFromContract?: boolean;
 	vote?: string;
 	legacyMerge?: Contracts.Evm.AccountMergeInfo;
 }
@@ -118,12 +117,6 @@ export class Restore {
 
 	@inject(Identifiers.Evm.ContractService.Consensus)
 	private readonly consensusContractService!: Contracts.Evm.ConsensusContractService;
-
-	@inject(EvmConsensusIdentifiers.Contracts.Addresses.Usernames)
-	private readonly usernamesContractAddress!: string;
-
-	@inject(EvmConsensusIdentifiers.Internal.Addresses.Deployer)
-	private readonly deployerAddress!: string;
 
 	@inject(Identifiers.Snapshot.Legacy.Importer)
 	@optional()
@@ -233,6 +226,8 @@ export class Restore {
 			EvmConsensusIdentifiers.Contracts.Addresses.MultiPayment,
 		);
 
+		const usernameContractAddress = this.app.get<string>(EvmConsensusIdentifiers.Contracts.Addresses.Usernames);
+
 		do {
 			const fromBlockNumber = Math.min(currentBlockNumber, mostRecentCommit.block.header.number);
 			const toBlockNumber = Math.min(currentBlockNumber + BATCH_SIZE - 1, mostRecentCommit.block.header.number);
@@ -291,13 +286,24 @@ export class Restore {
 
 					const { data } = transaction;
 					const { senderPublicKey } = data;
+					const parsedMultiPayments = parseMultiPayments(multiPaymentContractAddress, transaction, receipt);
+					const parsedUsernames = parseUsernames(usernameContractAddress, transaction, receipt);
+
 					if (!context.publicKeyToAddress[senderPublicKey]) {
 						const address = await this.addressFactory.fromPublicKey(senderPublicKey);
 						context.publicKeyToAddress[senderPublicKey] = address;
 						context.addressToPublicKey[address] = senderPublicKey;
 					}
 
-					const parsedMultiPayments = parseMultiPayments(multiPaymentContractAddress, transaction, receipt);
+					for (const parsedUsername of parsedUsernames ?? []) {
+						const userAttributes = context.userAttributes[parsedUsername.address] ?? {};
+
+						context.userAttributes[parsedUsername.address] = {
+							...userAttributes,
+							username: parsedUsername.username,
+							usernameFromContract: true,
+						};
+					}
 
 					transactions.push({
 						blockHash: block.header.hash,
@@ -400,7 +406,10 @@ export class Restore {
 
 		let totalVotes = 0;
 		for await (const votes of this.consensusContractService.getVotes()) {
+			const userAttributes = context.userAttributes[votes.voterAddress] ?? {};
+
 			context.userAttributes[votes.voterAddress] = {
+				...userAttributes,
 				vote: votes.validatorAddress,
 			};
 			totalVotes++;
@@ -418,6 +427,20 @@ export class Restore {
 		let offset: bigint | undefined = 0n;
 
 		if (this.snapshotImporter) {
+			for (const validator of this.snapshotImporter.validators) {
+				const userAttributes = context.userAttributes[validator.ethAddress] ?? {};
+
+				// Contract takes precedence over snapshot.
+				if (userAttributes.usernameFromContract) {
+					continue;
+				}
+
+				context.userAttributes[validator.ethAddress] = {
+					...userAttributes,
+					username: validator.username,
+				};
+			}
+
 			for (const wallet of this.snapshotImporter.drain()) {
 				// add any imported address to the mapping
 				if (wallet.ethAddress && wallet.publicKey) {
@@ -470,6 +493,7 @@ export class Restore {
 							: {}),
 						...(userAttributes
 							? {
+									...(userAttributes.username ? { username: userAttributes.username } : {}),
 									...(userAttributes.vote ? { vote: userAttributes.vote } : {}),
 									...(userAttributes.legacyMerge
 										? // merged legacy cold wallets
@@ -505,9 +529,7 @@ export class Restore {
 			}
 
 			for (const batch of chunk(accounts, CHUNK_SIZE)) {
-				await this.#readUsernames(batch).then((batch) =>
-					context.walletRepository.createQueryBuilder().insert().orIgnore().values(batch).execute(),
-				);
+				await context.walletRepository.createQueryBuilder().insert().orIgnore().values(batch).execute();
 			}
 
 			offset = result.nextOffset;
@@ -679,55 +701,4 @@ export class Restore {
 	async #updateValidatorRanks(context: RestoreContext): Promise<void> {
 		await context.entityManager.query("SELECT update_validator_ranks();", []);
 	}
-
-	async #readUsernames(wallets: Models.Wallet[]): Promise<Models.Wallet[]> {
-		const addressToWallet: Record<string, Models.Wallet> = wallets.reduce((previous, current) => {
-			previous[current.address] = current;
-			return previous;
-		}, {});
-
-		const addresses = Object.keys(addressToWallet);
-		const data = encodeFunctionData({
-			abi: UsernamesAbi.abi,
-			args: [addresses],
-			functionName: "getUsernames",
-		}).slice(2);
-
-		const { evmSpec } = this.configuration.getMilestone(this.configuration.getGenesisHeight());
-
-		const result = await this.evm.view({
-			data: Buffer.from(data, "hex"),
-			from: this.deployerAddress,
-			specId: evmSpec,
-			to: this.usernamesContractAddress,
-		});
-
-		if (!result.success) {
-			await this.app.terminate("getUsernames failed");
-		}
-
-		const users = decodeFunctionResult({
-			abi: UsernamesAbi.abi,
-			data: toHex(result.output!),
-			functionName: "getUsernames",
-		}) as Username[];
-
-		for (const { addr, username } of users) {
-			const wallet = addressToWallet[addr];
-			assert.defined(wallet);
-			assert.defined(username);
-
-			wallet.attributes = {
-				username,
-				...wallet.attributes,
-			};
-		}
-
-		return wallets;
-	}
-}
-
-interface Username {
-	readonly addr: string;
-	readonly username: string;
 }

--- a/packages/contracts/source/contracts/snapshot.ts
+++ b/packages/contracts/source/contracts/snapshot.ts
@@ -60,7 +60,7 @@ export interface ImportedLegacyVoter {
 
 export interface ImportedLegacyValidator {
 	readonly arkAddress: string;
-	readonly ethAddress?: string;
+	readonly ethAddress: string;
 	readonly publicKey: string;
 	readonly isResigned: boolean;
 

--- a/packages/snapshot-legacy-importer/source/importer.ts
+++ b/packages/snapshot-legacy-importer/source/importer.ts
@@ -230,6 +230,10 @@ export class Importer implements Contracts.Snapshot.LegacyImporter {
 					throw new Error("delegate is missing public key");
 				}
 
+				if (!ethAddress) {
+					throw new Error("delegate is missing eth address");
+				}
+
 				validators.push({
 					arkAddress: wallet.arkAddress,
 					blsPublicKey: wallet.attributes?.["delegate"]["blsPublicKey"],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Usernames are all available during restore, so no need to read from contract storage for each account.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
