### PR TITLE
fix(crypto-transaction): reject non-canonical integer RLP and out-of-range r/s in deserializer

### DIFF
--- a/packages/crypto-transaction/source/deserializer.test.ts
+++ b/packages/crypto-transaction/source/deserializer.test.ts
@@ -4,8 +4,17 @@ import { Application } from "@mainsail/kernel";
 import { describe } from "@mainsail/test-runner";
 import { parseTransaction } from "viem";
 import { Deserialized, Serialized } from "../test/fixtures/index.js";
-import { signTransfer, signUntilLeadingZeroRS } from "../test/helpers/canonical-transaction";
+import {
+	encodeLegacy,
+	fixedWidth32,
+	legacyRlpFields,
+	signTransfer,
+	signUntilLeadingZeroRS,
+} from "../test/helpers/canonical-transaction";
 import { prepareSandbox } from "../test/helpers/prepare-sandbox";
+
+// secp256k1 group order (n). r/s must be in [1, n).
+const SECP256K1_ORDER = "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141";
 
 describe<{
 	app: Application;
@@ -100,5 +109,80 @@ describe<{
 		const oversized = await serializer.serialize({ ...canonical, r: "ff" + canonical.r });
 
 		await assert.rejects(() => deserializer.deserialize(oversized), "exceeds 32 bytes");
+	});
+
+	// The canonicalization from PR #1398 made the serializer emit minimal-integer r/s but left the
+	// deserializer normalizing any <=32-byte value back to 32 bytes. That accepts a second, padded
+	// wire form for the same transaction — geth rejects it ("rlp: non-canonical integer"). Left
+	// unclosed, a padded transaction keeps its original wire bytes through the pool into the block
+	// payload, while storage persists canonical 32-byte r/s; the storage-rebuilt block then no longer
+	// matches its own payloadSize and fails to deserialize when served to a peer. Reject at decode.
+	it("should reject a zero-padded (non-minimal) r whose canonical form is accepted", async ({
+		app,
+		deserializer,
+	}) => {
+		// A real signature whose r (or s) has a leading zero byte: its canonical wire form is < 32 bytes.
+		const canonical = await signUntilLeadingZeroRS(app);
+		const component = canonical.r.startsWith("00") ? 7 : 8;
+		const paddedValue = component === 7 ? canonical.r : canonical.s;
+
+		// The canonical (minimal) wire form of exactly this transaction still deserializes.
+		await assert.resolves(() => deserializer.deserialize(encodeLegacy(legacyRlpFields(canonical))));
+
+		// The zero-padded 32-byte form of the same value is now rejected.
+		const fields = legacyRlpFields(canonical);
+		fields[component] = fixedWidth32(paddedValue);
+
+		await assert.rejects(() => deserializer.deserialize(encodeLegacy(fields)), "non-canonical integer");
+	});
+
+	it("should reject a zero-padded (non-minimal) s", async ({ app, deserializer }) => {
+		const canonical = await signTransfer(app);
+		const fields = legacyRlpFields(canonical);
+
+		// A 32-byte s with a leading 0x00 byte — canonical RLP would strip it to 31 bytes.
+		fields[8] = fixedWidth32("00" + "11".repeat(31));
+
+		await assert.rejects(() => deserializer.deserialize(encodeLegacy(fields)), "non-canonical integer");
+	});
+
+	it("should reject non-canonical integer fields (0x00 / leading zero)", async ({ app, deserializer }) => {
+		const canonical = await signTransfer(app);
+
+		// nonce, gasPrice, gasLimit, value, v — index → field name in the rejection message.
+		const cases: [number, Uint8Array, string][] = [
+			[0, new Uint8Array([0x00]), "nonce"], // zero encoded as 0x00 instead of the empty string
+			[1, new Uint8Array([0x00, 0x12]), "gasPrice"], // leading zero byte
+			[2, new Uint8Array([0x00, 0x52, 0x08]), "gasLimit"],
+			[4, new Uint8Array([0x00, 0x01]), "value"],
+			[6, new Uint8Array([0x00, 0x4e, 0x43]), "v"],
+		];
+
+		for (const [index, bytes, field] of cases) {
+			const fields = legacyRlpFields(canonical);
+			fields[index] = bytes;
+
+			await assert.rejects(
+				() => deserializer.deserialize(encodeLegacy(fields)),
+				`decoded RLP ${field} is a non-canonical integer (leading zeroes)`,
+			);
+		}
+	});
+
+	it("should reject r/s outside the valid ECDSA range [1, n)", async ({ app, deserializer }) => {
+		const canonical = await signTransfer(app);
+
+		for (const component of [7, 8] as const) {
+			// r/s = 0 (empty string is canonical zero, so this passes the canonical-integer check
+			// and must be caught by the range check).
+			const zeroFields = legacyRlpFields(canonical);
+			zeroFields[component] = new Uint8Array();
+			await assert.rejects(() => deserializer.deserialize(encodeLegacy(zeroFields)), "out of range");
+
+			// r/s = n (the group order itself; valid values are strictly below it).
+			const orderFields = legacyRlpFields(canonical);
+			orderFields[component] = fixedWidth32(SECP256K1_ORDER);
+			await assert.rejects(() => deserializer.deserialize(encodeLegacy(orderFields)), "out of range");
+		}
 	});
 });

