### PR TITLE
fix(p2p): properly log peer statistics when empty

### DIFF
--- a/packages/p2p/source/peer-statistic.ts
+++ b/packages/p2p/source/peer-statistic.ts
@@ -71,11 +71,19 @@ export class PeerStatistic implements Contracts.P2P.PeerStatistic {
 
 	#getBestLatencies(peers: Contracts.P2P.Peer[], count: number): number[] {
 		const latencies = this.#getLatencies(peers);
+		if (latencies.length === 0) {
+			return [0];
+		}
+
 		return latencies.slice(0, count);
 	}
 
 	#getWorstLatencies(peers: Contracts.P2P.Peer[], count: number): number[] {
 		const latencies = this.#getLatencies(peers);
+		if (latencies.length === 0) {
+			return [0];
+		}
+
 		return latencies.slice(-count);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Before
```
DEBUG:  [P2P] PEERS: Total: 0, Banned: 0, Round: 0, LATENCY: Average: 0 ms, Median: 0 ms, Best:  ms, Worst:  ms
```

After
```
DEBUG:  [P2P] PEERS: Total: 0, Banned: 0, Round: 0, LATENCY: Average: 0 ms, Median: 0 ms, Best:  0 ms, Worst: 0 ms
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
