### PR TITLE
fix(contracts): reject insufficient active validators instead of padding round slots

### DIFF
--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -79,7 +79,6 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
     error ValidatorAlreadyRegistered();
     error ValidatorAlreadyResigned();
     error BellowMinValidators();
-    error NoActiveValidators();
     error InsufficientActiveValidators(uint256 available, uint256 required);
 
     error BlsKeyAlreadyRegistered();
@@ -351,11 +350,6 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         _deleteRoundValidators();
 
         _roundValidatorsHead = address(0);
-        uint8 top = uint8(_clamp(n, 0, _activeValidators.length));
-
-        if (top == 0) {
-            revert NoActiveValidators();
-        }
 
         for (uint256 i = 0; i < _activeValidators.length; i++) {
             address addr = _activeValidators[i];
@@ -372,8 +366,8 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
                 continue;
             }
 
-            if (_roundValidatorsCount < top) {
-                _insertValidator(addr, top);
+            if (_roundValidatorsCount < n) {
+                _insertValidator(addr, n);
                 continue;
             }
 
@@ -382,36 +376,38 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             if (_isGreater(
                     Validator({addr: addr, data: data}), Validator({addr: _roundValidatorsHead, data: headData})
                 )) {
-                _insertValidator(addr, top);
+                _insertValidator(addr, n);
             }
         }
 
