### PR TITLE
use newer PostgreSQL versons - official repository

### DIFF
--- a/scripts/install-testnet.sh
+++ b/scripts/install-testnet.sh
@@ -233,6 +233,7 @@ addApi() {
 }
 
 heading "Installing PostgreSQL..."
+
     OS_CODENAME=$( (grep -w "VERSION_CODENAME" /etc/os-release)  2>/dev/null | cut -d'=' -f2 )
     PG_VERSION="18"
     (echo -e "Package: postgresql\nPin: origin apt.postgresql.org\nPin-Priority: 999" | sudo tee /etc/apt/preferences.d/postgresql)

--- a/scripts/install-testnet.sh
+++ b/scripts/install-testnet.sh
@@ -233,9 +233,13 @@ addApi() {
 }
 
 heading "Installing PostgreSQL..."
-
+    OS_CODENAME=$( (grep -w "VERSION_CODENAME" /etc/os-release)  2>/dev/null | cut -d'=' -f2 )
+    PG_VERSION="18"
+    (echo -e "Package: postgresql\nPin: origin apt.postgresql.org\nPin-Priority: 999" | sudo tee /etc/apt/preferences.d/postgresql)
+    curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /usr/share/keyrings/pgdg.gpg >/dev/null
+    (echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt ${OS_CODENAME}-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list)
     sudo apt-get update
-    sudo $APT_ENV apt-get install postgresql -yq
+    sudo $APT_ENV apt-get install postgresql-${PG_VERSION} postgresql -yq
 
 success "Installed PostgreSQL!"
 


### PR DESCRIPTION
## Summary
 - prefer official PostgreSQL repository over stock PostgreSQL
 - PostgresSQL version to be installed is defined by $PG_VERSION variable 