### PR TITLE
refactor(consensus): remove bls keys from validator import

### DIFF
--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -79,7 +79,6 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
     error ValidatorAlreadyRegistered();
     error ValidatorAlreadyResigned();
     error BellowMinValidators();
-    error NoActiveValidators();
     error InsufficientActiveValidators(uint256 available, uint256 required);
 
     error BlsKeyAlreadyRegistered();
@@ -351,11 +350,6 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         _deleteRoundValidators();
 
         _roundValidatorsHead = address(0);
-        uint8 top = uint8(_clamp(n, 0, _activeValidators.length));
-
-        if (top == 0) {
-            revert NoActiveValidators();
-        }
 
         for (uint256 i = 0; i < _activeValidators.length; i++) {
             address addr = _activeValidators[i];
@@ -372,8 +366,8 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
                 continue;
             }
 
-            if (_roundValidatorsCount < top) {
-                _insertValidator(addr, top);
+            if (_roundValidatorsCount < n) {
+                _insertValidator(addr, n);
                 continue;
             }
 
@@ -382,36 +376,38 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             if (_isGreater(
                     Validator({addr: addr, data: data}), Validator({addr: _roundValidatorsHead, data: headData})
                 )) {
-                _insertValidator(addr, top);
+                _insertValidator(addr, n);
             }
         }
 
-        // A round must consist of exactly `_minValidators` DISTINCT validators. With fewer
-        // eligible active validators, padding the round by repeating a validator across slots
-        // would orphan those slots: a validator only signs consensus messages under a single
-        // validatorIndex, so the duplicated slots never vote and the round cannot reach the
-        // +2/3 threshold. Fail loudly instead.
-        if (_roundValidatorsCount < _minValidators) {
-            revert InsufficientActiveValidators(_roundValidatorsCount, _minValidators);
+        // A round must consist of exactly `n` DISTINCT validators. With fewer eligible active
+        // validators (including none at all), padding the round by repeating a validator across
+        // slots would orphan those slots: a validator only signs consensus messages under a
+        // single validatorIndex, so the duplicated slots never vote and the round cannot reach
+        // the +2/3 threshold. Fail loudly instead.
+        if (_roundValidatorsCount < n) {
+            revert InsufficientActiveValidators(_roundValidatorsCount, n);
         }
 
+        // Materialize the sorted list so the slot order can be shuffled; the shuffled index
+        // becomes each validator's validatorIndex for the round. The count check above
+        // guarantees exactly `n` entries.
         address next = _roundValidatorsHead;
-        address[] memory tmpValidators = new address[](_roundValidatorsCount);
+        address[] memory shuffledValidators = new address[](n);
 
-        for (uint256 i = 0; i < _roundValidatorsCount; i++) {
-            tmpValidators[i] = next;
+        for (uint256 i = 0; i < n; i++) {
+            shuffledValidators[i] = next;
             next = _roundValidatorsMap[next];
         }
-        _shuffleMem(tmpValidators);
+        _shuffleMem(shuffledValidators);
 
-        // Fill round & _roundValidators with `_minValidators` distinct validators (guaranteed
-        // available by the check above) — no slot is ever duplicated.
+        // Fill round & _roundValidators with `n` distinct validators — no slot is ever duplicated.
         RoundValidator[] storage round = _rounds.push();
         delete _roundValidators;
-        _roundValidators = new address[](_minValidators);
+        _roundValidators = new address[](n);
 
-        for (uint256 i = 0; i < _minValidators; i++) {
-            address addr = tmpValidators[i];
+        for (uint256 i = 0; i < n; i++) {
+            address addr = shuffledValidators[i];
             _roundValidators[i] = addr;
             round.push(RoundValidator({addr: addr, voteBalance: _validatorsData[addr].voteBalance}));
         }

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -698,8 +698,8 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             _voters[voter.prev].next = address(0);
             _votersTail = voter.prev;
         } else if (_votersHead == msg.sender) {
-            _voters[_votersTail].prev = address(0);
-            _votersHead = _voters[_votersHead].next;
+            _voters[voter.next].prev = address(0);
+            _votersHead = voter.next;
         } else {
             _voters[voter.prev].next = voter.next;
             _voters[voter.next].prev = voter.prev;

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -80,6 +80,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
     error ValidatorAlreadyResigned();
     error BellowMinValidators();
     error NoActiveValidators();
+    error InsufficientActiveValidators(uint256 available, uint256 required);
 
     error BlsKeyAlreadyRegistered();
     error BlsKeyIsInvalid();
@@ -385,11 +386,15 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             }
         }
 
-        if (_roundValidatorsCount == 0) {
-            revert NoActiveValidators();
+        // A round must consist of exactly `_minValidators` DISTINCT validators. With fewer
+        // eligible active validators, padding the round by repeating a validator across slots
+        // would orphan those slots: a validator only signs consensus messages under a single
+        // validatorIndex, so the duplicated slots never vote and the round cannot reach the
+        // +2/3 threshold. Fail loudly instead.
+        if (_roundValidatorsCount < _minValidators) {
+            revert InsufficientActiveValidators(_roundValidatorsCount, _minValidators);
         }
 
-        // Prepare temp array. Used when _roundValidatorsCount < _minValidators
         address next = _roundValidatorsHead;
         address[] memory tmpValidators = new address[](_roundValidatorsCount);
 
@@ -399,13 +404,14 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         }
         _shuffleMem(tmpValidators);
 
-        // Fill round & _roundValidators
+        // Fill round & _roundValidators with `_minValidators` distinct validators (guaranteed
+        // available by the check above) — no slot is ever duplicated.
         RoundValidator[] storage round = _rounds.push();
         delete _roundValidators;
         _roundValidators = new address[](_minValidators);
 
         for (uint256 i = 0; i < _minValidators; i++) {
-            address addr = tmpValidators[i % _roundValidatorsCount];
+            address addr = tmpValidators[i];
             _roundValidators[i] = addr;
             round.push(RoundValidator({addr: addr, voteBalance: _validatorsData[addr].voteBalance}));
         }

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -137,8 +137,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
         emit FeeUpdated(registrationFee);
     }
 
