### PR TITLE
feat(evm):  implement semaphore to prevent EVM thread exhaustion

### DIFF
--- a/packages/evm-service/source/instances/evm.ts
+++ b/packages/evm-service/source/instances/evm.ts
@@ -13,11 +13,14 @@ export class EvmInstance implements Contracts.Evm.Instance, Contracts.Evm.Storag
 	@inject(Identifiers.Services.Log.Service)
 	protected readonly logger!: Contracts.Kernel.Logger;
 
+	protected readonly concurrency?: number;
+
 	#evm!: Evm;
 
 	@postConstruct()
 	public initialize(): void {
 		this.#evm = new Evm({
+			concurrency: this.concurrency,
 			historySize: 256n,
 			logger: (record) => {
 				try {

--- a/packages/evm-service/source/instances/index.ts
+++ b/packages/evm-service/source/instances/index.ts
@@ -1,1 +1,2 @@
 export * from "./evm.js";
+export * from "./limited-evm.js";

--- a/packages/evm-service/source/instances/limited-evm.test.ts
+++ b/packages/evm-service/source/instances/limited-evm.test.ts
@@ -1,0 +1,57 @@
+import type { Contracts } from "@mainsail/contracts";
+import { Application } from "@mainsail/kernel";
+import { setGracefulCleanup } from "tmp";
+
+import { describe } from "@mainsail/test-runner";
+import { prepareSandbox } from "../../test/helpers/prepare-sandbox";
+import { EvmInstance } from "./evm";
+import { LimitedEvmInstance } from "./limited-evm";
+
+describe<{
+	app: Application;
+	unlimitedInstance: Contracts.Evm.Instance & Contracts.Evm.Storage;
+	limitedInstance: Contracts.Evm.Instance & Contracts.Evm.Storage;
+}>("LimitedEvmInstance", ({ assert, afterAll, afterEach, beforeEach, it }) => {
+	afterAll(() => setGracefulCleanup());
+
+	afterEach(async ({ unlimitedInstance, limitedInstance }) => {
+		await unlimitedInstance.dispose();
+		await limitedInstance.dispose();
+	});
+
+	beforeEach(async (context) => {
+		await prepareSandbox(context);
+
+		context.unlimitedInstance = context.app.resolve(EvmInstance);
+		context.limitedInstance = context.app.resolve(LimitedEvmInstance);
+	});
+
+	const address = "0x0000000000000000000000000000000000000001";
+
+	// Fire `n` gated reads at once and return how long they took to all settle.
+	const hammer = async (evm: Contracts.Evm.Instance, n: number): Promise<number> => {
+		await evm.getAccountInfo(address); // warm up (one-time init cost out of the measurement)
+		const start = performance.now();
+		await Promise.all(Array.from({ length: n }, () => evm.getAccountInfo(address)));
+		return performance.now() - start;
+	};
+
+	it("serializes gated calls under a small limit and parallelizes without one", async ({
+		unlimitedInstance,
+		limitedInstance,
+	}) => {
+		const N = 500;
+
+		// limited → the semaphore admits less than N reads at the same time, so N reads take longer.
+		const limited = await hammer(limitedInstance, N);
+		// unlimited → N reads fan out across the blocking pool (512 threads) and overlap, so N reads take less.
+		const unlimited = await hammer(unlimitedInstance, N);
+
+		// console.log({ limited, unlimited });
+		// { limited: 9.473764999999958, unlimited: 2.2855690000000095 }
+
+		// The limited batch takes far longer than the unbounded one. That gap is the proof
+		// the semaphore is actually enforcing the cap
+		assert.true(limited > unlimited * 3);
+	});
+});

--- a/packages/evm-service/source/instances/limited-evm.test.ts
+++ b/packages/evm-service/source/instances/limited-evm.test.ts
@@ -47,11 +47,11 @@ describe<{
 		// unlimited → N reads fan out across the blocking pool (512 threads) and overlap, so N reads take less.
 		const unlimited = await hammer(unlimitedInstance, N);
 
-		// console.log({ limited, unlimited });
+		console.log({ limited, unlimited });
 		// { limited: 9.473764999999958, unlimited: 2.2855690000000095 }
 
-		// The limited batch takes far longer than the unbounded one. That gap is the proof
+		// The limited batch takes longer than the unbounded one. That gap is the proof
 		// the semaphore is actually enforcing the cap
-		assert.true(limited > unlimited * 3);
+		assert.true(limited > unlimited * 1.05);
 	});
 });

