### PR TITLE
fix(evm): prevent the forger from calculating the wrong state root when a transaction fails during collation

### DIFF
--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -729,7 +729,7 @@ impl EvmInner {
         &mut self,
         tx_ctx: TxContext,
     ) -> std::result::Result<TxReceipt, EVMError<String>> {
-        let commit_key = &tx_ctx.block_context.commit_key;
+        let commit_key = tx_ctx.block_context.commit_key;
 
         let (committed, _) = self
             .persistent_db
@@ -737,7 +737,15 @@ impl EvmInner {
             .map_err(|err| EVMError::Database(format!("commit receipt lookup: {}", err).into()))?;
         assert!(!committed);
 
-        if let Some(mut pending) = self.pending_commits.get_mut(commit_key) {
+        // A legacy cold-wallet merge mutates the pending commit *before* the transaction
+        // executes (so the tx can spend the merged balance). If the tx then fails it is
+        // dropped from the block, and an orphaned merge would diverge this validator's state
+        // root from nodes that replay the block. Snapshot the pending commit before such a
+        // merge so we can restore it on failure. This runs only for the first transaction of
+        // a legacy sender — a one-time, migration-era event — so the clone is not a hot path.
+        let mut merge_restore: Option<PendingCommit> = None;
+
+        if let Some(mut pending) = self.pending_commits.get_mut(&commit_key) {
             // Make legacy cold wallet balance available to pending commit if not already present
             if let Some(legacy_address) = tx_ctx.legacy_address {
                 if !pending
@@ -754,6 +762,11 @@ impl EvmInner {
                             )
                         })? {
                         Some(legacy_cold_wallet) if legacy_cold_wallet.merge_info.is_none() => {
+                            // Snapshot before the merge so a later transaction failure can
+                            // undo it. (An `apply_rewards` error is already self-healing: it
+                            // restores the prestate cache and never sets the bookkeeping.)
+                            merge_restore = Some(pending.clone());
+
                             let mut legacy_balances = HashMap::<Address, u128>::default();
                             legacy_balances.insert(
                                 tx_ctx.from,
@@ -789,13 +802,21 @@ impl EvmInner {
                 let receipt = map_execution_result(result, cumulative_gas_used);
                 Ok(receipt)
             }
-            Err(err) => match err {
-                EVMError::Transaction(err) => Err(EVMError::Transaction(err)),
-                EVMError::Database(err) => Err(EVMError::Database(err.to_string())),
-                _ => {
-                    panic!("fatal evm err {:?}", err);
+            Err(err) => {
+                // The transaction is dropped from the block; undo any legacy cold-wallet
+                // merge applied for it so the committed state never carries an orphaned merge.
+                if let Some(restore) = merge_restore {
+                    self.pending_commits.insert(commit_key, restore);
                 }
-            },
+
+                match err {
+                    EVMError::Transaction(err) => Err(EVMError::Transaction(err)),
+                    EVMError::Database(err) => Err(EVMError::Database(err.to_string())),
+                    _ => {
+                        panic!("fatal evm err {:?}", err);
+                    }
+                }
+            }
         }
     }
 
@@ -1150,7 +1171,21 @@ impl EvmInner {
 
                 Ok((result, cumulative_gas_used))
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                // revm validates the tx before mutating state, so on a recoverable error
+                // nothing was committed and `state_db.cache` still holds the prestate we
+                // moved out of the pending commit. Hand it back so a failed tx is a no-op
+                // on the pending commit instead of leaving it empty — otherwise the next
+                // tx in this block executes against committed-only state and the forged
+                // block's state root diverges from honest re-execution.
+                if let Some(commit_key) = ctx.block_context.as_ref().map(|b| &b.commit_key) {
+                    let state_db = evm.db_mut();
+                    if let Some(pending_commit) = self.pending_commits.get_mut(commit_key) {
+                        pending_commit.cache = std::mem::take(&mut state_db.cache);
+                    }
+                }
+                Err(err)
+            }
         }
     }
 

--- a/packages/evm/core/src/state_commit.rs
+++ b/packages/evm/core/src/state_commit.rs
@@ -253,7 +253,7 @@ mod tests {
         db::{Error, GenesisInfo, PendingCommit, PersistentDB},
         events,
         state_changes::{AccountMergeInfo, AccountUpdate, StateChangeset},
-        state_commit::{StateCommit, apply_rewards, collect_dirty_accounts},
+        state_commit::{StateCommit, apply_rewards, build_commit, collect_dirty_accounts},
     };
     use crate::{
         legacy::{LegacyAccountAttributes, LegacyAddress},
@@ -615,5 +615,205 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Lock)));
         assert_eq!(resizes, 0); // non-DbFull errors return immediately
+    }
+
+    /// `build_commit` derives the committed change set from a pending commit's `transitions`,
+    /// not from its account `cache`. Emptying the cache before building must therefore produce
+    /// an identical change set.
+    #[test]
+    fn build_commit_is_independent_of_a_drained_cache() {
+        let path = tempfile::Builder::new()
+            .prefix("evm.mdb")
+            .tempdir()
+            .unwrap();
+        let db = PersistentDB::new(crate::db::PersistentDBOptions::new(
+            path.path().to_path_buf(),
+        ))
+        .expect("database");
+
+        let account = address!("bd6f65c58a46427af4b257cbe231d0ed69ed5508");
+        let mut rewards = HashMap::<Address, u128>::default();
+        rewards.insert(account, 1234);
+
+        let mut pending = PendingCommit::default();
+        apply_rewards(&db, &mut pending, rewards).expect("apply rewards");
+        assert!(pending.cache.accounts.contains_key(&account));
+        assert!(pending.transitions.transitions.contains_key(&account));
+
+        // Baseline: build with the cache intact.
+        let mut intact = pending.clone();
+        let intact_commit = build_commit(&mut intact).expect("build intact");
+
+        // Build again with the cache emptied but the transitions kept.
+        let mut drained = pending.clone();
+        drained.cache = Default::default();
+        assert!(drained.cache.accounts.is_empty());
+        assert!(drained.transitions.transitions.contains_key(&account));
+        let drained_commit = build_commit(&mut drained).expect("build drained");
+
+        assert_eq!(
+            format!("{:?}", intact_commit.change_set),
+            format!("{:?}", drained_commit.change_set),
+            "draining the cache must not change the committed change set"
+        );
+    }
+
+    /// A transaction executes against the pending commit's account cache as its prestate. An
+    /// account credited only in the cache (not yet committed to the database) is visible to a
+    /// transfer from it: the transfer succeeds against the populated cache, and fails with
+    /// insufficient funds against an empty cache.
+    #[test]
+    fn drained_cache_diverges_a_dependent_transaction() {
+        use revm::{
+            Context, ExecuteEvm, MainBuilder, MainContext,
+            context::{BlockEnv, TxEnv},
+            database::{CacheState, State, WrapDatabaseRef},
+            primitives::{TxKind, hardfork::SpecId},
+        };
+
+        let path = tempfile::Builder::new()
+            .prefix("evm.mdb")
+            .tempdir()
+            .unwrap();
+        let db = PersistentDB::new(crate::db::PersistentDBOptions::new(
+            path.path().to_path_buf(),
+        ))
+        .expect("database");
+
+        let account = address!("bd6f65c58a46427af4b257cbe231d0ed69ed5508");
+        let recipient = address!("ad6f65c58a46427af4b257cbe231d0ed69ed5508");
+        let mut pending = PendingCommit::default();
+        let mut rewards = HashMap::<Address, u128>::default();
+        rewards.insert(account, 1_000_000);
+        apply_rewards(&db, &mut pending, rewards).expect("apply rewards");
+
+        let run_transfer = |prestate: CacheState| -> bool {
+            let state = State::builder()
+                .with_bundle_update()
+                .with_cached_prestate(prestate)
+                .with_database(WrapDatabaseRef(&db))
+                .build();
+
+            let mut evm = Context::mainnet()
+                .with_db(state)
+                .modify_cfg_chained(|cfg| {
+                    cfg.spec = SpecId::SHANGHAI;
+                    cfg.disable_nonce_check = true;
+                })
+                .modify_block_chained(|block: &mut BlockEnv| {
+                    block.gas_limit = 30_000_000;
+                })
+                .modify_tx_chained(|tx: &mut TxEnv| {
+                    tx.caller = account;
+                    tx.kind = TxKind::Call(recipient);
+                    tx.value = U256::from(1);
+                    tx.gas_limit = 21_000;
+                    tx.gas_price = 0;
+                    tx.gas_priority_fee = None;
+                    tx.nonce = 0;
+                })
+                .build_mainnet();
+
+            matches!(evm.replay(), Ok(result) if result.result.is_success())
+        };
+
+        assert!(
+            run_transfer(pending.cache.clone()),
+            "transfer should succeed against the populated cache"
+        );
+        assert!(
+            !run_transfer(CacheState::default()),
+            "transfer must NOT succeed against the empty cache"
+        );
+    }
+
+    /// A transaction that fails validation (here, spending more than its balance) leaves the
+    /// cached account state untouched: the sender's balance is unchanged and the recipient is
+    /// not credited.
+    #[test]
+    fn failed_replay_does_not_mutate_state_cache() {
+        use revm::{
+            Context, ExecuteEvm, MainBuilder, MainContext,
+            context::{BlockEnv, ContextTr, TxEnv},
+            database::{State, WrapDatabaseRef},
+            handler::EvmTr,
+            primitives::{TxKind, hardfork::SpecId},
+        };
+
+        let path = tempfile::Builder::new()
+            .prefix("evm.mdb")
+            .tempdir()
+            .unwrap();
+        let db = PersistentDB::new(crate::db::PersistentDBOptions::new(
+            path.path().to_path_buf(),
+        ))
+        .expect("database");
+
+        // Prestate: `from` holds exactly `balance`.
+        let from = address!("bd6f65c58a46427af4b257cbe231d0ed69ed5508");
+        let recipient = address!("ad6f65c58a46427af4b257cbe231d0ed69ed5508");
+        let balance: u128 = 1_000;
+        let mut pending = PendingCommit::default();
+        let mut rewards = HashMap::<Address, u128>::default();
+        rewards.insert(from, balance);
+        apply_rewards(&db, &mut pending, rewards).expect("seed prestate");
+
+        let state = State::builder()
+            .with_bundle_update()
+            .with_cached_prestate(pending.cache.clone())
+            .with_database(WrapDatabaseRef(&db))
+            .build();
+
+        // A transfer that fails validation (spends more than `balance`).
+        let mut evm = Context::mainnet()
+            .with_db(state)
+            .modify_cfg_chained(|cfg| {
+                cfg.spec = SpecId::SHANGHAI;
+                cfg.disable_nonce_check = true;
+            })
+            .modify_block_chained(|block: &mut BlockEnv| {
+                block.gas_limit = 30_000_000;
+            })
+            .modify_tx_chained(|tx: &mut TxEnv| {
+                tx.caller = from;
+                tx.kind = TxKind::Call(recipient);
+                tx.value = U256::from(balance + 1);
+                tx.gas_limit = 21_000;
+                tx.gas_price = 0;
+                tx.gas_priority_fee = None;
+                tx.nonce = 0;
+            })
+            .build_mainnet();
+
+        assert!(
+            evm.replay().is_err(),
+            "transfer must fail (insufficient funds)"
+        );
+
+        // The failed replay must not have mutated the cached prestate.
+        let ctx = evm.ctx_mut();
+        let cache = &ctx.db().cache;
+        let from_balance = cache
+            .accounts
+            .get(&from)
+            .and_then(|a| a.account.as_ref())
+            .map(|a| a.info.balance)
+            .expect("from cached");
+        assert_eq!(
+            from_balance,
+            U256::from(balance),
+            "from balance must be unchanged after a failed tx"
+        );
+        let recipient_balance = cache
+            .accounts
+            .get(&recipient)
+            .and_then(|a| a.account.as_ref())
+            .map(|a| a.info.balance)
+            .unwrap_or(U256::ZERO);
+        assert_eq!(
+            recipient_balance,
+            U256::ZERO,
+            "recipient must not be credited by a failed tx"
+        );
     }
 }