--- a/packages/crypto-transaction/source/deserializer.test.ts
+++ b/packages/crypto-transaction/source/deserializer.test.ts
@@ -136,6 +136,16 @@ describe<{
 		await assert.rejects(() => deserializer.deserialize(encodeLegacy(fields)), "non-canonical integer");
 	});
 
+	it("should reject a zero-padded (non-minimal) r", async ({ app, deserializer }) => {
+		const canonical = await signTransfer(app);
+		const fields = legacyRlpFields(canonical);
+
+		// A 32-byte r with a leading 0x00 byte — canonical RLP would strip it to 31 bytes.
+		fields[7] = fixedWidth32("00" + "11".repeat(31));
+
+		await assert.rejects(() => deserializer.deserialize(encodeLegacy(fields)), "non-canonical integer");
+	});
+
 	it("should reject a zero-padded (non-minimal) s", async ({ app, deserializer }) => {
 		const canonical = await signTransfer(app);
 		const fields = legacyRlpFields(canonical);

--- a/packages/crypto-transaction/source/deserializer.ts
+++ b/packages/crypto-transaction/source/deserializer.ts
@@ -3,6 +3,9 @@ import type { Contracts } from "@mainsail/contracts";
 import { injectable } from "@mainsail/container";
 import { bytesToHex, getAddress, Hex, hexToBigInt } from "viem";
 
+// secp256k1 group order (n). Valid ECDSA r/s values are in the range [1, n).
+const SECP256K1_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+
 function decodeListBounds(buffer: Uint8Array): { start: number; end: number } {
 	if (buffer.byteLength === 0) {
 		throw new Error("decode RLP empty buffer");
@@ -152,18 +155,18 @@ export class Deserializer implements Contracts.Crypto.TransactionDeserializer {
 			throw new Error("decoded RLP contains too few fields");
 		}
 
-		const nonce = this.#parseBigInt(fields[0]);
-		const gasPrice = this.#parseNumber(fields[1]);
-		const gasLimit = this.#parseNumber(fields[2]);
+		const nonce = this.#parseBigInt(fields[0], "nonce");
+		const gasPrice = this.#parseNumber(fields[1], "gasPrice");
+		const gasLimit = this.#parseNumber(fields[2], "gasLimit");
 
 		const recipientAddressRaw = this.#parseAddress(fields[3]);
 		const to = recipientAddressRaw ? getAddress(recipientAddressRaw) : undefined;
 
-		const value = this.#parseBigInt(fields[4]);
+		const value = this.#parseBigInt(fields[4], "value");
 		const data = this.#parseData(fields[5]);
 
 		// Signature
-		const v = this.#parseNumber(fields[6]);
+		const v = this.#parseNumber(fields[6], "v");
 		const chainId = Math.floor((v - 35) / 2);
 		const network = chainId;
 
@@ -213,15 +216,38 @@ export class Deserializer implements Contracts.Crypto.TransactionDeserializer {
 		if (hex.length > 64) {
 			throw new Error(`decoded RLP signature ${field} exceeds 32 bytes`);
 		}
+
+		this.#assertCanonicalInteger(value, field);
+
+		// Enforce the ECDSA range [1, n) at the decode boundary
+		// instead of relying on the downstream recover/verify/low-s checks to reject 0 or
+		// out-of-range values as a side effect. The low-s bound (s <= n/2) stays in the verifier.
+		const numeric = value === "0x" ? 0n : hexToBigInt(value);
+		if (numeric === 0n || numeric >= SECP256K1_ORDER) {
+			throw new Error(`decoded RLP signature ${field} is out of range`);
+		}
+
 		return hex.padStart(64, "0");
 	}
 
-	#parseNumber(value: Hex): number {
+	#parseNumber(value: Hex, field: string): number {
+		this.#assertCanonicalInteger(value, field);
 		return value === "0x" ? 0 : Number(value);
 	}
 
-	#parseBigInt(value: Hex): bigint {
+	#parseBigInt(value: Hex, field: string): bigint {
+		this.#assertCanonicalInteger(value, field);
 		return value === "0x" ? 0n : hexToBigInt(value);
+	}
+
+	// Canonical RLP integers are minimal big-endian: zero is the empty string ("0x") and no
+	// non-zero value carries a leading zero byte. Geth rejects the non-canonical forms with
+	// "rlp: non-canonical integer (leading zeroes)"; mirror that so a transaction has exactly
+	// one admissible wire encoding and keccak256(serialized) === hash always holds.
+	#assertCanonicalInteger(value: Hex, field: string): void {
+		if (value.startsWith("00", 2)) {
+			throw new Error(`decoded RLP ${field} is a non-canonical integer (leading zeroes)`);
+		}
 	}
 
 	#parseAddress(value: Hex): string | undefined {

--- a/packages/crypto-transaction/test/helpers/canonical-transaction.ts
+++ b/packages/crypto-transaction/test/helpers/canonical-transaction.ts
@@ -33,3 +33,31 @@ export const signUntilLeadingZeroRS = async (app: Application): Promise<Contract
 
 	throw new Error("could not find a signature with a leading-zero r/s byte");
 };
