### PR TITLE
chore(ci): fix contracts coverage file upload target

### DIFF
--- a/.github/workflows/_contracts.yml
+++ b/.github/workflows/_contracts.yml
@@ -41,6 +41,7 @@ jobs:
               if: ${{ env.CODECOV_TOKEN != '' }}
               uses: codecov/codecov-action@v5
               with:
+                  working-directory: contracts
                   files: ./lcov.info
                   token: ${{ env.CODECOV_TOKEN }}
                   slug: ArkEcosystem/mainsail


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
It resolves given file names at root level, while the output is inside `contracts/`. It happened to work because codecov auto searches coverage files but it's not something we should rely on.

```
./codecov  upload-coverage -t <redacted> --git-service github --sha 074c882470c8771312e479079d59ad95dc29c38d --slug ArkEcosystem/mainsail --file ./lcov.info --flag contracts --gcov-executable gcov
warning - 2026-07-14 10:05:02,972 -- Some files were not found --- {"not_found_files": ["lcov.info"]}
```

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
