### PR TITLE
perf(forger): reuse already validated pool data when building blocks

### DIFF
--- a/packages/contracts/source/contracts/crypto/transactions.ts
+++ b/packages/contracts/source/contracts/crypto/transactions.ts
@@ -112,6 +112,7 @@ export interface TransactionFactory {
 	fromBytes(buff: Buffer, strict?: boolean): Promise<Transaction>;
 	fromJson(json: TransactionJson): Promise<Transaction>;
 	fromData(data: TransactionSerializable, strict?: boolean): Promise<Transaction>;
+	fromPoolData(data: TransactionData): Promise<Transaction>;
 	fromStorage(data: TransactionStorageDataExtended): Promise<BlockTransaction>;
 	computeCryptoData(data: TransactionSerializable): Promise<TransactionCryptoData>;
 }

--- a/packages/crypto-transaction/source/factory.test.ts
+++ b/packages/crypto-transaction/source/factory.test.ts
@@ -118,7 +118,9 @@ describe<{
 
 			assert.equal(fromPool.hash, original.hash);
 			assert.equal(fromPool.from, original.from);
+			assert.equal(fromPool.to, original.to);
 			assert.equal(fromPool.senderPublicKey, original.senderPublicKey);
+			assert.equal(fromPool.senderLegacyAddress, original.senderLegacyAddress);
 			assert.true(fromPool.serialized.equals(original.serialized));
 			assert.equal(fromPool.toData(), original.toData());
 		}

--- a/packages/crypto-transaction/source/factory.test.ts
+++ b/packages/crypto-transaction/source/factory.test.ts
@@ -106,6 +106,24 @@ describe<{
 		}
 	});
 
+	it("fromPoolData - should deserialize well-formed transaction", async ({ factory }) => {
+		for (const transaction of [
+			Transactions.transactionTransfer,
+			Transactions.transactionContractCall,
+			Transactions.transactionContractCallWithSecondSignature,
+			Transactions.transactionDeploy,
+		]) {
+			const original = await factory.fromBytes(transaction.serialized);
+			const fromPool = await factory.fromPoolData(original.toData());
+
+			assert.equal(fromPool.hash, original.hash);
+			assert.equal(fromPool.from, original.from);
+			assert.equal(fromPool.senderPublicKey, original.senderPublicKey);
+			assert.true(fromPool.serialized.equals(original.serialized));
+			assert.equal(fromPool.toData(), original.toData());
+		}
+	});
+
 	it("fromStorage - should deserialize well-formed transaction", async ({ factory }) => {
 		for (const [storage, transaction] of [
 			[Storage.transactionTransfer, Transactions.transactionTransfer],

--- a/packages/crypto-transaction/source/factory.ts
+++ b/packages/crypto-transaction/source/factory.ts
@@ -57,6 +57,11 @@ export class TransactionFactory implements Contracts.Crypto.TransactionFactory {
 		return this.fromData(transactionData);
 	}
 
+	public async fromPoolData(data: Contracts.Crypto.TransactionData): Promise<Contracts.Crypto.Transaction> {
+		const serialized = await this.serializer.serialize(data);
+		return new Transaction(data, serialized);
+	}
+
 	public async fromStorage(
 		transaction: Contracts.Crypto.TransactionStorageDataExtended,
 	): Promise<Contracts.Crypto.BlockTransaction> {

--- a/packages/forger/source/transaction-iterable.ts
+++ b/packages/forger/source/transaction-iterable.ts
@@ -27,7 +27,8 @@ export class TransactionIterable implements AsyncIterable<Contracts.Crypto.Trans
 			});
 
 			for (const tx of batch.transactions) {
-				const transaction = await this.transactionFactory.fromData(tx);
+				// Pool-sourced txs are already verified by this node's mempool
+				const transaction = await this.transactionFactory.fromPoolData(tx);
 				yield transaction;
 			}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Re-create transactions from already-validated pool data without re-running signature recovery and strict schema validation.

The pool verifies transactions on intake, so the forger can skip the recompute when building blocks.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