+
+// Minimal big-endian encoding of an integer (canonical RLP form): zero is the empty string.
+const minimalInteger = (value: bigint): Uint8Array => (value === 0n ? new Uint8Array() : toBytes(value));
+
+// The ordered legacy RLP fields (nonce, gasPrice, gasLimit, to, value, data, v, r, s) for a signed
+// struct, each in canonical minimal-integer form — byte-identical to what the serializer emits.
+// Tests overwrite a single entry with a non-canonical value, then RLP-encode with `encodeLegacy`,
+// to exercise the deserializer's decode-time guards without going through the (canonicalizing) serializer.
+export const legacyRlpFields = (transaction: Contracts.Crypto.TransactionData): Uint8Array[] => {
+	const eip155V = BigInt(transaction.network) * 2n + 35n + BigInt(transaction.v);
+
+	return [
+		minimalInteger(BigInt(transaction.nonce)),
+		minimalInteger(BigInt(transaction.gasPrice)),
+		minimalInteger(BigInt(transaction.gasLimit)),
+		transaction.to ? hexToBytes(transaction.to as `0x${string}`) : new Uint8Array(),
+		minimalInteger(BigInt(transaction.value)),
+		hexToBytes(transaction.data as `0x${string}`),
+		minimalInteger(eip155V),
+		minimalInteger(BigInt(`0x${transaction.r}`)),
+		minimalInteger(BigInt(`0x${transaction.s}`)),
+	];
+};
+
+export const encodeLegacy = (fields: Uint8Array[]): Buffer => Buffer.from(toRlp(fields).slice(2), "hex");
+
+// A 32-byte big-endian buffer for a hex string, preserving leading zero bytes (unlike minimalInteger).
+export const fixedWidth32 = (hex: string): Uint8Array => hexToBytes(`0x${hex.padStart(64, "0")}`);

--- a/packages/crypto-transaction/test/helpers/canonical-transaction.ts
+++ b/packages/crypto-transaction/test/helpers/canonical-transaction.ts
@@ -1,5 +1,6 @@
 import type { Contracts } from "@mainsail/contracts";
 import { Application } from "@mainsail/kernel";
+import { hexToBytes, toBytes, toRlp } from "viem";
 
 import { TransactionBuilder } from "../../source/builder.js";
 import { wallet } from "../fixtures/index.js";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
