### PR TITLE
refactor(consensus-storage): store serialized values

### DIFF
--- a/packages/consensus-storage/source/service.ts
+++ b/packages/consensus-storage/source/service.ts
@@ -10,13 +10,13 @@ export class Service implements Contracts.ConsensusStorage.Service {
 	private readonly rootStorage!: RootDatabase;
 
 	@inject(Identifiers.ConsensusStorage.Storage.Proposal)
-	private readonly proposalStorage!: Database<Contracts.Crypto.ProposalData>;
+	private readonly proposalStorage!: Database<string>;
 
 	@inject(Identifiers.ConsensusStorage.Storage.PreVote)
-	private readonly prevoteStorage!: Database<Contracts.Crypto.PrevoteData>;
+	private readonly prevoteStorage!: Database<string>;
 
 	@inject(Identifiers.ConsensusStorage.Storage.PreCommit)
-	private readonly precommitStorage!: Database<Contracts.Crypto.PrecommitData>;
+	private readonly precommitStorage!: Database<string>;
 
 	@inject(Identifiers.ConsensusStorage.Storage.ConsensusState)
 	private readonly stateStorage!: Database<Contracts.Consensus.StateData>;
@@ -72,36 +72,36 @@ export class Service implements Contracts.ConsensusStorage.Service {
 			// Proposals
 			for (const proposal of proposals) {
 				const validator = this.validatorSet.getValidator(proposal.validatorIndex);
-				this.proposalStorage.putSync(`${proposal.round}-${validator.blsPublicKey}`, proposal.toData());
+				this.proposalStorage.putSync(`${proposal.round}-${validator.blsPublicKey}`, proposal.serialized.toString("hex"));
 			}
 
 			// Prevotes
 			for (const prevote of prevotes) {
 				const validator = this.validatorSet.getValidator(prevote.validatorIndex);
-				this.prevoteStorage.putSync(`${prevote.round}-${validator.blsPublicKey}`, prevote.toData());
+				this.prevoteStorage.putSync(`${prevote.round}-${validator.blsPublicKey}`, prevote.serialized.toString("hex"));
 			}
 
 			// Precommits
 			for (const precommit of precommits) {
 				const validator = this.validatorSet.getValidator(precommit.validatorIndex);
-				this.precommitStorage.putSync(`${precommit.round}-${validator.blsPublicKey}`, precommit.toData());
+				this.precommitStorage.putSync(`${precommit.round}-${validator.blsPublicKey}`, precommit.serialized.toString("hex"));
 			}
 		});
 	}
 
 	public async getProposals(): Promise<Contracts.Crypto.Proposal[]> {
 		const proposals = [...this.proposalStorage.getValues(undefined as unknown as Key)];
-		return Promise.all(proposals.map((proposal) => this.messageFactory.makeProposalFromData(proposal)));
+		return Promise.all(proposals.map((proposal) => this.messageFactory.makeProposalFromBytes(Buffer.from(proposal, "hex"))));
 	}
 
 	public async getPrevotes(): Promise<Contracts.Crypto.Prevote[]> {
 		const prevotes = [...this.prevoteStorage.getValues(undefined as unknown as Key)];
-		return Promise.all(prevotes.map((prevote) => this.messageFactory.makePrevoteFromData(prevote)));
+		return Promise.all(prevotes.map((prevote) => this.messageFactory.makePrevoteFromBytes(Buffer.from(prevote, "hex"))));
 	}
 
 	public async getPrecommits(): Promise<Contracts.Crypto.Precommit[]> {
 		const precommits = [...this.precommitStorage.getValues(undefined as unknown as Key)];
-		return Promise.all(precommits.map((precommit) => this.messageFactory.makePrecommitFromData(precommit)));
+		return Promise.all(precommits.map((precommit) => this.messageFactory.makePrecommitFromBytes(Buffer.from(precommit, "hex"))));
 	}
 
 	#clear(): void {