--- a/packages/evm/core/src/state_commit.rs
+++ b/packages/evm/core/src/state_commit.rs
@@ -66,21 +66,25 @@ pub fn apply_rewards(
         .with_database(WrapDatabaseRef(&db))
         .build();
 
-    state
+    let result = state
         .increment_balances(rewards)
-        .map_err(|err| crate::db::Error::State(format!("increment balances err={}", err)))?;
+        .map_err(|err| crate::db::Error::State(format!("increment balances err={}", err)));
 
-    if let Some(transition_state) = state.transition_state.take() {
-        // println!("transition state {:#?}", transition_state);
-        pending
-            .transitions
-            .add_transitions(transition_state.transitions.into_iter());
+    // `increment_balances` short-circuits before committing any transition, so on error
+    // the state carries no reward changes. Only fold transitions in on success; always
+    // return the prestate cache so a recoverable failure never leaves `pending` empty.
+    if result.is_ok() {
+        if let Some(transition_state) = state.transition_state.take() {
+            pending
+                .transitions
+                .add_transitions(transition_state.transitions.into_iter());
+        }
     }
 
     pending.cache = std::mem::take(&mut state.cache);
     // println!("cache {:#?}", pending.cache.accounts);
 
-    Ok(())
+    result
 }
 
 pub fn commit_to_db(

--- a/packages/forger/source/transaction-forger.ts
+++ b/packages/forger/source/transaction-forger.ts
@@ -145,8 +145,10 @@ export class TransactionForger implements Contracts.Forger.TransactionForger {
 		transaction: Contracts.Crypto.Transaction,
 		result: ProcessTransactionResult,
 	): Promise<void> {
+		const optimisticExecution = result.gasLeft - transaction.gasLimit < 0;
+		let snapshotTaken = false;
+
 		try {
-			const optimisticExecution = result.gasLeft - transaction.gasLimit < 0;
 			if (optimisticExecution) {
 				// Optimistically execute transaction even if the gas limit exceeds the remaining
 				// block space since there's possibly still space to fit the actual gas consumed.
@@ -158,6 +160,7 @@ export class TransactionForger implements Contracts.Forger.TransactionForger {
 				);
 
 				await this.evm.snapshot(this.#commitKey);
+				snapshotTaken = true;
 			}
 
 			const validation = await this.#validateTransaction(transaction);
@@ -170,7 +173,7 @@ export class TransactionForger implements Contracts.Forger.TransactionForger {
 					`Skipping tx ${transaction.hash} due to insufficient block space (tx.gasUsed=${gasUsed} gasLeft=${transaction.gasLimit} optimistic=${optimisticExecution})`,
 				);
 
-				if (optimisticExecution) {
+				if (snapshotTaken) {
 					await this.evm.rollback(this.#commitKey);
 					return;
 				} else {
@@ -186,6 +189,18 @@ export class TransactionForger implements Contracts.Forger.TransactionForger {
 			result.transactions.push(transaction);
 		} catch (rawError) {
 			const error = ensureError(rawError);
+
+			// Ensure unexpected errors keep the evm in a consistent state.
+			if (snapshotTaken) {
+				try {
+					await this.evm.rollback(this.#commitKey);
+				} catch (innerError) {
+					this.logger.warn(
+						`rollback failed after failed tx ${transaction.hash}: ${ensureError(innerError).message}`,
+					);
+				}
+			}
+
 			await this.#handleFailedTransaction(transaction, error as Error);
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
A transaction failing during collation (the forger creating a block) left the in-block cache empty, so later transactions ran against stale state and the forger calculated the wrong state root. Impact is limited to a missed block (the bad proposal is rejected by other validators and the round moves on).


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