--- a/packages/evm-service/source/instances/limited-evm.ts
+++ b/packages/evm-service/source/instances/limited-evm.ts
@@ -1,0 +1,26 @@
+import { injectable } from "@mainsail/container";
+
+import { EvmInstance } from "./evm.js";
+
+@injectable()
+export class LimitedEvmInstance extends EvmInstance {
+	// Max EVM calls this request-serving instance may run concurrently.
+	//
+	// Every napi EVM call holds one thread of the tokio blocking pool for its full duration, the
+	// pool is process-wide and capped at 512 (`max_blocking_threads`, set in the Rust addon's
+	// `init_tokio_runtime`), and ALL instances share it. So an unbounded API/mempool flood on the
+	// externally-driven instances (`rpc`, `transaction-pool`) could occupy every thread and make
+	// the consensus (`evm`) and forger (`validator`) instances — which are intentionally unbounded —
+	// queue behind it. Block processing and block building must never wait on untrusted reads, so
+	// only the externally-driven instances are capped; consensus/forger keep the remaining headroom.
+	//
+	// Sizing rule: Σ(per-instance caps) + peak consensus/forger demand < 512. The two capped
+	// instances at 192 each = 384 worst case, leaving ~128 threads always free for consensus+forger
+	// — ample, since their work is near-serial (one block at a time, sequential per-tx execution).
+	// Raise for more RPC throughput, lower to reserve more for consensus, and re-tune together with
+	// `max_blocking_threads` if that ever changes.
+	//
+	// TODO: move these limits (and `max_blocking_threads`) into config so operators can tune per
+	//       deployment (high-RPC node vs. pure validator) without a code change; keep 192 as default
+	protected override readonly concurrency = 192;
+}

--- a/packages/evm-service/source/service-provider.ts
+++ b/packages/evm-service/source/service-provider.ts
@@ -4,7 +4,7 @@ import { Identifiers } from "@mainsail/constants";
 import { injectable } from "@mainsail/container";
 import { Providers } from "@mainsail/kernel";
 
-import { EvmInstance } from "./instances/index.js";
+import { EvmInstance, LimitedEvmInstance } from "./instances/index.js";
 
 @injectable()
 export class ServiceProvider extends Providers.ServiceProvider {
@@ -15,11 +15,11 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
 		this.app
 			.bind(Identifiers.Evm.Instance)
-			.to(EvmInstance)
+			.to(LimitedEvmInstance)
 			.inSingletonScope()
 			.whenTagged("instance", "transaction-pool");
 
-		this.app.bind(Identifiers.Evm.Instance).to(EvmInstance).inSingletonScope().whenTagged("instance", "rpc");
+		this.app.bind(Identifiers.Evm.Instance).to(LimitedEvmInstance).inSingletonScope().whenTagged("instance", "rpc");
 	}
 
 	public async boot(): Promise<void> {}

--- a/packages/evm/bindings/Cargo.toml
+++ b/packages/evm/bindings/Cargo.toml
@@ -24,6 +24,7 @@ napi = { version = "3.4.0", default-features = false, features = [
     "napi9",
     "serde-json",
     "tokio_rt",
+    "tokio_sync"
 ] }
 napi-derive = "3.3.0"
 

--- a/packages/evm/bindings/src/ctx.rs
+++ b/packages/evm/bindings/src/ctx.rs
@@ -15,6 +15,8 @@ pub struct JsEvmOptions {
     pub path: String,
     pub logger: Option<Function<'static, JsLogMessage, ()>>,
     pub history_size: Option<BigInt>,
+    /// Max concurrent EVM ops for this instance. Omit to leave unbounded (consensus/forger).
+    pub concurrency: Option<u32>,
 }
 
 #[napi(object)]
@@ -273,6 +275,7 @@ pub struct EvmOptions {
     pub path: PathBuf,
     pub logger_callback: Option<Function<'static, JsLogMessage, ()>>,
     pub history_size: Option<u64>,
+    pub concurrency: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -613,6 +616,7 @@ impl TryFrom<JsEvmOptions> for EvmOptions {
             path: value.path.into(),
             logger_callback: value.logger,
             history_size,
+            concurrency: value.concurrency,
         })
     }
 }

--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -40,6 +40,7 @@ use revm::{
     primitives::{Address, B256, Bytes, TxKind, U256, hex::ToHexExt, map::HashMap},
     state::AccountInfo,
 };
+use tokio::sync::Semaphore;
 
 mod ctx;
 mod logger;