-    // TODO: import validator without bls public key
-    function addValidator(address addr, bytes calldata blsPublicKey, bool isResigned) external onlyOwner {
+    function addValidator(address addr, bool isResigned) external onlyOwner {
         if (_rounds.length > 0) {
             revert ImportIsNotAllowed();
         }
@@ -147,17 +146,8 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             revert ValidatorAlreadyRegistered();
         }
 
-        if (_blsPublicKeys[keccak256(blsPublicKey)]) {
-            revert BlsKeyAlreadyRegistered();
-        }
-
-        // Allow empty blsPublicKey for imports
-        if (blsPublicKey.length != 0) {
-            _verifyAndRegisterBlsPublicKey(blsPublicKey);
-        }
-
         ValidatorData memory validator =
-            ValidatorData({votersCount: 0, voteBalance: 0, fee: 0, isResigned: isResigned, blsPublicKey: blsPublicKey});
+            ValidatorData({votersCount: 0, voteBalance: 0, fee: 0, isResigned: isResigned, blsPublicKey: ""});
 
         _hasValidator[addr] = true;
         _validatorsData[addr] = validator;
@@ -167,11 +157,7 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
             _resignedValidatorsCount++;
         }
 
-        if (_canBecomeActiveValidator(addr)) {
-            _addActiveValidator(addr);
-        }
-
-        emit ValidatorRegistered(addr, blsPublicKey);
+        emit ValidatorRegistered(addr, "");
     }
 
     function addVotes(address[] calldata voters, address[] calldata validators) external onlyOwner {

--- a/contracts/src/consensus/ConsensusV1.sol
+++ b/contracts/src/consensus/ConsensusV1.sol
@@ -129,6 +129,10 @@ contract ConsensusV1 is UUPSUpgradeable, OwnableUpgradeable {
 
     // External functions
     function setFee(uint128 registrationFee) external onlyOwner {
+        if (_fee == registrationFee) {
+            return;
+        }
+
         _fee = registrationFee;
         emit FeeUpdated(registrationFee);
     }

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -86,7 +86,7 @@ contract ConsensusTest is Base {
         address addr = address(1);
 
         registerValidator(addr);
-        consensus.addValidator(address(2), new bytes(0), false);
+        consensus.addValidator(address(2), false);
 
         // address(2) has no BLS key, so it is not eligible; only one eligible validator remains.
         vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -50,46 +50,62 @@ contract ConsensusTest is Base {
         consensus.calculateRoundValidators(1);
     }
 
-    function test_should_ignore_resigned_validators() public {
+    function test_should_revert_with_insufficient_active_validators() public {
+        registerValidator(address(1));
+        registerValidator(address(2));
+
+        consensus.calculateRoundValidators(2);
+        assertEq(consensus.getRoundsCount(), 1);
+
+        // Requesting more round slots than there are active validators must revert with the
+        // exact available/required counts instead of padding slots with duplicates. The revert
+        // is atomic: no new round is pushed and the previous round validators remain intact.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 2, 3));
+        consensus.calculateRoundValidators(3);
+
+        assertEq(consensus.getRoundsCount(), 1);
+        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
+        assertEq(validators.length, 2);
+        assertTrue(validators[0].addr != validators[1].addr);
+    }
+
+    function test_should_not_count_resigned_validator_toward_round() public {
         address addr = address(1);
 
         registerValidator(addr);
         registerValidator(address(2));
         resignValidator(addr);
 
+        // The resigned validator is not eligible, so only 1 of the 2 requested slots can be
+        // filled with a distinct validator.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));
         consensus.calculateRoundValidators(2);
-        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
-        assertEq(validators.length, 2);
-        assertEq(validators[0].addr, address(2));
-        assertEq(validators[1].addr, address(2)); // Second validator is duplicated
     }
 
-    // Inverted order
-    function test_should_ignore_resigned_validators_2() public {
-        address addr = address(1);
-
-        registerValidator(addr);
-        registerValidator(address(2));
-        resignValidator(address(2));
-
-        consensus.calculateRoundValidators(2);
-        ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
-        assertEq(validators.length, 2);
-        assertEq(validators[0].addr, addr);
-        assertEq(validators[1].addr, addr); // Second validator is duplicated
-    }
-
-    function test_should_ignore_validators_without_bls_public_key() public {
+    function test_should_not_count_validator_without_bls_public_key_toward_round() public {
         address addr = address(1);
 
         registerValidator(addr);
         consensus.addValidator(address(2), new bytes(0), false);
 
+        // address(2) has no BLS key, so it is not eligible; only one eligible validator remains.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));
+        consensus.calculateRoundValidators(2);
+    }
+
+    function test_should_exclude_resigned_validator_and_form_distinct_round() public {
+        registerValidator(address(1));
+        registerValidator(address(2));
+        registerValidator(address(3));
+        resignValidator(address(2));
+
+        // Two eligible validators remain (1 and 3); the round is formed from DISTINCT validators,
+        // excluding the resigned one and never duplicating a slot.
         consensus.calculateRoundValidators(2);
         ConsensusV1.Validator[] memory validators = consensus.getRoundValidators();
         assertEq(validators.length, 2);
-        assertEq(validators[0].addr, addr);
-        assertEq(validators[1].addr, addr); // Second validator is duplicated
+        assertTrue(validators[0].addr != validators[1].addr); // no duplicate slot
+        assertTrue(validators[0].addr != address(2) && validators[1].addr != address(2)); // resigned excluded
     }
 
     function test_consensus_sortedValidators_sameVoteCounts() public {

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -32,21 +32,21 @@ contract ConsensusTest is Base {
     }
 
     function test_should_revert_without_validators() public {
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 
     function test_should_revert_with_only_resigned_validators() public {
         consensus.addValidator(address(2), prepareBLSKey(address(2)), true);
 
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 
     function test_should_revert_with_only_validators_without_public_key() public {
         consensus.addValidator(address(1), new bytes(0), false);
 
-        vm.expectRevert(ConsensusV1.NoActiveValidators.selector);
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 

--- a/contracts/test/consensus/Consensus-CalculateTop.sol
+++ b/contracts/test/consensus/Consensus-CalculateTop.sol
@@ -37,14 +37,14 @@ contract ConsensusTest is Base {
     }
 
     function test_should_revert_with_only_resigned_validators() public {
-        consensus.addValidator(address(2), prepareBLSKey(address(2)), true);
+        consensus.addValidator(address(2), true);
 
         vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
     }
 
     function test_should_revert_with_only_validators_without_public_key() public {
-        consensus.addValidator(address(1), new bytes(0), false);
+        consensus.addValidator(address(1), false);
 
         vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 0, 1));
         consensus.calculateRoundValidators(1);
@@ -86,7 +86,7 @@ contract ConsensusTest is Base {
         address addr = address(1);
 
         registerValidator(addr);
-        consensus.addValidator(address(2), new bytes(0), false);
+        consensus.addValidator(address(2), false);
 
         // address(2) has no BLS key, so it is not eligible; only one eligible validator remains.
         vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 1, 2));

--- a/contracts/test/consensus/Consensus-Fee.sol
+++ b/contracts/test/consensus/Consensus-Fee.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {ConsensusV1} from "@contracts/consensus/ConsensusV1.sol";
 import {Base} from "./Base.sol";
+import {Vm} from "@forge-std/Vm.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
@@ -29,5 +30,53 @@ contract ConsensusTest is Base {
         consensus.setFee(newFee);
 
         assertEq(consensus.fee(), newFee);
+    }
+
+    function test_set_fee_same_value_is_noop() public {
+        uint128 newFee = 1000;
+
+        // Establish a non-zero fee.
+        vm.expectEmit(address(consensus));
+        emit ConsensusV1.FeeUpdated(newFee);
+        consensus.setFee(newFee);
+        assertEq(consensus.fee(), newFee);
+
+        // Setting the same value again changes nothing and emits no event.
+        vm.recordLogs();
+        consensus.setFee(newFee);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0);
+        assertEq(consensus.fee(), newFee);
+    }
+
+    function test_set_fee_same_as_default_is_noop() public {
+        // Default fee is 0; setting it to 0 again is a no-op (no event, no change).
+        assertEq(consensus.fee(), 0);
+
+        vm.recordLogs();
+        consensus.setFee(0);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0);
+        assertEq(consensus.fee(), 0);
+    }
+
+    function test_set_fee_still_updates_after_noop() public {
+        uint128 firstFee = 1000;
+        consensus.setFee(firstFee);
+
+        // A repeated value is skipped...
+        vm.recordLogs();
+        consensus.setFee(firstFee);
+        assertEq(vm.getRecordedLogs().length, 0);
+
+        // ...but a different value still updates and emits (guard is strictly equality).
+        uint128 secondFee = 2000;
+        vm.expectEmit(address(consensus));
+        emit ConsensusV1.FeeUpdated(secondFee);
+        consensus.setFee(secondFee);
+
+        assertEq(consensus.fee(), secondFee);
     }
 }

--- a/contracts/test/consensus/Consensus-ValidatoUpdate.sol
+++ b/contracts/test/consensus/Consensus-ValidatoUpdate.sol
@@ -31,7 +31,7 @@ contract ConsensusTest is Base {
         bytes memory pop = createValidPop();
 
         address addr = address(1);
-        consensus.addValidator(addr, "", false);
+        consensus.addValidator(addr, false);
         assertEq(consensus.validatorsCount(), 1);
         assertEq(consensus.activeValidatorsCount(), 0);
 

--- a/contracts/test/consensus/Consensus-ValidatorAdd.sol
+++ b/contracts/test/consensus/Consensus-ValidatorAdd.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import {ConsensusV1} from "@contracts/consensus/ConsensusV1.sol";
 import {Base} from "./Base.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract ConsensusTest is Base {
@@ -15,17 +14,19 @@ contract ConsensusTest is Base {
 
         // Act
         vm.expectEmit(address(consensus));
-        emit ConsensusV1.ValidatorRegistered(addr, prepareBLSKey(addr));
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        emit ConsensusV1.ValidatorRegistered(addr, new bytes(0));
+        consensus.addValidator(addr, false);
 
         // Assert
         assertEq(consensus.validatorsCount(), 1);
-        assertEq(consensus.activeValidatorsCount(), 1);
+        // Imported validators are dormant: registered but never active, because they
+        // carry no BLS public key. They only become active via updateValidator().
+        assertEq(consensus.activeValidatorsCount(), 0);
         assertEq(consensus.resignedValidatorsCount(), 0);
 
         ConsensusV1.Validator memory validator = consensus.getValidator(addr);
         assertEq(validator.addr, addr);
-        assertEq(validator.data.blsPublicKey, prepareBLSKey(addr));
+        assertEq(validator.data.blsPublicKey, new bytes(0));
         assertEq(validator.data.voteBalance, 0);
         assertEq(validator.data.votersCount, 0);
         assertEq(validator.data.fee, 0);
@@ -40,8 +41,8 @@ contract ConsensusTest is Base {
 
         // Act
         vm.expectEmit(address(consensus));
-        emit ConsensusV1.ValidatorRegistered(addr, prepareBLSKey(addr));
-        consensus.addValidator(addr, prepareBLSKey(addr), true);
+        emit ConsensusV1.ValidatorRegistered(addr, new bytes(0));
+        consensus.addValidator(addr, true);
 
         // Assert
         assertEq(consensus.validatorsCount(), 1);
@@ -49,81 +50,63 @@ contract ConsensusTest is Base {
         assertEq(consensus.resignedValidatorsCount(), 1);
         ConsensusV1.Validator memory validator = consensus.getValidator(addr);
         assertEq(validator.addr, addr);
-        assertEq(validator.data.blsPublicKey, prepareBLSKey(addr));
+        assertEq(validator.data.blsPublicKey, new bytes(0));
         assertEq(validator.data.voteBalance, 0);
         assertEq(validator.data.votersCount, 0);
         assertEq(validator.data.fee, 0);
         assertEq(validator.data.isResigned, true);
     }
 
-    function test_validator_add_pass_if_ble_key_is_zero() public {
-        assertEq(consensus.validatorsCount(), 0);
+    function test_validator_add_keeps_validators_dormant() public {
+        // No matter how many validators are imported, none enter the active set:
+        // the active set is only reachable via the PoP-verified registerValidator /
+        // updateValidator paths.
+        consensus.addValidator(address(1), false);
+        consensus.addValidator(address(2), true);
+        consensus.addValidator(address(3), false);
+
+        assertEq(consensus.validatorsCount(), 3);
         assertEq(consensus.activeValidatorsCount(), 0);
-        assertEq(consensus.resignedValidatorsCount(), 0);
-        address addr = address(1);
+        assertEq(consensus.resignedValidatorsCount(), 1);
 
-        // Act
-        vm.expectEmit(address(consensus));
-        emit ConsensusV1.ValidatorRegistered(addr, new bytes(0));
-        consensus.addValidator(addr, new bytes(0), false);
-
-        // Assert
-        assertEq(consensus.validatorsCount(), 1);
-        assertEq(consensus.activeValidatorsCount(), 0);
-        assertEq(consensus.resignedValidatorsCount(), 0);
-
-        ConsensusV1.Validator memory validator = consensus.getValidator(addr);
-        assertEq(validator.addr, addr);
-        assertEq(validator.data.blsPublicKey, new bytes(0));
-        assertEq(validator.data.voteBalance, 0);
-        assertEq(validator.data.votersCount, 0);
-        assertEq(validator.data.fee, 0);
-        assertEq(validator.data.isResigned, false);
+        assertEq(consensus.getValidator(address(1)).data.blsPublicKey, new bytes(0));
+        assertEq(consensus.getValidator(address(2)).data.blsPublicKey, new bytes(0));
+        assertEq(consensus.getValidator(address(3)).data.blsPublicKey, new bytes(0));
     }
 
     function test_validator_add_revert_if_caller_is_not_owner() public {
         address addr = address(1);
         vm.startPrank(addr);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, addr));
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        consensus.addValidator(addr, false);
+        vm.stopPrank();
     }
 
     function test_validator_add_revert_if_round_already_calculated() public {
-        address addr = address(1);
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        // An active validator is required for the round calculation to succeed, since
+        // imported (dormant) validators never enter the active set.
+        registerValidator(address(1));
 
         consensus.calculateRoundValidators(1);
 
         vm.expectRevert(ConsensusV1.ImportIsNotAllowed.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        consensus.addValidator(address(2), false);
     }
 
     function test_validator_add_revert_if_validator_is_already_registered() public {
         address addr = address(1);
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        consensus.addValidator(addr, false);
 
         vm.expectRevert(ConsensusV1.ValidatorAlreadyRegistered.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        consensus.addValidator(addr, false);
     }
 
-    function test_validator_registration_revert_if_bls_key_is_already_registered() public {
+    function test_validator_add_revert_if_validator_is_already_active() public {
+        // A validator that registered through the live path cannot be shadow-imported.
         address addr = address(1);
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        registerValidator(addr);
 
-        vm.expectRevert(ConsensusV1.BlsKeyAlreadyRegistered.selector);
-        consensus.addValidator(address(2), prepareBLSKey(addr), false);
-    }
-
-    function test_validator_registration_revert_if_bls_key_length_is_invalid() public {
-        address addr = address(1);
-
-        vm.expectRevert(ConsensusV1.BlsKeyIsInvalid.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr, 46), false);
-        vm.expectRevert(ConsensusV1.BlsKeyIsInvalid.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr, 47), false);
-        vm.expectRevert(ConsensusV1.BlsKeyIsInvalid.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr, 49), false);
-        vm.expectRevert(ConsensusV1.BlsKeyIsInvalid.selector);
-        consensus.addValidator(addr, prepareBLSKey(addr, 50), false);
+        vm.expectRevert(ConsensusV1.ValidatorAlreadyRegistered.selector);
+        consensus.addValidator(addr, false);
     }
 }

--- a/contracts/test/consensus/Consensus-ValidatorResignation.sol
+++ b/contracts/test/consensus/Consensus-ValidatorResignation.sol
@@ -208,16 +208,12 @@ contract ConsensusTest is Base {
 
         assertEq(consensus.validatorsCount(), 3);
 
-        // Act - higher value
+        // Act - value higher than the active validator count must revert (no duplicate-slot padding).
+        // _minValidators is left unchanged because the whole call reverts.
+        vm.expectRevert(abi.encodeWithSelector(ConsensusV1.InsufficientActiveValidators.selector, 3, 5));
         consensus.calculateRoundValidators(5);
 
-        // Test
-        vm.startPrank(addr);
-        vm.expectRevert(ConsensusV1.BellowMinValidators.selector);
-        consensus.resignValidator();
-        vm.stopPrank();
-
-        // Act - same value
+        // Act - same value as the active count sets _minValidators = 3
         consensus.calculateRoundValidators(3);
 
         // Test

--- a/contracts/test/consensus/Consensus-ValidatorResignation.sol
+++ b/contracts/test/consensus/Consensus-ValidatorResignation.sol
@@ -234,5 +234,6 @@ contract ConsensusTest is Base {
         vm.startPrank(address(2));
         vm.expectRevert(ConsensusV1.BellowMinValidators.selector);
         consensus.resignValidator();
+        vm.stopPrank();
     }
 }

--- a/contracts/test/consensus/Consensus-Vote.sol
+++ b/contracts/test/consensus/Consensus-Vote.sol
@@ -413,6 +413,60 @@ contract ConsensusTest is Base {
         assertEq(allVoters.length, 0);
     }
 
+    function test_unvote_head_with_multiple_remaining() public {
+        // removing the voter-list HEAD while >=2 voters remain must keep the list consistent.
+        registerValidator(address(1));
+        registerValidator(address(2));
+        registerValidator(address(3));
+
+        address voterA = address(11); // head
+        address voterB = address(12);
+        address voterC = address(13); // tail
+        vm.deal(voterA, 100 ether);
+        vm.deal(voterB, 100 ether);
+        vm.deal(voterC, 100 ether);
+
+        vm.prank(voterA);
+        consensus.vote(address(1));
+        vm.prank(voterB);
+        consensus.vote(address(2));
+        vm.prank(voterC);
+        consensus.vote(address(3));
+
+        assertEq(consensus.getVotesCount(), 3);
+
+        // Unvote the HEAD while B and C remain.
+        vm.prank(voterA);
+        consensus.unvote();
+
+        assertEq(consensus.getVotesCount(), 2);
+        ConsensusV1.VoteResult[] memory voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 2);
+        assertEq(voters[0].voter, voterB);
+        assertEq(voters[1].voter, voterC);
+
+        // Unvote the TAIL next.
+        vm.prank(voterC);
+        consensus.unvote();
+
+        assertEq(consensus.getVotesCount(), 1);
+        voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 1);
+        assertEq(voters[0].voter, voterB);
+
+        // A subsequent vote must remain reachable from the head.
+        address voterD = address(14);
+        vm.deal(voterD, 100 ether);
+        vm.prank(voterD);
+        consensus.vote(address(1));
+
+        assertEq(consensus.getVotesCount(), 2);
+        voters = consensus.getVotes(address(0), 10);
+        assertEq(voters.length, 2);
+        assertEq(voters[0].voter, voterB);
+        assertEq(voters[1].voter, voterD);
+    }
+
     function test_multiple_voted_different_validators() public {
         // Assert voters
         assertEq(consensus.getVotesCount(), 0);

--- a/contracts/test/consensus/Consensus-Vote.sol
+++ b/contracts/test/consensus/Consensus-Vote.sol
@@ -190,7 +190,7 @@ contract ConsensusTest is Base {
 
     function test_vote_prevent_for_validator_without_bls_key() public {
         address addr = address(1);
-        consensus.addValidator(addr, new bytes(0), false);
+        consensus.addValidator(addr, false);
 
         vm.startPrank(addr);
         vm.expectRevert(ConsensusV1.VoteValidatorWithoutBlsPublicKey.selector);

--- a/contracts/test/consensus/Consensus-VoteAdd.sol
+++ b/contracts/test/consensus/Consensus-VoteAdd.sol
@@ -56,7 +56,7 @@ contract ConsensusTest is Base {
 
         // Register validator
         address addr = address(1);
-        consensus.addValidator(addr, prepareBLSKey(addr), true);
+        consensus.addValidator(addr, true);
 
         // Prepare voter
         address voterAddr = address(2);
@@ -95,7 +95,7 @@ contract ConsensusTest is Base {
 
         // Register validator
         address addr = address(1);
-        consensus.addValidator(addr, new bytes(0), false);
+        consensus.addValidator(addr, false);
 
         // Prepare voter
         address voterAddr = address(2);
@@ -145,7 +145,7 @@ contract ConsensusTest is Base {
         address[] memory validators = new address[](1);
         validators[0] = addr;
 
-        consensus.addValidator(addr, prepareBLSKey(addr), false);
+        registerValidator(addr);
 
         consensus.calculateRoundValidators(1);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
`addValidator` no longer accepts a BLS key, imported validators are registered dormant and only enter the active set via the PoP-verified `updateValidator` path. `setFee` skips storage and event when unchanged.

Contract changes taken from #1379 

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
