### PR TITLE
fix(validator): mandatory keystore password

### DIFF
--- a/packages/validator/source/service-provider.ts
+++ b/packages/validator/source/service-provider.ts
@@ -48,7 +48,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 					.configure(
 						await new BIP38().configure(
 							parsed,
-							configuration.getOptional<string | undefined>("validatorKeystorePassword", undefined)!,
+							configuration.getRequired<string>("validatorKeystorePassword"),
 						),
 					),
 			);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

`core:run` sets the keystore password inside `buildValidatorConfiguration`.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
