### PR TITLE
chore: docker musl build for evm & pnpm 10 downgrade

### DIFF
--- a/docker/testnet/api/Dockerfile
+++ b/docker/testnet/api/Dockerfile
@@ -6,15 +6,15 @@ ADD entrypoint.sh /entrypoint.sh
 
 ARG mainsail_channel=rc
 
-ENV PNPM_HOME=/home/node/.pnpm
-ENV PATH="${PATH}:${PNPM_HOME}/bin"
+ENV PNPM_HOME=/home/node/.pnpm/bin
+ENV PATH="${PATH}:${PNPM_HOME}"
 
 RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 py3-setuptools git \
-    && apk add --no-cache bash sudo git openntpd jemalloc \
+    && apk add --no-cache bash sudo git openntpd jemalloc curl \
     && echo "servers pool.ntp.org" > /etc/ntpd.conf \
     && echo "servers time.google.com" >> /etc/ntpd.conf \
     && npm install -g npm@latest \
-    && su node -c "npm install --prefix=/home/node/.pnpm -g pnpm" \
+    && su node -c "npm install --prefix=/home/node/.pnpm -g pnpm@10.34.3" \
     && su node -c "pnpm add -g @mainsail/api@${mainsail_channel} --allow-build=nsfw" \
     && su node -c "export PNPM_HOME=/home/node/.pnpm/bin" \
     && su node -c "pnpm store prune" \

--- a/docker/testnet/api/Dockerfile
+++ b/docker/testnet/api/Dockerfile
@@ -10,7 +10,7 @@ ENV PNPM_HOME=/home/node/.pnpm/bin
 ENV PATH="${PATH}:${PNPM_HOME}"
 
 RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 py3-setuptools git \
-    && apk add --no-cache bash sudo git openntpd jemalloc curl \
+    && apk add --no-cache bash sudo git openntpd jemalloc \
     && echo "servers pool.ntp.org" > /etc/ntpd.conf \
     && echo "servers time.google.com" >> /etc/ntpd.conf \
     && npm install -g npm@latest \

--- a/docker/testnet/core/Dockerfile
+++ b/docker/testnet/core/Dockerfile
@@ -6,19 +6,22 @@ ADD entrypoint.sh /entrypoint.sh
 
 ARG mainsail_channel=rc
 
-ENV PNPM_HOME=/home/node/.pnpm
-ENV PATH="${PATH}:${PNPM_HOME}/bin"
+ENV PNPM_HOME=/home/node/.pnpm/bin
+ENV CARGO_HOME=/home/node/.cargo
+ENV PATH="${PATH}:${PNPM_HOME}:${CARGO_HOME}/bin"
 
 RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 py3-setuptools git \
     && apk add --no-cache bash sudo git openntpd openssl jemalloc curl \
     && echo "servers pool.ntp.org" > /etc/ntpd.conf \
     && echo "servers time.google.com" >> /etc/ntpd.conf \
     && npm install -g npm@latest \
-    && su node -c "npm install --prefix=/home/node/.pnpm -g pnpm" \
-    && su node -c "pnpm add -g @mainsail/core@${mainsail_channel} --allow-build=@chainsafe/blst --allow-build=bcrypto --allow-build=better-sqlite3 --allow-build=bstring --allow-build=lmdb --allow-build=msgpackr-extract --allow-build=nsfw --allow-build=protobufjs" \
+    && su node -c "curl https://sh.rustup.rs -sSf | sh -s -- -y" \
+    && su node -c "npm install --prefix=/home/node/.pnpm -g pnpm@10.34.3" \
+    && su node -c "pnpm add -g @mainsail/core@${mainsail_channel} --allow-build=@mainsail/evm --allow-build=@chainsafe/blst --allow-build=bcrypto --allow-build=better-sqlite3 --allow-build=bstring --allow-build=lmdb --allow-build=msgpackr-extract --allow-build=nsfw --allow-build=protobufjs" \
     && su node -c "export PNPM_HOME=/home/node/.pnpm/bin" \
     && su node -c "pnpm store prune" \
     && su node -c "rm -rf ~/.cache/node-gyp" \
+    && su node -c "rustup self uninstall -y" \
     && apk del .build-deps \
     && echo 'node ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/docker/testnet/core/docker-compose-build.yml
+++ b/docker/testnet/core/docker-compose-build.yml
@@ -4,7 +4,7 @@ services:
             context: .
             dockerfile: Dockerfile
             args:
-                core_channel: rc
+                mainsail_channel: rc
         image: mainsail-test
         container_name: mainsail-testnet
         restart: always


### PR DESCRIPTION
## Summary
- Downgrade PNPM to latest stable version - 10.34.3 (following several bugs detected with v11).
- Prepare for EVM builds by installing Rust along with Mainsail Core at docker image build stage (Rust then being removed, after successful build). 

