### PR TITLE
refactor(crypto-messages): remove toData method on `Prevote` and `Precommit`

### DIFF
--- a/packages/contracts/source/contracts/crypto/messages.ts
+++ b/packages/contracts/source/contracts/crypto/messages.ts
@@ -63,7 +63,6 @@ export interface Prevote extends PrevoteData {
 	readonly serialized: Buffer;
 
 	toSignatureData(): SignaturePrevoteData;
-	toData(): PrevoteData;
 	toString(): string;
 }
 
@@ -80,7 +79,6 @@ export interface Precommit extends PrecommitData {
 	readonly serialized: Buffer;
 
 	toSignatureData(): SignaturePrecommitData;
-	toData(): PrecommitData;
 	toString(): string;
 }
 

--- a/packages/crypto-messages/source/factory.test.ts
+++ b/packages/crypto-messages/source/factory.test.ts
@@ -46,12 +46,12 @@ describe<{
 					consensusSignature: (method, message, privateKey) =>
 						context.sandbox.app
 							.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
-						[method](message, privateKey),
+							[method](message, privateKey),
 					// @ts-ignore
 					transactionFactory: (method, message, privateKey) =>
 						context.sandbox.app
 							.get(Identifiers.Cryptography.Transaction.Factory)!
-						[method](message, privateKey),
+							[method](message, privateKey),
 				};
 			},
 		};

--- a/packages/crypto-messages/source/factory.test.ts
+++ b/packages/crypto-messages/source/factory.test.ts
@@ -6,7 +6,6 @@ import { describe, Factories, Sandbox } from "../../test-framework/source";
 import { Types } from "../../test-framework/source/factories";
 import {
 	blockData,
-	blockHeader,
 	precommitData,
 	precommitDataNoBlock,
 	prevoteData,
@@ -23,6 +22,7 @@ import {
 	validatorMnemonic,
 } from "../test/fixtures/index.js";
 import { prepareSandbox } from "../test/helpers/prepare-sandbox";
+import { toData } from "../test/helpers/utilities.js";
 import { MessageFactory } from "./factory";
 
 describe<{
@@ -46,12 +46,12 @@ describe<{
 					consensusSignature: (method, message, privateKey) =>
 						context.sandbox.app
 							.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
-							[method](message, privateKey),
+						[method](message, privateKey),
 					// @ts-ignore
 					transactionFactory: (method, message, privateKey) =>
 						context.sandbox.app
 							.get(Identifiers.Cryptography.Transaction.Factory)!
-							[method](message, privateKey),
+						[method](message, privateKey),
 				};
 			},
 		};
@@ -185,24 +185,23 @@ describe<{
 	it("#makePrevoteFromBytes - should be ok", async ({ factory }) => {
 		const prevote = await factory.makePrevoteFromBytes(Buffer.from(serializedPrevote, "hex"));
 
-		assert.equal(prevote.toData(), prevoteData);
+		assert.equal(toData(prevote), prevoteData);
 	});
 
 	it("#makePrevoteFromBytes - should be ok with no block", async ({ factory }) => {
 		const prevote = await factory.makePrevoteFromBytes(Buffer.from(serializedPrevoteNoBlock, "hex"));
 
-		assert.equal(prevote.toData(), prevoteDataNoBlock);
+		assert.equal(toData(prevote), prevoteDataNoBlock);
 	});
 
 	it("#makePrecommitFromBytes - should be ok", async ({ factory }) => {
 		const precommit = await factory.makePrecommitFromBytes(Buffer.from(serializedPrecommit, "hex"));
 
-		assert.equal(precommit.toData(), precommitData);
+		assert.equal(toData(precommit), precommitData);
 	});
 
 	it("#makePrecommitFromBytes - should be ok with no block", async ({ factory }) => {
 		const precommit = await factory.makePrecommitFromBytes(Buffer.from(serializedPrecommitNoBlock, "hex"));
-
-		assert.equal(precommit.toData(), precommitDataNoBlock);
+		assert.equal(toData(precommit), precommitDataNoBlock);
 	});
 });

--- a/packages/crypto-messages/source/precommit.test.ts
+++ b/packages/crypto-messages/source/precommit.test.ts
@@ -37,8 +37,4 @@ describe<{
 			`{"blockHash":"${precommitData.blockHash}","blockNumber":1,"round":1,"signature":"${precommitData.signature}","validatorIndex":0}`,
 		);
 	});
-
-	it("#toData", async () => {
-		assert.equal(precommit.toData(), precommitData);
-	});
 });

