### PR TITLE
ci: replace deprecated `actions-rs/toolchain` with `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/publish-evm.yml
+++ b/.github/workflows/publish-evm.yml
@@ -119,12 +119,9 @@ jobs:
                   path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
                   restore-keys: ${{ runner.os }}-pnpm-
 
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
                   components: llvm-tools-preview
-                  profile: minimal
-                  override: true
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -119,12 +119,9 @@ jobs:
                   path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
                   restore-keys: ${{ runner.os }}-pnpm-
 
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
                   components: llvm-tools-preview
-                  profile: minimal
-                  override: true
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,9 @@ jobs:
                   key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
                   path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
 
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
                   components: llvm-tools-preview
-                  profile: minimal
-                  override: true
 
             - name: Install dependencies
               run: pnpm install
@@ -103,12 +100,9 @@ jobs:
               with:
                   key: lerna-${{ github.sha }}
                   path: ./.cache
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
                   components: llvm-tools-preview
-                  profile: minimal
-                  override: true
             - name: Install cargo-llvm-cov
               run: cargo install cargo-llvm-cov
             - name: Check rustc version


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

[actions-rs/toolchain](https://github.com/actions-rs/toolchain) is no longer maintained.

```
[Run actions-rs/toolchain@v1](https://github.com/ArkEcosystem/mainsail/actions/runs/19028555478/job/54337059984#annotation:7:75)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
