### PR TITLE
fix(api-database): tolerate concurrent CREATE EXTENSION race during bootstrap

### DIFF
--- a/packages/api-database/source/index.ts
+++ b/packages/api-database/source/index.ts
@@ -4,5 +4,6 @@ export * as Models from "./models/index.js";
 export * as Repositories from "./repositories/index.js";
 export * as Search from "./search/index.js";
 export * from "./service-provider.js";
+export * from "./utils/create-extensions.js";
 export * as Pg from "pg";
 export * as TypeOrm from "typeorm";

--- a/packages/api-database/source/service-provider.ts
+++ b/packages/api-database/source/service-provider.ts
@@ -66,6 +66,7 @@ import {
 	makeWalletRepository,
 } from "./repositories/index.js";
 import { makeMultiPaymentRepository } from "./repositories/multi-payment-repository.js";
+import { createExtensions } from "./utils/create-extensions.js";
 import { SnakeNamingStrategy } from "./utils/snake-naming-strategy.js";
 
 @injectable()
@@ -127,8 +128,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
 			// Note: this only initializes the connection pool, etc. but does not run migrations.
 			// Migrations are handled during bootstrap elsewhere in the main process (see sync.ts)
 			await dataSource.initialize();
-			await dataSource.createQueryRunner().query("CREATE EXTENSION IF NOT EXISTS citext;");
-			await dataSource.createQueryRunner().query("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
+			await createExtensions(dataSource);
 
 			this.app.bind(Identifiers.DataSource).toConstantValue(dataSource);
 			this.app.bind(Identifiers.Migrations).to(Migrations).inSingletonScope();

--- a/packages/api-database/source/utils/create-extensions.test.ts
+++ b/packages/api-database/source/utils/create-extensions.test.ts
@@ -26,10 +26,7 @@ describe<{
 	it("should create all default extensions", async ({ queries }) => {
 		await createExtensions(makeDataSource(queries));
 
-		assert.equal(queries, [
-			"CREATE EXTENSION IF NOT EXISTS citext;",
-			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-		]);
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;", "CREATE EXTENSION IF NOT EXISTS pg_trgm;"]);
 	});
 
 	it("should create custom extensions", async ({ queries }) => {
@@ -43,28 +40,19 @@ describe<{
 			makeDataSource(queries, (sql) => (sql.includes("citext") ? makeError({ code: "23505" }) : undefined)),
 		);
 
-		assert.equal(queries, [
-			"CREATE EXTENSION IF NOT EXISTS citext;",
-			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-		]);
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;", "CREATE EXTENSION IF NOT EXISTS pg_trgm;"]);
 	});
 
 	it("should ignore a duplicate object error", async ({ queries }) => {
 		await createExtensions(makeDataSource(queries, () => makeError({ code: "42710" })));
 
-		assert.equal(queries, [
-			"CREATE EXTENSION IF NOT EXISTS citext;",
-			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-		]);
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;", "CREATE EXTENSION IF NOT EXISTS pg_trgm;"]);
 	});
 
 	it("should read the code from the wrapped driver error", async ({ queries }) => {
 		await createExtensions(makeDataSource(queries, () => makeError({ driverError: { code: "23505" } })));
 
-		assert.equal(queries, [
-			"CREATE EXTENSION IF NOT EXISTS citext;",
-			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-		]);
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;", "CREATE EXTENSION IF NOT EXISTS pg_trgm;"]);
 	});
 
 	it("should rethrow any other error", async ({ queries }) => {

--- a/packages/api-database/source/utils/create-extensions.test.ts
+++ b/packages/api-database/source/utils/create-extensions.test.ts
@@ -1,0 +1,84 @@
+import { describe } from "@mainsail/test-runner";
+
+import { createExtensions } from "./create-extensions";
+
+const makeError = (properties: Record<string, unknown>): Error => Object.assign(new Error("query failed"), properties);
+
+describe<{
+	queries: string[];
+}>("createExtensions", ({ it, beforeEach, assert }) => {
+	beforeEach((context) => {
+		context.queries = [];
+	});
+
+	const makeDataSource = (queries: string[], failWith?: (sql: string) => Error | undefined) =>
+		({
+			query: async (sql: string) => {
+				queries.push(sql);
+
+				const error = failWith?.(sql);
+				if (error) {
+					throw error;
+				}
+			},
+		}) as any;
+
+	it("should create all default extensions", async ({ queries }) => {
+		await createExtensions(makeDataSource(queries));
+
+		assert.equal(queries, [
+			"CREATE EXTENSION IF NOT EXISTS citext;",
+			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+		]);
+	});
+
+	it("should create custom extensions", async ({ queries }) => {
+		await createExtensions(makeDataSource(queries), ["uuid-ossp"]);
+
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS uuid-ossp;"]);
+	});
+
+	it("should ignore a unique violation from a concurrent creation and continue", async ({ queries }) => {
+		await createExtensions(
+			makeDataSource(queries, (sql) => (sql.includes("citext") ? makeError({ code: "23505" }) : undefined)),
+		);
+
+		assert.equal(queries, [
+			"CREATE EXTENSION IF NOT EXISTS citext;",
+			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+		]);
+	});
+
+	it("should ignore a duplicate object error", async ({ queries }) => {
+		await createExtensions(makeDataSource(queries, () => makeError({ code: "42710" })));
+
+		assert.equal(queries, [
+			"CREATE EXTENSION IF NOT EXISTS citext;",
+			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+		]);
+	});
+
+	it("should read the code from the wrapped driver error", async ({ queries }) => {
+		await createExtensions(makeDataSource(queries, () => makeError({ driverError: { code: "23505" } })));
+
+		assert.equal(queries, [
+			"CREATE EXTENSION IF NOT EXISTS citext;",
+			"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+		]);
+	});
+
+	it("should rethrow any other error", async ({ queries }) => {
+		await assert.rejects(
+			() => createExtensions(makeDataSource(queries, () => makeError({ code: "42501" }))),
+			"query failed",
+		);
+
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;"]);
+	});
+
+	it("should rethrow an error without a code", async ({ queries }) => {
+		await assert.rejects(() => createExtensions(makeDataSource(queries, () => new Error("connection lost"))));
+
+		assert.equal(queries, ["CREATE EXTENSION IF NOT EXISTS citext;"]);
+	});
+});

--- a/packages/api-database/source/utils/create-extensions.ts
+++ b/packages/api-database/source/utils/create-extensions.ts
@@ -1,0 +1,25 @@
+import type { DataSource } from "typeorm";
+
+// Postgres implements `CREATE EXTENSION IF NOT EXISTS` as a non-atomic check-then-insert,
+// so two processes bootstrapping the same database (e.g. a node with api-sync and the
+// standalone API server) can both pass the check and the loser fails with a duplicate-key
+// violation on `pg_extension_name_index`. The extension is installed either way, so those
+// two error codes are safe to swallow.
+const CONCURRENT_CREATION_CODES = new Set([
+	"23505", // unique_violation
+	"42710", // duplicate_object
+]);
+
+export const createExtensions = async (dataSource: DataSource, extensions = ["citext", "pg_trgm"]): Promise<void> => {
+	for (const extension of extensions) {
+		try {
+			await dataSource.query(`CREATE EXTENSION IF NOT EXISTS ${extension};`);
+		} catch (error) {
+			const { code, driverError } = error as { code?: string; driverError?: { code?: string } };
+
+			if (!CONCURRENT_CREATION_CODES.has(code ?? driverError?.code ?? "")) {
+				throw error;
+			}
+		}
+	}
+};

--- a/packages/api-sync/source/service.test.ts
+++ b/packages/api-sync/source/service.test.ts
@@ -147,7 +147,6 @@ describe<Ctx>("Sync", ({ it, beforeEach, assert, stub, spy, clock }) => {
 		};
 
 		context.dataSource = {
-			createQueryRunner: () => ({ query: async () => {} }),
 			query: async (sql: string) =>
 				sql.startsWith("select count(1)") ? context.queryResults.blocksCount : context.queryResults.maxHeight,
 			synchronize: async () => {},

--- a/packages/api-sync/source/service.ts
+++ b/packages/api-sync/source/service.ts
@@ -2,6 +2,7 @@ import type { Contracts } from "@mainsail/contracts";
 
 import {
 	Contracts as ApiDatabaseContracts,
+	createExtensions,
 	Identifiers as ApiDatabaseIdentifiers,
 	Models,
 	TypeOrm,
@@ -680,12 +681,7 @@ export class Sync implements Contracts.ApiSync.Service {
 
 		try {
 			await (this.dataSource as TypeOrm.DataSource).synchronize(true);
-			await (this.dataSource as TypeOrm.DataSource)
-				.createQueryRunner()
-				.query("CREATE EXTENSION IF NOT EXISTS citext;");
-			await (this.dataSource as TypeOrm.DataSource)
-				.createQueryRunner()
-				.query("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
+			await createExtensions(this.dataSource as TypeOrm.DataSource);
 		} catch (rawError) {
 			await this.app.terminate("failed to reset database", ensureError(rawError));
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

Can be occasionally seen during E2E consensus test runs:

<img width="2132" height="574" alt="image" src="https://github.com/user-attachments/assets/a427cabe-19e9-4324-b3ee-d92a062e49f8" />


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