-        // A round must consist of exactly `_minValidators` DISTINCT validators. With fewer
-        // eligible active validators, padding the round by repeating a validator across slots
-        // would orphan those slots: a validator only signs consensus messages under a single
-        // validatorIndex, so the duplicated slots never vote and the round cannot reach the
-        // +2/3 threshold. Fail loudly instead.
-        if (_roundValidatorsCount < _minValidators) {
-            revert InsufficientActiveValidators(_roundValidatorsCount, _minValidators);
+        // A round must consist of exactly `n` DISTINCT validators. With fewer eligible active
+        // validators (including none at all), padding the round by repeating a validator across
+        // slots would orphan those slots: a validator only signs consensus messages under a
+        // single validatorIndex, so the duplicated slots never vote and the round cannot reach
+        // the +2/3 threshold. Fail loudly instead.
+        if (_roundValidatorsCount < n) {
+            revert InsufficientActiveValidators(_roundValidatorsCount, n);
         }
 
+        // Materialize the sorted list so the slot order can be shuffled; the shuffled index
+        // becomes each validator's validatorIndex for the round. The count check above
+        // guarantees exactly `n` entries.
         address next = _roundValidatorsHead;
-        address[] memory tmpValidators = new address[](_roundValidatorsCount);
+        address[] memory shuffledValidators = new address[](n);
 
-        for (uint256 i = 0; i < _roundValidatorsCount; i++) {
-            tmpValidators[i] = next;
+        for (uint256 i = 0; i < n; i++) {
+            shuffledValidators[i] = next;
             next = _roundValidatorsMap[next];
         }
-        _shuffleMem(tmpValidators);
+        _shuffleMem(shuffledValidators);
 
-        // Fill round & _roundValidators with `_minValidators` distinct validators (guaranteed
-        // available by the check above) — no slot is ever duplicated.
+        // Fill round & _roundValidators with `n` distinct validators — no slot is ever duplicated.
         RoundValidator[] storage round = _rounds.push();
         delete _roundValidators;
-        _roundValidators = new address[](_minValidators);
+        _roundValidators = new address[](n);
 
-        for (uint256 i = 0; i < _minValidators; i++) {
-            address addr = tmpValidators[i];
+        for (uint256 i = 0; i < n; i++) {
+            address addr = shuffledValidators[i];
             _roundValidators[i] = addr;
             round.push(RoundValidator({addr: addr, voteBalance: _validatorsData[addr].voteBalance}));
         }

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -698,8 +698,8 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             _voters[voter.prev].next = address(0);
             _votersTail = voter.prev;
         } else if (_votersHead == msg.sender) {
-            _voters[_votersTail].prev = address(0);
-            _votersHead = _voters[_votersHead].next;
+            _voters[voter.next].prev = address(0);
+            _votersHead = voter.next;
         } else {
             _voters[voter.prev].next = voter.next;
             _voters[voter.next].prev = voter.prev;

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -80,6 +80,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
     error ValidatorAlreadyResigned();
     error BellowMinValidators();
     error NoActiveValidators();
+    error InsufficientActiveValidators(uint256 available, uint256 required);
 
     error BlsKeyAlreadyRegistered();
     error BlsKeyIsInvalid();
@@ -385,11 +386,15 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             }
         }
 
-        if (_roundValidatorsCount == 0) {
-            revert NoActiveValidators();
+        // A round must consist of exactly `_minValidators` DISTINCT validators. With fewer
+        // eligible active validators, padding the round by repeating a validator across slots
+        // would orphan those slots: a validator only signs consensus messages under a single
+        // validatorIndex, so the duplicated slots never vote and the round cannot reach the
+        // +2/3 threshold. Fail loudly instead.
+        if (_roundValidatorsCount < _minValidators) {
+            revert InsufficientActiveValidators(_roundValidatorsCount, _minValidators);
         }
 
-        // Prepare temp array. Used when _roundValidatorsCount < _minValidators
         address next = _roundValidatorsHead;
         address[] memory tmpValidators = new address[](_roundValidatorsCount);
 
@@ -399,13 +404,14 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         }
         _shuffleMem(tmpValidators);
 
-        // Fill round & _roundValidators
+        // Fill round & _roundValidators with `_minValidators` distinct validators (guaranteed
+        // available by the check above) — no slot is ever duplicated.
         RoundValidator[] storage round = _rounds.push();
         delete _roundValidators;
         _roundValidators = new address[](_minValidators);
 
         for (uint256 i = 0; i < _minValidators; i++) {
-            address addr = tmpValidators[i % _roundValidatorsCount];
+            address addr = tmpValidators[i];
             _roundValidators[i] = addr;
             round.push(RoundValidator({addr: addr, voteBalance: _validatorsData[addr].voteBalance}));
         }

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -50,46 +50,62 @@ contract ConsensusTest is Base {
         consensus.calculateRoundValidators(1);
     }
 
-    function test_should_ignore_resigned_validators() public {
+    function test_should_revert_with_insufficient_active_validators() public {
+        registerValidator(address(1));
+        registerValidator(address(2));
+
+        consensus.calculateRoundValidators(2);
+        assertEq(consensus.getRoundsCount(), 1);
+
+        // Requesting more round slots than there are active validators must revert with the
+        // exact available/required counts instead of padding slots with duplicates. The revert
+        // is atomic: no new round is pushed and the previous round validators remain intact.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 2, 3));
+        consensus.calculateRoundValidators(3);
+
+        assertEq(consensus.getRoundsCount(), 1);
+        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
+        assertEq(validators.length, 2);
+        assertTrue(validators[0].addr != validators[1].addr);
+    }
+
+    function test_should_not_count_resigned_validator_toward_round() public {
         address addr = address(1);
 
         registerValidator(addr);
         registerValidator(address(2));
         resignValidator(addr);
 
+        // The resigned validator is not eligible, so only 1 of the 2 requested slots can be
+        // filled with a distinct validator.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));
         consensus.calculateRoundValidators(2);
-        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
-        assertEq(validators.length, 2);
-        assertEq(validators[0].addr, address(2));
-        assertEq(validators[1].addr, address(2)); // Second validator is duplicated
     }
 
-    // Inverted order
-    function test_should_ignore_resigned_validators_2() public {
-        address addr = address(1);
-
-        registerValidator(addr);
-        registerValidator(address(2));
-        resignValidator(address(2));
-
-        consensus.calculateRoundValidators(2);
-        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
-        assertEq(validators.length, 2);
-        assertEq(validators[0].addr, addr);
-        assertEq(validators[1].addr, addr); // Second validator is duplicated
-    }
-
-    function test_should_ignore_validators_without_bls_public_key() public {
+    function test_should_not_count_validator_without_bls_public_key_toward_round() public {
         address addr = address(1);
 
         registerValidator(addr);
         consensus.addValidator(address(2), new bytes(0), false);
 
+        // address(2) has no BLS key, so it is not eligible; only one eligible validator remains.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));
+        consensus.calculateRoundValidators(2);
+    }
+
+    function test_should_exclude_resigned_validator_and_form_distinct_round() public {
+        registerValidator(address(1));
+        registerValidator(address(2));
+        registerValidator(address(3));
+        resignValidator(address(2));
+
+        // Two eligible validators remain (1 and 3); the round is formed from DISTINCT validators,
+        // excluding the resigned one and never duplicating a slot.
         consensus.calculateRoundValidators(2);
         ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
         assertEq(validators.length, 2);
-        assertEq(validators[0].addr, addr);
-        assertEq(validators[1].addr, addr); // Second validator is duplicated
+        assertTrue(validators[0].addr != validators[1].addr); // no duplicate slot
+        assertTrue(validators[0].addr != address(2) && validators[1].addr != address(2)); // resigned excluded
     }
 
     function test_consensus_sortedValidators_sameVoteCounts() public {

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -32,21 +32,21 @@ contract ConsensusTest is Base {
     }
 
     function test_should_revert_without_validators() public {
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 
     function test_should_revert_with_only_resigned_validators() public {
         consensus.addValidator(address(2), prepareBLSKey(address(2)), true);
 
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 
     function test_should_revert_with_only_validators_without_public_key() public {
         consensus.addValidator(address(1), new bytes(0), false);
 
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 

--- a/contracts/test/consensus/Consensus-ValidatorResignation.sol
+++ b/contracts/test/consensus/Consensus-ValidatorResignation.sol
@@ -208,16 +208,12 @@ contract ConsensusTest is Base {
 
         assertEq(consensus.validatorsCount(), 3);
 
-        // Act - higher value
+        // Act - value higher than the active validator count must revert (no duplicate-slot padding).
+        // _minValidators is left unchanged because the whole call reverts.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 3, 5));
         consensus.calculateRoundValidators(5);
 
-        // Test
-        vm.startPrank(addr);
-        vm.expectRevert(ConsensusV1.BellowMinValidators.selector);
-        consensus.resignValidator();
-        vm.stopPrank();
-
-        // Act - same value
+        // Act - same value as the active count sets _minValidators = 3
         consensus.calculateRoundValidators(3);
 
         // Test

--- a/contracts/test/consensus/Consensus-Vote.sol
+++ b/contracts/test/consensus/Consensus-Vote.sol
@@ -413,6 +413,60 @@ contract ConsensusTest is Base {
         assertEq(allVoters.length, 0);
     }
 
+    function test_unvote_head_with_multiple_remaining() public {
+        // removing the voter-list HEAD while >=2 voters remain must keep the list consistent.
+        registerValidator(address(1));
+        registerValidator(address(2));
+        registerValidator(address(3));
+
+        address voterA = address(11); // head
+        address voterB = address(12);
+        address voterC = address(13); // tail
+        vm.deal(voterA, 100 ether);
+        vm.deal(voterB, 100 ether);
+        vm.deal(voterC, 100 ether);
+
+        vm.prank(voterA);
+        consensus.vote(address(1));
+        vm.prank(voterB);
+        consensus.vote(address(2));
+        vm.prank(voterC);
+        consensus.vote(address(3));
+
+        assertEq(consensus.getVotesCount(), 3);
+
+        // Unvote the HEAD while B and C remain.
+        vm.prank(voterA);
+        consensus.unvote();
+
+        assertEq(consensus.getVotesCount(), 2);
+        ConsensusV1.VoteResult[] memory voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 2);
+        assertEq(voters[0].voter, voterB);
+        assertEq(voters[1].voter, voterC);
+
+        // Unvote the TAIL next.
+        vm.prank(voterC);
+        consensus.unvote();
+
+        assertEq(consensus.getVotesCount(), 1);
+        voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 1);
+        assertEq(voters[0].voter, voterB);
+
+        // A subsequent vote must remain reachable from the head.
+        address voterD = address(14);
+        vm.deal(voterD, 100 ether);
+        vm.prank(voterD);
+        consensus.vote(address(1));
+
+        assertEq(consensus.getVotesCount(), 2);
+        voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 2);
+        assertEq(voters[0].voter, voterB);
+        assertEq(voters[1].voter, voterD);
+    }
+
     function test_multiple_voted_different_validators() public {
         // Assert voters
         assertEq(consensus.getVotesCount(), 0);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

When there weren't enough active validators to fill a round, the contract quietly filled the remaining slots by repeating validators that were already in it. Those repeated slots can never actually vote: every vote is tied to a single `validatorIndex`, and a validator only ever signs under one index, so its other slots just stay silent. 

Depending on how many validators were missing, the chain would either get stuck forever without any error, or keep running in a broken state where some rounds always time out and a vote could be replayed under a duplicate slot to count twice.

`calculateRoundValidators` now fails with `InsufficientActiveValidators` instead, so a misconfigured network stops immediately with a clear error rather than starting up broken.


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