--- a/packages/crypto-messages/source/precommit.ts
+++ b/packages/crypto-messages/source/precommit.ts
@@ -71,15 +71,4 @@ export class Precommit implements Contracts.Crypto.Precommit {
 			type: this.type,
 		};
 	}
-
-	toData(): Contracts.Crypto.PrecommitData {
-		return {
-			blockHash: this.#blockHash,
-			blockNumber: this.#blockNumber,
-			round: this.#round,
-			signature: this.#signature,
-			type: this.type,
-			validatorIndex: this.#validatorIndex,
-		};
-	}
 }

--- a/packages/crypto-messages/source/prevote.test.ts
+++ b/packages/crypto-messages/source/prevote.test.ts
@@ -37,8 +37,4 @@ describe<{
 			`{"blockHash":"${prevoteData.blockHash}","blockNumber":1,"round":1,"signature":"${prevoteData.signature}","validatorIndex":0}`,
 		);
 	});
-
-	it("#toData", async () => {
-		assert.equal(prevote.toData(), prevoteData);
-	});
 });

--- a/packages/crypto-messages/source/prevote.ts
+++ b/packages/crypto-messages/source/prevote.ts
@@ -71,15 +71,4 @@ export class Prevote implements Contracts.Crypto.Prevote {
 			type: this.type,
 		};
 	}
-
-	toData(): Contracts.Crypto.PrevoteData {
-		return {
-			blockHash: this.#blockHash,
-			blockNumber: this.#blockNumber,
-			round: this.#round,
-			signature: this.#signature,
-			type: this.type,
-			validatorIndex: this.#validatorIndex,
-		};
-	}
 }

--- a/packages/crypto-messages/source/proposal.test.ts
+++ b/packages/crypto-messages/source/proposal.test.ts
@@ -37,7 +37,7 @@ describe<{
 				consensusSignature: (method, message, privateKey) =>
 					context.sandbox.app
 						.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
-					[method](message, privateKey),
+						[method](message, privateKey),
 				// @ts-ignore
 				transactionFactory: (method, message, privateKey) =>
 					context.sandbox.app.get(Identifiers.Cryptography.Transaction.Factory)![method](message, privateKey),

--- a/packages/crypto-messages/source/proposal.test.ts
+++ b/packages/crypto-messages/source/proposal.test.ts
@@ -37,7 +37,7 @@ describe<{
 				consensusSignature: (method, message, privateKey) =>
 					context.sandbox.app
 						.getTagged(Identifiers.Cryptography.Signature.Instance, "type", "consensus")!
-						[method](message, privateKey),
+					[method](message, privateKey),
 				// @ts-ignore
 				transactionFactory: (method, message, privateKey) =>
 					context.sandbox.app.get(Identifiers.Cryptography.Transaction.Factory)![method](message, privateKey),
@@ -76,7 +76,8 @@ describe<{
 		assert.undefined(proposal.lockProof);
 	});
 
-	it.only("#lockProof - should be undefined", async ({ sandbox }) => {
+	// TODO: Fix test
+	it("#lockProof - should be defined", async ({ sandbox }) => {
 		const proposalWithValidRound = sandbox.app.resolve(Proposal).initialize({
 			...proposalDataWithValidRound,
 			dataSerialized: proposalDataWithValidRound.data.serialized,
@@ -85,8 +86,6 @@ describe<{
 		});
 
 		await proposalWithValidRound.deserializeData();
-		console.log("HERE", proposalWithValidRound.toData().lockProof);
-
 		// assert.defined(proposalWithValidRound.lockProof);
 	});
 

--- a/packages/crypto-messages/test/helpers/utilities.ts
+++ b/packages/crypto-messages/test/helpers/utilities.ts
@@ -1,0 +1,10 @@
+import type { Contracts } from "@mainsail/contracts";
+
+export const toData = (message: Contracts.Crypto.Precommit): Contracts.Crypto.PrecommitData => ({
+	blockHash: message.blockHash,
+	blockNumber: message.blockNumber,
+	round: message.round,
+	signature: message.signature,
+	type: message.type,
+	validatorIndex: message.validatorIndex,
+})

--- a/packages/crypto-messages/test/helpers/utilities.ts
+++ b/packages/crypto-messages/test/helpers/utilities.ts
@@ -7,4 +7,4 @@ export const toData = (message: Contracts.Crypto.Precommit): Contracts.Crypto.Pr
 	signature: message.signature,
 	type: message.type,
 	validatorIndex: message.validatorIndex,
-})
+});


### PR DESCRIPTION
## Summary

toData is not used anywhere in code

## Checklist

<!-- Have you done all of these things?  -->

- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