--- a/packages/consensus-storage/source/service.ts
+++ b/packages/consensus-storage/source/service.ts
@@ -72,36 +72,51 @@ export class Service implements Contracts.ConsensusStorage.Service {
 			// Proposals
 			for (const proposal of proposals) {
 				const validator = this.validatorSet.getValidator(proposal.validatorIndex);
-				this.proposalStorage.putSync(`${proposal.round}-${validator.blsPublicKey}`, proposal.serialized.toString("hex"));
+				this.proposalStorage.putSync(
+					`${proposal.round}-${validator.blsPublicKey}`,
+					proposal.serialized.toString("hex"),
+				);
 			}
 
 			// Prevotes
 			for (const prevote of prevotes) {
 				const validator = this.validatorSet.getValidator(prevote.validatorIndex);
-				this.prevoteStorage.putSync(`${prevote.round}-${validator.blsPublicKey}`, prevote.serialized.toString("hex"));
+				this.prevoteStorage.putSync(
+					`${prevote.round}-${validator.blsPublicKey}`,
+					prevote.serialized.toString("hex"),
+				);
 			}
 
 			// Precommits
 			for (const precommit of precommits) {
 				const validator = this.validatorSet.getValidator(precommit.validatorIndex);
-				this.precommitStorage.putSync(`${precommit.round}-${validator.blsPublicKey}`, precommit.serialized.toString("hex"));
+				this.precommitStorage.putSync(
+					`${precommit.round}-${validator.blsPublicKey}`,
+					precommit.serialized.toString("hex"),
+				);
 			}
 		});
 	}
 
 	public async getProposals(): Promise<Contracts.Crypto.Proposal[]> {
 		const proposals = [...this.proposalStorage.getRange().map((item) => item.value)];
-		return Promise.all(proposals.map((proposal) => this.messageFactory.makeProposalFromBytes(Buffer.from(proposal, "hex"))));
+		return Promise.all(
+			proposals.map((proposal) => this.messageFactory.makeProposalFromBytes(Buffer.from(proposal, "hex"))),
+		);
 	}
 
 	public async getPrevotes(): Promise<Contracts.Crypto.Prevote[]> {
 		const prevotes = [...this.prevoteStorage.getRange().map((item) => item.value)];
-		return Promise.all(prevotes.map((prevote) => this.messageFactory.makePrevoteFromBytes(Buffer.from(prevote, "hex"))));
+		return Promise.all(
+			prevotes.map((prevote) => this.messageFactory.makePrevoteFromBytes(Buffer.from(prevote, "hex"))),
+		);
 	}
 
 	public async getPrecommits(): Promise<Contracts.Crypto.Precommit[]> {
 		const precommits = [...this.precommitStorage.getRange().map((item) => item.value)];
-		return Promise.all(precommits.map((precommit) => this.messageFactory.makePrecommitFromBytes(Buffer.from(precommit, "hex"))));
+		return Promise.all(
+			precommits.map((precommit) => this.messageFactory.makePrecommitFromBytes(Buffer.from(precommit, "hex"))),
+		);
 	}
 
 	#clear(): void {

--- a/packages/consensus-storage/source/service.ts
+++ b/packages/consensus-storage/source/service.ts
@@ -2,7 +2,7 @@ import { Identifiers } from "@mainsail/constants";
 import { inject, injectable } from "@mainsail/container";
 import type { Contracts } from "@mainsail/contracts";
 import { assert } from "@mainsail/utils";
-import type { Database, Key, RootDatabase } from "lmdb";
+import type { Database, RootDatabase } from "lmdb";
 
 @injectable()
 export class Service implements Contracts.ConsensusStorage.Service {
@@ -90,17 +90,17 @@ export class Service implements Contracts.ConsensusStorage.Service {
 	}
 
 	public async getProposals(): Promise<Contracts.Crypto.Proposal[]> {
-		const proposals = [...this.proposalStorage.getValues(undefined as unknown as Key)];
+		const proposals = [...this.proposalStorage.getRange().map((item) => item.value)];
 		return Promise.all(proposals.map((proposal) => this.messageFactory.makeProposalFromBytes(Buffer.from(proposal, "hex"))));
 	}
 
 	public async getPrevotes(): Promise<Contracts.Crypto.Prevote[]> {
-		const prevotes = [...this.prevoteStorage.getValues(undefined as unknown as Key)];
+		const prevotes = [...this.prevoteStorage.getRange().map((item) => item.value)];
 		return Promise.all(prevotes.map((prevote) => this.messageFactory.makePrevoteFromBytes(Buffer.from(prevote, "hex"))));
 	}
 
 	public async getPrecommits(): Promise<Contracts.Crypto.Precommit[]> {
-		const precommits = [...this.precommitStorage.getValues(undefined as unknown as Key)];
+		const precommits = [...this.precommitStorage.getRange().map((item) => item.value)];
 		return Promise.all(precommits.map((precommit) => this.messageFactory.makePrecommitFromBytes(Buffer.from(precommit, "hex"))));
 	}
 


### PR DESCRIPTION
## Summary

Use serialized values, because data objects can contain non primitive data types like BigNumber. 

## Checklist

- [x] Ready to be merged
