### PR TITLE
feat(core): add `--consensusData` and `--txPoolData` flags to `env:paths:clear` command

### DIFF
--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -28,40 +28,40 @@ export class Command extends Commands.Command {
 
 	public async execute(): Promise<void> {
 		if (this.hasFlag("data") || this.hasFlag("all")) {
-			await this.#clear("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
+			await this.#clearDir("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
 		}
 
 		if (this.hasFlag("config") || this.hasFlag("all")) {
-			await this.#clear("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
+			await this.#clearDir("Config", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).config);
 		}
 
 		if (this.hasFlag("cache") || this.hasFlag("all")) {
-			await this.#clear("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
+			await this.#clearDir("Cache", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).cache);
 		}
 
 		if (this.hasFlag("log") || this.hasFlag("all")) {
-			await this.#clear("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
+			await this.#clearDir("Log", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).log);
 		}
 		if (this.hasFlag("temp") || this.hasFlag("all")) {
-			await this.#clear("Temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
+			await this.#clearDir("Temp", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).temp);
 		}
 
 		if (this.hasFlag("state-export")) {
-			await this.#clear(
+			await this.#clearDir(
 				"State export",
 				join(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data, "state-export"),
 			);
 		}
 
 		if (this.hasFlag("plugins")) {
-			await this.#clear(
+			await this.#clearDir(
 				"Plugins",
 				join(this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data, "plugins"),
 			);
 		}
 	}
 
-	async #clear(name, path: string) {
+	async #clearDir(name, path: string) {
 		if (existsSync(path) && readdirSync(path).length > 0) {
 			emptyDirSync(path);
 

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -2,7 +2,7 @@
 import { Commands, Contracts, Identifiers } from "@mainsail/cli";
 import { injectable, postConstruct } from "@mainsail/container";
 import { existsSync, readdirSync } from "fs";
-import { emptyDirSync } from "fs-extra/esm";
+import { emptyDirSync, removeSync } from "fs-extra/esm";
 import Joi from "joi";
 import { join } from "path";
 
@@ -29,6 +29,14 @@ export class Command extends Commands.Command {
 	public async execute(): Promise<void> {
 		if (this.hasFlag("data") || this.hasFlag("all")) {
 			await this.#clearDir("Data", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
+		}
+
+		if (this.hasFlag("consensusData")) {
+			await this.#clearDb("consensus", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
+		}
+
+		if (this.hasFlag("txPoolData")) {
+			await this.#clearDb("transaction-pool", this.app.get<Contracts.Paths>(Identifiers.ApplicationPaths).data);
 		}
 
 		if (this.hasFlag("config") || this.hasFlag("all")) {
@@ -61,11 +69,27 @@ export class Command extends Commands.Command {
 		}
 	}
 
-	async #clearDir(name, path: string) {
+	async #clearDir(name: string, path: string) {
 		if (existsSync(path) && readdirSync(path).length > 0) {
 			emptyDirSync(path);
 
 			this.components.log(`${name} path (${path}) has been cleared.`);
+		}
+	}
+
+	async #clearDb(nameLike: string, path: string) {
+		if (existsSync(path)) {
+			const files = readdirSync(path).filter(file => file.includes(nameLike));
+
+			if (files.length === 0) {
+				return;
+			}
+
+			for (const file of files) {
+				removeSync(join(path, file));
+			}
+
+			this.components.log(`Cleared ${files.length} file(s) in path (${path}): ${files.join(", ")}`);
 		}
 	}
 }

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -79,7 +79,7 @@ export class Command extends Commands.Command {
 
 	async #clearDb(nameLike: string, path: string) {
 		if (existsSync(path)) {
-			const files = readdirSync(path).filter(file => file.includes(nameLike));
+			const files = readdirSync(path).filter((file) => file.includes(nameLike));
 
 			if (files.length === 0) {
 				return;

--- a/packages/core/source/commands/env-paths-clear.ts
+++ b/packages/core/source/commands/env-paths-clear.ts
@@ -17,6 +17,8 @@ export class Command extends Commands.Command {
 		this.definition.setFlag("state-export", "Clear state exports.", Joi.boolean());
 		this.definition.setFlag("plugins", "Clear installed plugins.", Joi.boolean());
 		this.definition.setFlag("data", "Clear data.", Joi.boolean());
+		this.definition.setFlag("consensusData", "Clear consensus data.", Joi.boolean());
+		this.definition.setFlag("txPoolData", "Clear transaction pool data.", Joi.boolean());
 		this.definition.setFlag("config", "Clear config.", Joi.boolean());
 		this.definition.setFlag("cache", "Clear cache.", Joi.boolean());
 		this.definition.setFlag("log", "Clear log.", Joi.boolean());


### PR DESCRIPTION
## Summary

Add additional flags to clear consensus and tx-pool databases.

## Checklist

- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
