### PR TITLE
fix(api-sync): change listeners to recursive `setTimeout` loop

### DIFF
--- a/packages/api-sync/source/listeners/abstract-listener.ts
+++ b/packages/api-sync/source/listeners/abstract-listener.ts
@@ -35,7 +35,7 @@ export abstract class AbstractListener<TEventData, TEntity extends object> imple
 	@inject(Identifiers.ApiSync.Logger)
 	protected readonly logger!: Contracts.ApiSync.Logger;
 
-	#syncInterval?: NodeJS.Timeout;
+	#syncTimeout?: NodeJS.Timeout;
 	#addedEvents: Map<string, TEventData> = new Map();
 	#removedEvents: Map<string, TEventData> = new Map();
 
@@ -48,15 +48,23 @@ export abstract class AbstractListener<TEventData, TEntity extends object> imple
 	public async boot(): Promise<void> {
 		await this.#truncate();
 
+		void this.#startSyncLoop();
+	}
+
+	async #startSyncLoop(): Promise<void> {
 		const syncInterval = this.getSyncIntervalMs();
 
-		this.#syncInterval = setInterval(async () => {
+		const run = async () => {
 			try {
 				await this.#syncToDatabaseTransaction();
 			} catch (ex) {
 				this.logger.error(`#syncToDatabaseTransaction failed: ${ex}`);
+			} finally {
+				this.#syncTimeout = setTimeout(run, syncInterval);
 			}
-		}, syncInterval);
+		};
+
+		void run();
 	}
 
 	public async dispose(): Promise<void> {
@@ -64,8 +72,8 @@ export abstract class AbstractListener<TEventData, TEntity extends object> imple
 			this.events.forget(eventName, this);
 		}
 
-		if (this.#syncInterval) {
-			clearInterval(this.#syncInterval);
+		if (this.#syncTimeout) {
+			clearTimeout(this.#syncTimeout);
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
`setInterval` piles up when the database is unavailable which leads to undesired side effects

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
