### PR TITLE
refactor(crypto-transaction): stricter transaction schema and renames

### DIFF
--- a/packages/api-evm/source/actions/eth-get-transaction-by-hash.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-by-hash.ts
@@ -19,7 +19,7 @@ export class EthGetTransactionByHash implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedTransactionId" }],
+		prefixItems: [{ $ref: "prefixedTransactionHash" }],
 		type: "array",
 	};
 

--- a/packages/api-evm/source/actions/eth-get-transaction-receipt.ts
+++ b/packages/api-evm/source/actions/eth-get-transaction-receipt.ts
@@ -24,7 +24,7 @@ export class EthGetTransactionReceipt implements Contracts.Api.RPC.Action {
 		maxItems: 1,
 		minItems: 1,
 
-		prefixItems: [{ $ref: "prefixedTransactionId" }],
+		prefixItems: [{ $ref: "prefixedTransactionHash" }],
 		type: "array",
 	};
 

--- a/packages/crypto-transaction-evm-call/source/versions/1.test.ts
+++ b/packages/crypto-transaction-evm-call/source/versions/1.test.ts
@@ -42,6 +42,7 @@ describe<{
 		gasPrice: 5 * 1e9,
 		gasLimit: 21000,
 		nonce: 1,
+		network: 10000,
 		to: zeroAddress,
 		senderPublicKey: "a".repeat(66),
 		from: "0x" + "a".repeat(40),

--- a/packages/crypto-transaction-evm-call/source/versions/1.ts
+++ b/packages/crypto-transaction-evm-call/source/versions/1.ts
@@ -12,7 +12,6 @@ export class EvmCallTransaction extends Transaction {
 			$id: "evmCall",
 			properties: {
 				data: { bytecode: {} },
-				gasPrice: { transactionGasPrice: {} },
 				to: { $ref: "address" },
 				value: { bignumber: { maximum: undefined, minimum: 0 } },
 			},

--- a/packages/crypto-transaction/source/validation/schemas.test.ts
+++ b/packages/crypto-transaction/source/validation/schemas.test.ts
@@ -128,7 +128,7 @@ describe<{
 			assert.true(validator.validate("transaction", transaction).error.includes(field));
 		}
 
-		const optionalFields = ["hash", "v", "r", "s", "typeGroup", "version"];
+		const optionalFields = ["hash", "v", "r", "s"];
 		for (const field of optionalFields) {
 			const transaction = {
 				...transactionOriginal,

--- a/packages/crypto-transaction/source/validation/schemas.test.ts
+++ b/packages/crypto-transaction/source/validation/schemas.test.ts
@@ -117,7 +117,7 @@ describe<{
 	it("transactionBaseSchema - should have required fields", ({ validator }) => {
 		validator.addSchema(schema);
 
-		const requiredFields = ["value", "gasPrice", "nonce", "senderPublicKey"];
+		const requiredFields = ["network", "value", "gasPrice", "nonce", "senderPublicKey"];
 		for (const field of requiredFields) {
 			const transaction = {
 				...transactionOriginal,
@@ -128,7 +128,7 @@ describe<{
 			assert.true(validator.validate("transaction", transaction).error.includes(field));
 		}
 
-		const optionalFields = ["hash", "network", "v", "r", "s", "typeGroup", "version"];
+		const optionalFields = ["hash", "v", "r", "s", "typeGroup", "version"];
 		for (const field of optionalFields) {
 			const transaction = {
 				...transactionOriginal,

--- a/packages/crypto-transaction/source/validation/schemas.test.ts
+++ b/packages/crypto-transaction/source/validation/schemas.test.ts
@@ -43,28 +43,28 @@ describe<{
 		}
 	});
 
-	it("transactionId - should be ok", ({ validator }) => {
-		assert.undefined(validator.validate("transactionId", "0".repeat(64)).error);
+	it("transactionHash - should be ok", ({ validator }) => {
+		assert.undefined(validator.validate("transactionHash", "0".repeat(64)).error);
 
 		const validChars = "0123456789abcdef";
 
 		for (const char of validChars) {
-			assert.undefined(validator.validate("transactionId", char.repeat(64)).error);
+			assert.undefined(validator.validate("transactionHash", char.repeat(64)).error);
 		}
 	});
 
-	it("transactionId - should not be ok", ({ validator }) => {
-		assert.defined(validator.validate("transactionId", "0".repeat(63)).error);
-		assert.defined(validator.validate("transactionId", "0".repeat(65)).error);
-		assert.defined(validator.validate("transactionId", 123).error);
-		assert.defined(validator.validate("transactionId", null).error);
-		assert.defined(validator.validate("transactionId").error);
-		assert.defined(validator.validate("transactionId", {}).error);
+	it("transactionHash - should not be ok", ({ validator }) => {
+		assert.defined(validator.validate("transactionHash", "0".repeat(63)).error);
+		assert.defined(validator.validate("transactionHash", "0".repeat(65)).error);
+		assert.defined(validator.validate("transactionHash", 123).error);
+		assert.defined(validator.validate("transactionHash", null).error);
+		assert.defined(validator.validate("transactionHash").error);
+		assert.defined(validator.validate("transactionHash", {}).error);
 
 		const invalidChars = "ABCDEFGHIJKLghijkl!#$%&'|+/";
 
 		for (const char of invalidChars) {
-			assert.defined(validator.validate("transactionId", char.repeat(64)).error);
+			assert.defined(validator.validate("transactionHash", char.repeat(64)).error);
 		}
 	});
 
@@ -128,7 +128,7 @@ describe<{
 			assert.true(validator.validate("transaction", transaction).error.includes(field));
 		}
 
-		const optionalFields = ["id", "network", "v", "r", "s", "typeGroup", "version"];
+		const optionalFields = ["hash", "network", "v", "r", "s", "typeGroup", "version"];
 		for (const field of optionalFields) {
 			const transaction = {
 				...transactionOriginal,
@@ -217,7 +217,7 @@ describe<{
 		assert.undefined(validator.validate("transaction", transaction).error);
 	});
 
-	it("transactionBaseSchema - id should be transactionId", ({ validator }) => {
+	it("transactionBaseSchema - hash should be transactionHash", ({ validator }) => {
 		validator.addSchema(schema);
 
 		const validChars = "0123456789abcdef";

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -1,13 +1,13 @@
 import { SchemaObject } from "ajv";
 
-const transactionId: SchemaObject = {
-	$id: "transactionId",
+const transactionHash: SchemaObject = {
+	$id: "transactionHash",
 	allOf: [{ maxLength: 64, minLength: 64 }, { $ref: "hex" }],
 	type: "string",
 };
 
-const prefixedTransactionId: SchemaObject = {
-	$id: "prefixedTransactionId",
+const prefixedTransactionHash: SchemaObject = {
+	$id: "prefixedTransactionHash",
 	allOf: [{ maxLength: 66, minLength: 66 }, { $ref: "prefixedQuantityHex" }],
 	type: "string",
 };
@@ -19,8 +19,8 @@ const networkByte: SchemaObject = {
 
 export const schemas = {
 	networkByte,
-	prefixedTransactionId,
-	transactionId,
+	prefixedTransactionHash,
+	transactionHash,
 };
 
 export const transactionBaseSchema: SchemaObject = {
@@ -29,7 +29,7 @@ export const transactionBaseSchema: SchemaObject = {
 		gasLimit: { transactionGasLimit: {} },
 		gasPrice: { transactionGasPrice: {} },
 
-		hash: { anyOf: [{ $ref: "transactionId" }, { type: "null" }] },
+		hash: { anyOf: [{ $ref: "transactionHash" }, { type: "null" }] },
 
 		// Legacy
 		legacySecondSignature: {

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -51,6 +51,6 @@ export const transactionBaseSchema: SchemaObject = {
 		v: { maximum: 1, minimum: 0, type: "number" },
 		value: { bignumber: { maximum: undefined, minimum: 0 } },
 	},
-	required: ["from", "senderPublicKey", "gasPrice", "gasLimit", "value", "nonce"],
+	required: ["network", "from", "senderPublicKey", "gasPrice", "gasLimit", "value", "nonce"],
 	type: "object",
 };

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -41,10 +41,8 @@ export const transactionBaseSchema: SchemaObject = {
 
 		nonce: { bignumber: { minimum: 0 } },
 
-		r: { type: "string" },
-
-		// TODO: prefixed hex
-		s: { type: "string" },
+		r: { $ref: "hex" },
+		s: { $ref: "hex" },
 
 		senderLegacyAddress: { type: "string" },
 

--- a/packages/crypto-transaction/source/validation/schemas.ts
+++ b/packages/crypto-transaction/source/validation/schemas.ts
@@ -29,7 +29,7 @@ export const transactionBaseSchema: SchemaObject = {
 		gasLimit: { transactionGasLimit: {} },
 		gasPrice: { transactionGasPrice: {} },
 
-		hash: { anyOf: [{ $ref: "transactionHash" }, { type: "null" }] },
+		hash: { $ref: "transactionHash" },
 
 		// Legacy
 		legacySecondSignature: {

--- a/packages/p2p/test/helpers/prepare-validator-context.ts
+++ b/packages/p2p/test/helpers/prepare-validator-context.ts
@@ -30,5 +30,5 @@ export const prepareValidatorContext = (context: Context) => {
 
 	context.validator.addSchema(cryptoValidationSchemas.hex);
 	context.validator.addSchema(cryptoBlockSchemas.blockHash);
-	context.validator.addSchema(cryptoTransactionSchemas.transactionId);
+	context.validator.addSchema(cryptoTransactionSchemas.transactionHash);
 };


### PR DESCRIPTION
## Summary


Use hex for **r** & **s** values.
Rename *transactionId to *transactionHash

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
