### PR TITLE
test(functional): do not flush mempool in `getTransactions`

### DIFF
--- a/packages/test-transaction-builders/source/utilities.ts
+++ b/packages/test-transaction-builders/source/utilities.ts
@@ -180,42 +180,6 @@ export const waitBlock = async ({ app }: { app: Contracts.Kernel.Application }, 
 	}
 };
 
-export const getRandomFundedWallet = async (context: Context, amount?: bigint): Promise<Contracts.Crypto.KeyPair> => {
-	if (context.fundedWalletProvider) {
-		return context.fundedWalletProvider(context, amount);
-	}
-
-	const { app, wallets } = context;
-
-	//const seed = randomBytes(32).toString("hex");
-
-	const randomKeyPair = await app
-		.getTagged<Contracts.Crypto.KeyPairFactory>(Identifiers.Cryptography.Identity.KeyPair.Factory, "type", "wallet")
-		.fromMnemonic("ladder pet busy silver convince lens either observe gap program debate film");
-
-	const recipient = await app
-		.get<Contracts.Crypto.AddressFactory>(Identifiers.Cryptography.Identity.Address.Factory)
-		.fromPublicKey(randomKeyPair.publicKey);
-	amount = amount ?? BigInt("1000000000000000000");
-
-	const nonce = await getNonceByPublicKey(app, wallets[0].publicKey);
-
-	const fundTx = await (
-		await app
-			.resolve(TransactionBuilder)
-			.gasPrice(5)
-			.recipientAddress(recipient)
-			.value(amount.toString())
-			.nonce((nonce + 1n).toString())
-			.signWithKeyPair(wallets[0])
-	).build();
-
-	await addTransactionsToPool(context, [fundTx]);
-	await waitBlock({ app }, 2); // Await 2 blocks to ensure the transaction is confirmed
-
-	return randomKeyPair;
-};
-
 export const getRandomConsensusKeyPair = async ({ app }: Context): Promise<Contracts.Crypto.KeyPair> => {
 	const seed = Array.from({ length: 12 }).fill(Date.now().toString()).join(" ");
 

--- a/packages/test-transaction-builders/source/utilities.ts
+++ b/packages/test-transaction-builders/source/utilities.ts
@@ -1,7 +1,8 @@
 import type { Contracts } from "@mainsail/contracts";
+import type { TransactionBuilder } from "@mainsail/crypto-transaction";
 
 import { Identifiers } from "@mainsail/constants";
-import { TransactionBuilder, TransactionFactory, Verifier } from "@mainsail/crypto-transaction";
+import { TransactionFactory, Verifier } from "@mainsail/crypto-transaction";
 import { sleep } from "@mainsail/utils";
 import { randomBytes } from "crypto";
 

--- a/tests/functional/resync/source/pool-worker.ts
+++ b/tests/functional/resync/source/pool-worker.ts
@@ -5,45 +5,68 @@ import { inject, injectable } from "@mainsail/container";
 
 @injectable()
 export class PoolWorker implements Contracts.TransactionPool.Worker {
-	@inject(Identifiers.TransactionPool.Query)
-	private readonly poolQuery!: Contracts.TransactionPool.Query;
+	@inject(Identifiers.Cryptography.Configuration)
+	private readonly configuration!: Contracts.Crypto.Configuration;
+
+	@inject(Identifiers.TransactionPool.Selector)
+	private readonly selector!: Contracts.TransactionPool.Selector;
+
+	@inject(Identifiers.TransactionPool.Service)
+	private readonly transactionPoolService!: Contracts.TransactionPool.Service;
 
 	@inject(Identifiers.TransactionPool.Mempool)
 	private readonly transactionPoolMempool!: Contracts.TransactionPool.Mempool;
 
-	public async boot(flags: Contracts.TransactionPool.WorkerFlags): Promise<void> { }
+	public async boot(flags: Contracts.TransactionPool.WorkerFlags): Promise<void> {}
 
-	public async handle(): Promise<void> { }
+	public async handle(): Promise<void> {}
 
-	public async start(): Promise<void> { }
+	public async start(): Promise<void> {}
 
 	public async kill(): Promise<number> {
 		return 0;
 	}
 
 	public async dispose(): Promise<void> {}
+
 	public getQueueSize(): number {
 		return 0;
 	}
-	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {}
 
-	public async getTransactions(options: Contracts.TransactionPool.GetBatchOptions): Promise<Contracts.TransactionPool.GetBatchResult> {
-		const result =  {
-			remaining: 0,
-			transactions: (await this.poolQuery.getFromHighestPriority().all()).map((transaction) => transaction.toData()),
+	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
+		const block = unit.getBlock();
+
+		const sendersAddresses = new Set<string>();
+		for (const transaction of block.transactions) {
+			sendersAddresses.add(transaction.from);
 		}
 
-		this.transactionPoolMempool.flush();
-		return result;
+		const { blockTime } = this.configuration.getMilestone().timeouts;
+		const isSyncing = block.timestamp < Date.now() - blockTime * 3;
+
+		// Discard the batch snapshot so the next round re-reads the pool.
+		this.selector.clear();
+
+		if (this.configuration.isNewMilestone()) {
+			await this.transactionPoolService.reAddTransactions();
+		} else {
+			await this.transactionPoolService.commit([...sendersAddresses], block.gasUsed, isSyncing);
+		}
+	}
+
+	public async getTransactions(
+		options: Contracts.TransactionPool.GetBatchOptions,
+	): Promise<Contracts.TransactionPool.GetBatchResult> {
+		return this.selector.getBatch(options);
 	}
 
 	public async removeTransaction(address: string, hash: string): Promise<void> {
 		await this.transactionPoolMempool.removeTransaction(address, hash);
 	}
 
-	registerEventHandler(event: string, callback: Contracts.Kernel.IPC.EventCallback<any>): void { }
+	public registerEventHandler<T>(event: string, callback: Contracts.Kernel.IPC.EventCallback<T>): void {}
 
-	async setPeer(ip: string): Promise<void> { }
-	async forgetPeer(ip: string): Promise<void> { }
-	async reloadWebhooks(): Promise<void> { }
+	public async setPeer(ip: string): Promise<void> {}
+	public async forgetPeer(ip: string): Promise<void> {}
+	public async reloadWebhooks(): Promise<void> {}
 }

--- a/tests/functional/transaction-pool-api/source/pool-worker.ts
+++ b/tests/functional/transaction-pool-api/source/pool-worker.ts
@@ -5,8 +5,14 @@ import { inject, injectable } from "@mainsail/container";
 
 @injectable()
 export class PoolWorker implements Contracts.TransactionPool.Worker {
-	@inject(Identifiers.TransactionPool.Query)
-	private readonly poolQuery!: Contracts.TransactionPool.Query;
+	@inject(Identifiers.Cryptography.Configuration)
+	private readonly configuration!: Contracts.Crypto.Configuration;
+
+	@inject(Identifiers.TransactionPool.Selector)
+	private readonly selector!: Contracts.TransactionPool.Selector;
+
+	@inject(Identifiers.TransactionPool.Service)
+	private readonly transactionPoolService!: Contracts.TransactionPool.Service;
 
 	@inject(Identifiers.TransactionPool.Mempool)
 	private readonly transactionPoolMempool!: Contracts.TransactionPool.Mempool;
@@ -22,29 +28,45 @@ export class PoolWorker implements Contracts.TransactionPool.Worker {
 	}
 
 	public async dispose(): Promise<void> {}
+
 	public getQueueSize(): number {
 		return 0;
 	}
 
-	async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {}
+	public async onCommit(unit: Contracts.Processor.ProcessableUnit): Promise<void> {
+		const block = unit.getBlock();
 
-	public async getTransactions(options: Contracts.TransactionPool.GetBatchOptions): Promise<Contracts.TransactionPool.GetBatchResult> {
-		const result =  {
-			remaining: 0,
-			transactions: (await this.poolQuery.getFromHighestPriority().all()).map((transaction) => transaction.toData()),
+		const sendersAddresses = new Set<string>();
+		for (const transaction of block.transactions) {
+			sendersAddresses.add(transaction.from);
 		}
 
-		this.transactionPoolMempool.flush();
-		return result;
+		const { blockTime } = this.configuration.getMilestone().timeouts;
+		const isSyncing = block.timestamp < Date.now() - blockTime * 3;
+
+		// Discard the batch snapshot so the next round re-reads the pool.
+		this.selector.clear();
+
+		if (this.configuration.isNewMilestone()) {
+			await this.transactionPoolService.reAddTransactions();
+		} else {
+			await this.transactionPoolService.commit([...sendersAddresses], block.gasUsed, isSyncing);
+		}
+	}
+
+	public async getTransactions(
+		options: Contracts.TransactionPool.GetBatchOptions,
+	): Promise<Contracts.TransactionPool.GetBatchResult> {
+		return this.selector.getBatch(options);
 	}
 
 	public async removeTransaction(address: string, hash: string): Promise<void> {
 		await this.transactionPoolMempool.removeTransaction(address, hash);
 	}
 
-	registerEventHandler(event: string, callback: Contracts.Kernel.IPC.EventCallback<any>): void {}
+	public registerEventHandler<T>(event: string, callback: Contracts.Kernel.IPC.EventCallback<T>): void {}
 
-	async setPeer(ip: string): Promise<void> {}
-	async forgetPeer(ip: string): Promise<void> {}
-	async reloadWebhooks(): Promise<void> {}
+	public async setPeer(ip: string): Promise<void> {}
+	public async forgetPeer(ip: string): Promise<void> {}
+	public async reloadWebhooks(): Promise<void> {}
 }

--- a/tests/functional/transaction-pool-api/source/utilities.ts
+++ b/tests/functional/transaction-pool-api/source/utilities.ts
@@ -21,7 +21,9 @@ export const getRandomConsensusKeyPair = async ({
 }: {
 	app: Contracts.Kernel.Application;
 }): Promise<Contracts.Crypto.KeyPair> => {
-	const seed = Array.from({ length: 12 }).fill(Date.now().toString()).join(" ");
+	// Must not be time-derived: back-to-back calls would otherwise yield the same consensus
+	// key, so a test expecting two distinct validator keys would silently register the same one.
+	const seed = Array.from({ length: 12 }, () => randomBytes(4).toString("hex")).join(" ");
 
 	return app
 		.getTagged<Contracts.Crypto.KeyPairFactory>(

--- a/tests/functional/transaction-pool-api/source/utilities.ts
+++ b/tests/functional/transaction-pool-api/source/utilities.ts
@@ -1,7 +1,6 @@
 import type { Contracts } from "@mainsail/contracts";
 
 import { Identifiers } from "@mainsail/constants";
-import { EvmCalls, Utils } from "@mainsail/test-transaction-builders";
 import { assert } from "@mainsail/utils";
 import { randomBytes } from "crypto";
 
@@ -9,33 +8,6 @@ export const getAddressByPublicKey = async (app: Contracts.Kernel.Application, p
 	return app
 		.get<Contracts.Crypto.AddressFactory>(Identifiers.Cryptography.Identity.Address.Factory)
 		.fromPublicKey(publicKey);
-};
-
-export const getRandomFundedWallet = async (
-	context: { app: Contracts.Kernel.Application; wallets: Contracts.Crypto.KeyPair[] },
-	funder: Contracts.Crypto.KeyPair,
-	amount?: bigint,
-): Promise<Contracts.Crypto.KeyPair> => {
-	const { app } = context;
-
-	const seed = Date.now().toString();
-
-	const randomKeyPair = await app
-		.getTagged<Contracts.Crypto.KeyPairFactory>(Identifiers.Cryptography.Identity.KeyPair.Factory, "type", "wallet")
-		.fromMnemonic(seed);
-
-	const recipient = await app
-		.get<Contracts.Crypto.AddressFactory>(Identifiers.Cryptography.Identity.Address.Factory)
-		.fromPublicKey(randomKeyPair.publicKey);
-
-	amount = amount ?? 1000000000000000000n;
-
-	const fundTx = await EvmCalls.makeEvmCall(context, { recipient, sender: funder, value: amount });
-
-	await addTransactionsToPool(context, [fundTx]);
-	await Utils.waitBlock(context);
-
-	return randomKeyPair;
 };
 
 export const getRandomSignature = async (app: Contracts.Kernel.Application): Promise<string> => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

The mocked `PoolWorker` flushed the whole mempool from `getTransactions`, so any transaction added between the snapshot read and the flush was discarded without ever being proposed. `waitBlock` treats an empty pool as "swept", so it returned early and `isTransactionCommitted` failed in whichever test lost the race.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
