### PR TITLE
perf(kernel): improve bootstrap by removing large dependency

### DIFF
--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -33,7 +33,6 @@
 		"@mainsail/utils": "workspace:*",
 		"chalk": "5.6.2",
 		"cron": "4.4.0",
-		"date-fns": "4.1.0",
 		"deepmerge": "4.3.1",
 		"env-paths": "4.0.0",
 		"fs-extra": "11.3.5",

--- a/packages/kernel/source/services/log/drivers/memory.ts
+++ b/packages/kernel/source/services/log/drivers/memory.ts
@@ -3,8 +3,14 @@ import type { Contracts } from "@mainsail/contracts";
 import { injectable } from "@mainsail/container";
 import { isEmpty, prettyTime } from "@mainsail/utils";
 import chalk, { ChalkInstance } from "chalk";
-import { differenceInMilliseconds, format } from "date-fns";
 import { inspect } from "util";
+
+const pad = (value: number, length = 2): string => value.toString().padStart(length, "0");
+
+// Local-time "yyyy-MM-dd HH:mm:ss.SSS" timestamp for log lines.
+const formatTimestamp = (date: Date): string =>
+	`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+	`${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
 
 @injectable()
 export class MemoryLogger implements Contracts.Kernel.Logger {
@@ -70,7 +76,7 @@ export class MemoryLogger implements Contracts.Kernel.Logger {
 
 		level = level ? this.levelStyles[level](`[${level.toUpperCase()}] `) : "";
 
-		const timestamp: string = format(new Date(), "yyyy-MM-dd HH:MM:ss.SSS");
+		const timestamp: string = formatTimestamp(new Date());
 		const timestampDiff: string = this.getTimestampDiff();
 
 		process.stdout.write(`[${timestamp}] ${level}${message}${timestampDiff}\n`);
@@ -79,7 +85,7 @@ export class MemoryLogger implements Contracts.Kernel.Logger {
 	protected getTimestampDiff(): string {
 		const now = new Date();
 
-		const diff: number = differenceInMilliseconds(now, this.#lastTimestamp);
+		const diff: number = now.getTime() - this.#lastTimestamp.getTime();
 
 		this.#lastTimestamp = new Date();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 9.1.7
       lerna:
         specifier: 9.0.7
-        version: 9.0.7(@types/node@25.7.0)(debug@4.3.7)
+        version: 9.0.7(@types/node@25.7.0)
       lint-staged:
         specifier: 17.0.4
         version: 17.0.4
@@ -2362,9 +2362,6 @@ importers:
       cron:
         specifier: 4.4.0
         version: 4.4.0
-      date-fns:
-        specifier: 4.1.0
-        version: 4.1.0
       deepmerge:
         specifier: 4.3.1
         version: 4.3.1
@@ -3487,7 +3484,7 @@ importers:
         version: 0.5.6
       viem:
         specifier: 2.22.15
-        version: 2.22.15(typescript@6.0.3)(zod@4.4.3)
+        version: 2.22.15(typescript@6.0.3)
 
   tests/e2e/consensus/checks:
     dependencies:
@@ -3499,7 +3496,7 @@ importers:
         version: 14.2.1
       viem:
         specifier: 2.33.1
-        version: 2.33.1(typescript@6.0.3)(zod@4.4.3)
+        version: 2.33.1(typescript@6.0.3)
 
   tests/e2e/consensus/peer-discovery:
     dependencies:
@@ -3532,7 +3529,7 @@ importers:
         version: 14.2.1
       viem:
         specifier: 2.33.1
-        version: 2.33.1(typescript@6.0.3)(zod@4.4.3)
+        version: 2.33.1(typescript@6.0.3)
 
   tests/functional/consensus:
     devDependencies:
@@ -3673,7 +3670,7 @@ importers:
         version: 0.5.6
       viem:
         specifier: 2.33.1
-        version: 2.33.1(typescript@6.0.3)(zod@4.4.3)
+        version: 2.33.1(typescript@6.0.3)
 
   tests/functional/resync:
     devDependencies:
@@ -3820,7 +3817,7 @@ importers:
         version: 0.5.6
       viem:
         specifier: 2.33.1
-        version: 2.33.1(typescript@6.0.3)(zod@4.4.3)
+        version: 2.33.1(typescript@6.0.3)
 
   tests/functional/transaction-pool-api:
     devDependencies:
@@ -3964,7 +3961,7 @@ importers:
         version: 0.5.6
       viem:
         specifier: 2.33.1
-        version: 2.33.1(typescript@6.0.3)(zod@4.4.3)
+        version: 2.33.1(typescript@6.0.3)
 
 packages:
 
@@ -12488,13 +12485,13 @@ snapshots:
       proc-log: 6.1.0
       which: 6.0.1
 
-  '@nx/devkit@22.7.1(nx@22.7.1(debug@4.3.7))':
+  '@nx/devkit@22.7.1(nx@22.7.1)':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 5.0.1
       enquirer: 2.3.6
       minimatch: 10.2.4
-      nx: 22.7.1(debug@4.3.7)
+      nx: 22.7.1
       semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -13457,7 +13454,7 @@ snapshots:
       camel-case: 4.1.2
       fast-glob: 3.3.3
 
-  axios@1.15.0(debug@4.3.7):
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11(debug@4.3.7)
       form-data: 4.0.5
@@ -15876,12 +15873,12 @@ snapshots:
     dependencies:
       package-json: 10.0.1
 
-  lerna@9.0.7(@types/node@25.7.0)(debug@4.3.7):
+  lerna@9.0.7(@types/node@25.7.0):
     dependencies:
       '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
       '@npmcli/run-script': 10.0.3
-      '@nx/devkit': 22.7.1(nx@22.7.1(debug@4.3.7))
+      '@nx/devkit': 22.7.1(nx@22.7.1)
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 20.1.2
       aproba: 2.0.0
@@ -15919,7 +15916,7 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
-      nx: 22.7.1(debug@4.3.7)
+      nx: 22.7.1
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-pipe: 3.1.0
@@ -16697,7 +16694,7 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nx@22.7.1(debug@4.3.7):
+  nx@22.7.1:
     dependencies:
       '@emnapi/core': 1.4.5
       '@emnapi/runtime': 1.4.5
@@ -16712,7 +16709,7 @@ snapshots:
       ansi-styles: 4.3.0
       argparse: 2.0.1
       asynckit: 0.4.0
-      axios: 1.15.0(debug@4.3.7)
+      axios: 1.15.0
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
@@ -16965,7 +16962,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@6.0.3)(zod@4.4.3):
+  ox@0.6.7(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.6
@@ -16979,7 +16976,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.8.1(typescript@6.0.3)(zod@4.4.3):
+  ox@0.8.1(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -18681,7 +18678,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.22.15(typescript@6.0.3)(zod@4.4.3):
+  viem@2.22.15(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
@@ -18689,7 +18686,7 @@ snapshots:
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@6.0.3)
       isows: 1.0.6(ws@8.18.0)
-      ox: 0.6.7(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.6.7(typescript@6.0.3)
       ws: 8.18.0
     optionalDependencies:
       typescript: 6.0.3
@@ -18698,7 +18695,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.33.1(typescript@6.0.3)(zod@4.4.3):
+  viem@2.33.1(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0
@@ -18706,7 +18703,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@6.0.3)
       isows: 1.0.7(ws@8.18.2)
-      ox: 0.8.1(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.8.1(typescript@6.0.3)
       ws: 8.18.2
     optionalDependencies:
       typescript: 6.0.3


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Before

```shell
time pnpm run mainsail version
$ node ./bin/run.js version
0.0.1-rc.9

real    0m1.591s
user    0m1.802s
sys     0m0.291s
```
After

```shell
time pnpm run mainsail version
$ node ./bin/run.js version
0.0.1-rc.9

real    0m1.009s
user    0m1.059s
sys     0m0.170s
```

The saved overhead applies to each worker/process.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
