### PR TITLE
ci: use foundry stable instead of nightly

### DIFF
--- a/.github/workflows/_lint-external.yml
+++ b/.github/workflows/_lint-external.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/_lint-internal.yml
+++ b/.github/workflows/_lint-internal.yml
@@ -73,7 +73,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Install dependencies
               run: pnpm install


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Nightly seems to have weird issues. Also we are using stable everywhere else anyway, there's no reason to use.

<img width="1692" height="1299" alt="image" src="https://github.com/user-attachments/assets/bc9cf737-0f47-4b50-b183-8f6a27bd92aa" />

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