@@ -1266,6 +1267,7 @@ impl EvmInner {
 #[napi(js_name = "Evm")]
 pub struct JsEvmWrapper {
     evm: Arc<parking_lot::RwLock<EvmInner>>,
+    concurrency: Option<Arc<Semaphore>>, // None => unbounded (consensus/forger)
 }
 
 /// Pin the napi tokio runtime explicitly instead of relying on napi-rs's implicit default.
@@ -1292,8 +1294,13 @@ impl JsEvmWrapper {
     #[napi(constructor)]
     pub fn new(opts: JsEvmOptions) -> Result<Self> {
         let opts = EvmOptions::try_from(opts)?;
+        let concurrency = opts
+            .concurrency
+            .map(|n| Arc::new(Semaphore::new(n as usize)));
+
         Ok(JsEvmWrapper {
             evm: Arc::new(parking_lot::RwLock::new(EvmInner::new(opts))),
+            concurrency,
         })
     }
 
@@ -1881,7 +1888,10 @@ impl JsEvmWrapper {
         V: ToNapiValue,
         C: FnOnce(&'env Env, R) -> Result<V> + 'static,
     {
-        env.spawn_future_with_callback(Self::with_read(self.evm.clone(), f), cb)
+        env.spawn_future_with_callback(
+            Self::with_read(self.evm.clone(), self.concurrency.clone(), f),
+            cb,
+        )
     }
 
     fn write<'env, F, R, E, C, V>(&self, env: &'env Env, f: F, cb: C) -> Result<PromiseRaw<'env, V>>
@@ -1892,17 +1902,34 @@ impl JsEvmWrapper {
         V: ToNapiValue,
         C: FnOnce(&'env Env, R) -> Result<V> + 'static,
     {
-        env.spawn_future_with_callback(Self::with_write(self.evm.clone(), f), cb)
+        env.spawn_future_with_callback(
+            Self::with_write(self.evm.clone(), self.concurrency.clone(), f),
+            cb,
+        )
     }
 
     /// Run `f` against a shared (read) view of the EVM on the blocking pool.
     /// Concurrent readers proceed in parallel; only an in-flight writer blocks them.
-    async fn with_read<F, R, E>(evm: Arc<parking_lot::RwLock<EvmInner>>, f: F) -> Result<R>
+    async fn with_read<F, R, E>(
+        evm: Arc<parking_lot::RwLock<EvmInner>>,
+        concurrency: Option<Arc<Semaphore>>,
+        f: F,
+    ) -> Result<R>
     where
         F: FnOnce(&EvmInner) -> std::result::Result<R, E> + Send + 'static,
         R: Send + 'static,
         E: std::fmt::Display + Send + 'static,
     {
+        // Bounded instances wait here — off the blocking pool — when at capacity.
+        let _permit = match concurrency {
+            Some(sem) => Some(
+                sem.acquire_owned()
+                    .await
+                    .map_err(|_| napi::Error::from_reason("evm concurrency limiter closed"))?,
+            ),
+            None => None,
+        };
+
         tokio::task::spawn_blocking(move || {
             let evm = evm.read(); // shared lock; dropped at closure end
             f(&evm)
@@ -1913,12 +1940,26 @@ impl JsEvmWrapper {
     }
 
     /// Run `f` against an exclusive (write) view of the EVM on the blocking pool.
-    async fn with_write<F, R, E>(evm: Arc<parking_lot::RwLock<EvmInner>>, f: F) -> Result<R>
+    async fn with_write<F, R, E>(
+        evm: Arc<parking_lot::RwLock<EvmInner>>,
+        concurrency: Option<Arc<Semaphore>>,
+        f: F,
+    ) -> Result<R>
     where
         F: FnOnce(&mut EvmInner) -> std::result::Result<R, E> + Send + 'static,
         R: Send + 'static,
         E: std::fmt::Display + Send + 'static,
     {
+        // Bounded instances wait here — off the blocking pool — when at capacity.
+        let _permit = match concurrency {
+            Some(sem) => Some(
+                sem.acquire_owned()
+                    .await
+                    .map_err(|_| napi::Error::from_reason("evm concurrency limiter closed"))?,
+            ),
+            None => None,
+        };
+
         tokio::task::spawn_blocking(move || {
             let mut evm = evm.write(); // exclusive lock
             f(&mut evm)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
An unbounded API/mempool flood on the externally-driven instances (rpc, transaction-pool) could occupy
every thread and make the consensus (evm) and forger (validator) instances queue behind it — a liveness DoS.

Add an optional per-instance concurrency limit. The Evm constructor takes a `concurrency`; with_read/with_write acquire a permit from a per-instance Semaphore before spawn_blocking, so over-limit calls park off the pool rather than consuming a thread. The rpc and transaction-pool instances are capped (192 each, via `LimitedEvmInstance`); evm and validator pass no limit and stay unbounded, so block processing and block building always keep pool headroom. 


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
