### PR TITLE
fix(evm): expose `block.timestamp` in unix seconds instead of milliseconds

### DIFF
--- a/packages/api-evm/source/resources/block.test.ts
+++ b/packages/api-evm/source/resources/block.test.ts
@@ -55,7 +55,7 @@ describe<{
 		assert.equal(result.size, "0x100");
 		assert.equal(result.gasLimit, "0x1c9c380");
 		assert.equal(result.gasUsed, "0x5208");
-		assert.equal(result.timestamp, "0x1000");
+		assert.equal(result.timestamp, "0x4");
 		assert.equal(result.transactions, [`0x${"a".repeat(64)}`, `0x${"b".repeat(64)}`]);
 		assert.equal(result.uncles, []);
 	});

--- a/packages/api-evm/source/resources/block.ts
+++ b/packages/api-evm/source/resources/block.ts
@@ -35,7 +35,7 @@ export class BlockResource {
 			size: `0x${block.payloadSize.toString(16)}`, // TODO: Add block header size
 			gasLimit: `0x${milestone.block.maxGasLimit.toString(16)}`,
 			gasUsed: `0x${block.gasUsed.toString(16)}`,
-			timestamp: `0x${block.timestamp.toString(16)}`,
+			timestamp: `0x${Math.floor(block.timestamp / 1000).toString(16)}`,
 			transactions: transactionObject
 				? await this.#transformTransactions(block)
 				: block.transactions.map((transaction) => `0x${transaction.hash}`),

--- a/packages/evm-service/source/instances/evm.test.ts
+++ b/packages/evm-service/source/instances/evm.test.ts
@@ -188,7 +188,7 @@ describe<{
 		// }
 
 		assert.equal(data.blockHeight, 1245n);
-		assert.equal(data.blockTimestamp, 123_456_789n);
+		assert.equal(data.blockTimestamp, 123_456n);
 		assert.equal(data.blockGasLimit, 12_000_000n);
 		assert.equal(data.blockCoinbase, validator.address);
 		assert.equal(data.blockDifficulty, 0n); // difficulty always 0

--- a/packages/evm/bindings/src/lib.rs
+++ b/packages/evm/bindings/src/lib.rs
@@ -1227,7 +1227,7 @@ impl EvmInner {
 
                 block_env.number = U256::from(block_ctx.commit_key.0);
                 block_env.beneficiary = block_ctx.validator_address;
-                block_env.timestamp = U256::from(block_ctx.timestamp);
+                block_env.timestamp = U256::from(block_ctx.timestamp / 1000);
                 block_env.gas_limit = block_ctx.gas_limit;
                 block_env.difficulty = U256::ZERO;
             })
@@ -1346,7 +1346,7 @@ impl EvmInner {
                 };
                 block_env.number = U256::from(block_ctx.commit_key.0);
                 block_env.beneficiary = block_ctx.validator_address;
-                block_env.timestamp = U256::from(block_ctx.timestamp);
+                block_env.timestamp = U256::from(block_ctx.timestamp / 1000);
                 block_env.gas_limit = block_ctx.gas_limit;
                 block_env.difficulty = U256::ZERO;
             })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
