### PR TITLE
fix(p2p): block downloader fixes and test coverage

### DIFF
--- a/packages/p2p/source/downloader/block-downloader.test.ts
+++ b/packages/p2p/source/downloader/block-downloader.test.ts
@@ -226,6 +226,36 @@ describe<{
 		assert.false(downloader.isDownloading());
 	});
 
+	it("#tryToDownload - should download from an eligible peer", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks").returnValue(new Promise(() => {}));
+		stub(repository, "getPeers").returnValue([makePeer(3)]);
+
+		downloader.tryToDownload();
+
+		getBlocks.calledOnce();
+		assert.true(downloader.isDownloading());
+	});
+
+	it("#tryToDownload - should not spin when a peer is exactly one block ahead", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks");
+		// The peer's stored block (blockNumber - 1) equals ours: nothing to download.
+		stub(repository, "getPeers").returnValue([makePeer(1)]);
+
+		downloader.tryToDownload();
+
+		getBlocks.neverCalled();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#tryToDownload - should stop when the job cap is reached", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks").returnValue(new Promise(() => {}));
+		stub(repository, "getPeers").returnValue([makePeer(100_000)]);
+
+		downloader.tryToDownload();
+
+		getBlocks.calledTimes(10);
+	});
+
 	it("#download - should not ban when the short reply was near the payload limit", async ({ downloader }) => {
 		// 3 MiB of block data: adding another maxPayload (2 MiB) block could exceed the 5 MiB
 		// response limit, so the short reply is legitimate.

--- a/packages/p2p/source/downloader/block-downloader.test.ts
+++ b/packages/p2p/source/downloader/block-downloader.test.ts
@@ -1,0 +1,161 @@
+import { Enums, Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { sleep } from "@mainsail/utils";
+
+import { describe } from "@mainsail/test-runner";
+import { BlockDownloader } from "./block-downloader";
+
+describe<{
+	app: Application;
+	downloader: BlockDownloader;
+}>("BlockDownloader", ({ it, assert, beforeEach, stub }) => {
+	const communicator = { getBlocks: async () => ({ blocks: [] }) };
+	const repository = { getPeers: () => [] };
+	const peerDisposer = { banPeer: () => {} };
+	const configuration = { getMilestone: () => ({ block: { maxPayload: 2_097_152 } }) };
+	// One slice per batch: every batch fits into the round that starts at its first block.
+	const roundCalculator = { calculateRound: () => ({ maxValidators: 400, roundHeight: 1 }) };
+	const stateStore = { getBlockNumber: () => 0, getLastBlock: () => ({ hash: "hash0" }) };
+	const state = { resetLastMessageTime: () => {} };
+	const commitProcessor = {
+		hasValidSignature: async () => true,
+		process: async () => Enums.Consensus.ProcessorResult.Accepted,
+	};
+	// Blocks are one-byte buffers carrying their block number.
+	const commitFactory = {
+		fromBytes: async (buffer: Buffer) => ({ block: { hash: `hash${buffer[0]}`, number: buffer[0] } }),
+	};
+	const logger = { debug: () => {}, error: () => {}, info: () => {}, warning: () => {} };
+
+	const makePeer = (blockNumber: number, ip = "1.2.3.4") => ({ header: { blockNumber }, ip });
+	const makeBlock = (number: number, size = 1): Buffer => {
+		const buffer = Buffer.alloc(size);
+		buffer[0] = number;
+		return buffer;
+	};
+
+	beforeEach((context) => {
+		context.app = new Application();
+
+		context.app.bind(Identifiers.P2P.Peer.Communicator).toConstantValue(communicator);
+		context.app.bind(Identifiers.P2P.Peer.Repository).toConstantValue(repository);
+		context.app.bind(Identifiers.P2P.Peer.Disposer).toConstantValue(peerDisposer);
+		context.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(configuration);
+		context.app.bind(Identifiers.BlockchainUtils.RoundCalculator).toConstantValue(roundCalculator);
+		context.app.bind(Identifiers.State.Store).toConstantValue(stateStore);
+		context.app.bind(Identifiers.P2P.State).toConstantValue(state);
+		context.app.bind(Identifiers.Consensus.Processor.Commit).toConstantValue(commitProcessor);
+		context.app.bind(Identifiers.Cryptography.Commit.Factory).toConstantValue(commitFactory);
+		context.app.bind(Identifiers.Services.Log.Service).toConstantValue(logger);
+
+		context.downloader = context.app.resolve(BlockDownloader);
+	});
+
+	it("#download - should request the expected ranges", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks").returnValue(new Promise(() => {}));
+
+		// Stored blocks end at peer height - 1; the first job starts after our stored block (0).
+		const peer = makePeer(3);
+		downloader.download(peer);
+		getBlocks.calledWith(peer, { fromBlockNumber: 1, limit: 2 });
+
+		// The next job continues after the last requested block and is capped at 400 blocks.
+		const farAhead = makePeer(1000);
+		downloader.download(farAhead);
+		getBlocks.calledWith(farAhead, { fromBlockNumber: 3, limit: 400 });
+
+		assert.true(downloader.isDownloading());
+	});
+
+	it("#download - should not download when the peer has nothing new", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks");
+
+		downloader.download(makePeer(0));
+		downloader.download(makePeer(1));
+
+		getBlocks.neverCalled();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should not exceed the job cap", ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks").returnValue(new Promise(() => {}));
+
+		for (let index = 0; index < 12; index++) {
+			downloader.download(makePeer(100_000));
+		}
+
+		getBlocks.calledTimes(10);
+	});
+
+	it("#download - should process a successful batch and continue with the next job", async ({ downloader }) => {
+		const getBlocks = stub(communicator, "getBlocks")
+			.resolvedValueNth(0, { blocks: [makeBlock(1), makeBlock(2)] })
+			.resolvedValueNth(1, { blocks: [makeBlock(3)] });
+		const process = stub(commitProcessor, "process").resolvedValue(Enums.Consensus.ProcessorResult.Accepted);
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(makePeer(3));
+		downloader.download(makePeer(4));
+		assert.true(downloader.isDownloading());
+
+		await sleep(10);
+
+		process.calledTimes(3);
+		banPeer.neverCalled();
+		assert.false(downloader.isDownloading());
+		getBlocks.calledTimes(2);
+	});
+
+	it("#download - should ban the peer and replay with another peer when the request fails", async ({
+		downloader,
+	}) => {
+		let calls = 0;
+		const getBlocks = stub(communicator, "getBlocks").callsFake(() =>
+			++calls === 1 ? Promise.reject(new Error("boom")) : new Promise(() => {}),
+		);
+		const banPeer = stub(peerDisposer, "banPeer");
+		stub(repository, "getPeers").returnValue([makePeer(1000, "2.2.2.2")]);
+
+		downloader.download(makePeer(3));
+		await sleep(10);
+
+		banPeer.calledOnce();
+		getBlocks.calledTimes(2);
+		assert.true(downloader.isDownloading());
+	});
+
+	it("#download - should truncate the queue when no peer can serve the replay", async ({ downloader }) => {
+		stub(communicator, "getBlocks").rejectedValue(new Error("boom"));
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(makePeer(3));
+		await sleep(10);
+
+		banPeer.calledOnce();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should ban a peer that returns fewer blocks than requested", async ({ downloader }) => {
+		stub(communicator, "getBlocks").resolvedValue({ blocks: [makeBlock(1)] });
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(makePeer(3));
+		await sleep(10);
+
+		banPeer.calledOnce();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should not ban when the short reply was near the payload limit", async ({ downloader }) => {
+		// 3 MiB of block data: adding another maxPayload (2 MiB) block could exceed the 5 MiB
+		// response limit, so the short reply is legitimate.
+		stub(communicator, "getBlocks").resolvedValue({ blocks: [makeBlock(1, 3_145_728)] });
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(makePeer(3));
+		await sleep(10);
+
+		banPeer.neverCalled();
+		assert.false(downloader.isDownloading());
+	});
+});

--- a/packages/p2p/source/downloader/block-downloader.test.ts
+++ b/packages/p2p/source/downloader/block-downloader.test.ts
@@ -226,6 +226,65 @@ describe<{
 		assert.false(downloader.isDownloading());
 	});
 
+	it("#download - should cap the replay of the only queued job at the maximum batch size", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+		const replayPeer = makePeer(100_000, "2.2.2.2");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		// Job for blocks 1-400 (a full batch) fails; the replacement range must be measured
+		// from the job's start, not from the end of the failed job (which allowed 800).
+		downloader.download(makePeer(500));
+		rejecters[0](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(2);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 1, limit: 400 });
+	});
+
+	it("#download - should accept a replay peer that can serve the shrunken range", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+
+		// Job for blocks 1-400 fails after blocks up to 390 were applied meanwhile; a peer
+		// holding blocks up to 394 (short of the original range's end) can serve the rest.
+		downloader.download(makePeer(500));
+		stub(stateStore, "getBlockNumber").returnValue(390);
+		const replayPeer = makePeer(395, "3.3.3.3");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		rejecters[0](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(2);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 391, limit: 4 });
+		assert.true(downloader.isDownloading());
+	});
+
+	it("#download - should keep the exact range when replaying a job with successors", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+		const replayPeer = makePeer(100_000, "2.2.2.2");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		// Jobs for blocks 1-400 and 401-800; the second fails and must be replayed unchanged
+		// so the requested ranges stay contiguous.
+		downloader.download(makePeer(500));
+		downloader.download(makePeer(900));
+		rejecters[1](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(3);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 401, limit: 400 });
+		assert.true(downloader.isDownloading());
+	});
+
 	it("#tryToDownload - should download from an eligible peer", ({ downloader }) => {
 		const getBlocks = stub(communicator, "getBlocks").returnValue(new Promise(() => {}));
 		stub(repository, "getPeers").returnValue([makePeer(3)]);

--- a/packages/p2p/source/downloader/block-downloader.test.ts
+++ b/packages/p2p/source/downloader/block-downloader.test.ts
@@ -146,6 +146,86 @@ describe<{
 		assert.false(downloader.isDownloading());
 	});
 
+	it("#download - should skip already applied blocks instead of banning the peer", async ({ downloader }) => {
+		// Realistic signature check: a commit's proof signs over its predecessor's hash.
+		const hasValidSignature = stub(commitProcessor, "hasValidSignature").callsFake(
+			async (commit: any, previousBlockHash: string) => previousBlockHash === `hash${commit.block.number - 1}`,
+		);
+		const process = stub(commitProcessor, "process").resolvedValue(Enums.Consensus.ProcessorResult.Accepted);
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		let resolveBlocks: any;
+		stub(communicator, "getBlocks").returnValue(new Promise((resolve) => (resolveBlocks = resolve)));
+
+		// Job for blocks 1-3 while our stored block is 0.
+		downloader.download(makePeer(4));
+
+		// Consensus commits blocks 1 and 2 via live gossip while the download is in flight.
+		stub(stateStore, "getBlockNumber").returnValue(2);
+		stub(stateStore, "getLastBlock").returnValue({ hash: "hash2" });
+
+		resolveBlocks({ blocks: [makeBlock(1), makeBlock(2), makeBlock(3)] });
+		await sleep(10);
+
+		// Only block 3 is verified (against the store's block 2) and processed; no ban.
+		banPeer.neverCalled();
+		hasValidSignature.calledOnce();
+		process.calledOnce();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should skip exactly the applied block when the store advanced by one", async ({ downloader }) => {
+		const hasValidSignature = stub(commitProcessor, "hasValidSignature").callsFake(
+			async (commit: any, previousBlockHash: string) => previousBlockHash === `hash${commit.block.number - 1}`,
+		);
+		const process = stub(commitProcessor, "process").resolvedValue(Enums.Consensus.ProcessorResult.Accepted);
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		let resolveBlocks: any;
+		stub(communicator, "getBlocks").returnValue(new Promise((resolve) => (resolveBlocks = resolve)));
+
+		// Job for blocks 1-2 while our stored block is 0.
+		downloader.download(makePeer(3));
+
+		// The boundary case: exactly the first block of the job gets applied meanwhile.
+		stub(stateStore, "getBlockNumber").returnValue(1);
+		stub(stateStore, "getLastBlock").returnValue({ hash: "hash1" });
+
+		resolveBlocks({ blocks: [makeBlock(1), makeBlock(2)] });
+		await sleep(10);
+
+		// Block 1 is dropped, block 2 is verified against block 1 and processed; no ban.
+		banPeer.neverCalled();
+		hasValidSignature.calledOnce();
+		process.calledOnce();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should complete a job whose blocks were all applied meanwhile", async ({ downloader }) => {
+		const hasValidSignature = stub(commitProcessor, "hasValidSignature").callsFake(
+			async (commit: any, previousBlockHash: string) => previousBlockHash === `hash${commit.block.number - 1}`,
+		);
+		const process = stub(commitProcessor, "process");
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		let resolveBlocks: any;
+		stub(communicator, "getBlocks").returnValue(new Promise((resolve) => (resolveBlocks = resolve)));
+
+		// Job for blocks 1-2 while our stored block is 0.
+		downloader.download(makePeer(3));
+
+		stub(stateStore, "getBlockNumber").returnValue(2);
+		stub(stateStore, "getLastBlock").returnValue({ hash: "hash2" });
+
+		resolveBlocks({ blocks: [makeBlock(1), makeBlock(2)] });
+		await sleep(10);
+
+		banPeer.neverCalled();
+		hasValidSignature.neverCalled();
+		process.neverCalled();
+		assert.false(downloader.isDownloading());
+	});
+
 	it("#download - should not ban when the short reply was near the payload limit", async ({ downloader }) => {
 		// 3 MiB of block data: adding another maxPayload (2 MiB) block could exceed the 5 MiB
 		// response limit, so the short reply is legitimate.

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -136,6 +136,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		try {
 			const bytesForProcess = [...job.blocks];
+			number = this.#skipAppliedBlocks(bytesForProcess, number);
 
 			while (bytesForProcess.length > 0) {
 				const roundInfo = this.roundCalculator.calculateRound(number);
@@ -198,6 +199,23 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		this.#downloadJobs.shift();
 		this.#processNextJob();
+	}
+
+	// Drops leading blocks that are already applied (e.g. committed by live consensus while
+	// the job was in flight) and returns the first block number left to process. Verifying
+	// them against the store's last block would use the wrong predecessor hash and ban an
+	// honest peer.
+	#skipAppliedBlocks(bytesForProcess: Buffer[], fromBlockNumber: number): number {
+		const storedBlockNumber = this.stateStore.getBlockNumber();
+
+		if (fromBlockNumber > storedBlockNumber) {
+			return fromBlockNumber;
+		}
+
+		const skipCount = Math.min(bytesForProcess.length, storedBlockNumber - fromBlockNumber + 1);
+		bytesForProcess.splice(0, skipCount);
+
+		return fromBlockNumber + skipCount;
 	}
 
 	#processNextJob(): void {

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -60,10 +60,17 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 		let peers = this.repository.getPeers();
 
 		while (
-			(peers = peers.filter((peer) => peer.header.blockNumber > this.#getLastRequestedBlockNumber())) &&
+			(peers = peers.filter((peer) => peer.header.blockNumber - 1 > this.#getLastRequestedBlockNumber())) &&
 			peers.length > 0
 		) {
+			const jobCount = this.#downloadJobs.length;
+
 			this.download(getRandomPeer(peers));
+
+			// download() can decline (e.g. the job cap is reached); stop instead of spinning.
+			if (this.#downloadJobs.length === jobCount) {
+				return;
+			}
 		}
 	}
 

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -84,7 +84,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		const downloadJob: DownloadJob = {
 			blockNumberFrom: this.#getLastRequestedBlockNumber() + 1,
-			blockNumberTo: this.#calculateBlockNumberTo(peer),
+			blockNumberTo: this.#calculateBlockNumberTo(peer, this.#getLastRequestedBlockNumber()),
 			blocks: [],
 			peer,
 			peerBlockNumber: peer.header.blockNumber - 1,
@@ -274,11 +274,14 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 		}
 
 		const isFirstJob = index === 0;
+		const isSoleJob = this.#downloadJobs.length === 1;
 		const blockNumberFrom = isFirstJob ? this.stateStore.getBlockNumber() + 1 : job.blockNumberFrom;
 
-		const peers = this.repository
-			.getPeers()
-			.filter((peer) => peer.header.blockNumber > Math.max(blockNumberFrom, job.blockNumberTo));
+		// A sole job may shrink to whatever the new peer can serve; a job with successors must
+		// keep its exact range so the requested ranges stay contiguous.
+		const requiredBlockNumber = isSoleJob ? blockNumberFrom : Math.max(blockNumberFrom, job.blockNumberTo);
+
+		const peers = this.repository.getPeers().filter((peer) => peer.header.blockNumber > requiredBlockNumber);
 
 		if (peers.length === 0) {
 			// Remove higher jobs, because peer is no longer available
@@ -288,7 +291,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		const peer = getRandomPeer(peers);
 
-		const blockNumberTo = this.#downloadJobs.length === 1 ? this.#calculateBlockNumberTo(peer) : job.blockNumberTo;
+		const blockNumberTo = isSoleJob ? this.#calculateBlockNumberTo(peer, blockNumberFrom - 1) : job.blockNumberTo;
 
 		// Skip if blockNumberFrom is higher than blockNumberTo
 		if (isFirstJob && blockNumberFrom > blockNumberTo) {
@@ -310,10 +313,10 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 		void this.#downloadBlocksFromPeer(newJob);
 	}
 
-	#calculateBlockNumberTo(peer: Contracts.P2P.Peer): number {
+	#calculateBlockNumberTo(peer: Contracts.P2P.Peer, lastRequestedBlockNumber: number): number {
 		// Check that we don't exceed maxDownloadBlocks
-		return peer.header.blockNumber - this.#getLastRequestedBlockNumber() > constants.MAX_DOWNLOAD_BLOCKS
-			? this.#getLastRequestedBlockNumber() + constants.MAX_DOWNLOAD_BLOCKS
+		return peer.header.blockNumber - lastRequestedBlockNumber > constants.MAX_DOWNLOAD_BLOCKS
+			? lastRequestedBlockNumber + constants.MAX_DOWNLOAD_BLOCKS
 			: peer.header.blockNumber - 1; // Stored block number is always 1 less than the consensus block number
 	}
 }

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -15,7 +15,6 @@ enum JobStatus {
 
 type DownloadJob = {
 	peer: Contracts.P2P.Peer;
-	peerBlockNumber: number;
 	blockNumberFrom: number;
 	blockNumberTo: number;
 	blocks: Buffer[];
@@ -87,7 +86,6 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 			blockNumberTo: this.#calculateBlockNumberTo(peer, this.#getLastRequestedBlockNumber()),
 			blocks: [],
 			peer,
-			peerBlockNumber: peer.header.blockNumber - 1,
 			status: JobStatus.Downloading,
 		};
 
@@ -304,7 +302,6 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 			blockNumberTo,
 			blocks: [],
 			peer,
-			peerBlockNumber: peer.header.blockNumber - 1,
 			status: JobStatus.Downloading,
 		};
 

--- a/packages/p2p/source/downloader/message-downloader.test.ts
+++ b/packages/p2p/source/downloader/message-downloader.test.ts
@@ -1,0 +1,235 @@
+import { Enums, Events, Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { sleep } from "@mainsail/utils";
+
+import { describe } from "@mainsail/test-runner";
+import { MessageDownloader } from "./message-downloader";
+
+describe<{
+	app: Application;
+	downloader: MessageDownloader;
+	ourHeader: any;
+	peer: any;
+	appliedListener: { handle: (payload: { data: { number: number } }) => Promise<void> };
+}>("MessageDownloader", ({ it, assert, beforeEach, stub }) => {
+	const communicator = { getMessages: async () => ({ precommits: [], prevotes: [] }) };
+	const repository = { getPeers: () => [] };
+	const blockDownloader = { isDownloading: () => false };
+	const peerDisposer = { banPeer: () => {} };
+	const factory = { makeMessageFromBytes: async () => ({}) };
+	const messageProcessor = { process: async () => Enums.Consensus.ProcessorResult.Accepted };
+	const cryptoConfiguration = { getMilestone: () => ({ roundValidators: 2 }) };
+	const state = { resetLastMessageTime: () => {} };
+
+	beforeEach((context) => {
+		// Eligible for a partial download: peer is at our (blockNumber, round) and has
+		// prevotes and precommits (indexes 0 and 1) that we are missing.
+		context.ourHeader = {
+			blockNumber: 2,
+			getValidatorsSignedPrecommitCount: () => 0,
+			getValidatorsSignedPrevoteCount: () => 0,
+			round: 0,
+			validatorsSignedPrecommit: [false, false],
+			validatorsSignedPrevote: [false, false],
+		};
+		context.peer = {
+			header: {
+				blockNumber: 2,
+				round: 0,
+				validatorsSignedPrecommit: [true, true],
+				validatorsSignedPrevote: [true, true],
+			},
+			ip: "1.2.3.4",
+		};
+
+		context.app = new Application();
+
+		context.app.bind(Identifiers.P2P.Peer.Communicator).toConstantValue(communicator);
+		context.app.bind(Identifiers.P2P.Peer.Repository).toConstantValue(repository);
+		context.app.bind(Identifiers.P2P.Header.Factory).toConstantValue(() => context.ourHeader);
+		context.app.bind(Identifiers.P2P.Downloader.Block).toConstantValue(blockDownloader);
+		context.app.bind(Identifiers.P2P.Peer.Disposer).toConstantValue(peerDisposer);
+		context.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue(factory);
+		context.app.bind(Identifiers.Consensus.Processor.Message).toConstantValue(messageProcessor);
+		context.app.bind(Identifiers.Cryptography.Configuration).toConstantValue(cryptoConfiguration);
+		context.app.bind(Identifiers.P2P.State).toConstantValue(state);
+		context.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue({
+			listen: (event: string, listener: { handle: (payload: { data: { number: number } }) => Promise<void> }) => {
+				if (event === Events.BlockEvent.Applied) {
+					context.appliedListener = listener;
+				}
+			},
+		});
+
+		context.downloader = context.app.resolve(MessageDownloader);
+	});
+
+	it("#download - should release the downloads on an empty reply and allow them to be re-pulled", async ({
+		downloader,
+		peer,
+	}) => {
+		const getMessages = stub(communicator, "getMessages").resolvedValue({ precommits: [], prevotes: [] });
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(peer);
+		assert.true(downloader.isDownloading());
+
+		await sleep(10);
+
+		assert.false(downloader.isDownloading());
+		getMessages.calledOnce();
+		banPeer.neverCalled();
+
+		downloader.download(peer);
+		await sleep(10);
+
+		getMessages.calledTimes(2);
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should release the downloads after a successful download", async ({ downloader, peer }) => {
+		// The peer only has messages of validator 0, so the reply is complete.
+		peer.header.validatorsSignedPrevote = [true, false];
+		peer.header.validatorsSignedPrecommit = [true, false];
+
+		stub(communicator, "getMessages").resolvedValue({
+			precommits: [Buffer.alloc(1)],
+			prevotes: [Buffer.alloc(1)],
+		});
+		stub(factory, "makeMessageFromBytes").resolvedValueSequence([
+			{ blockNumber: 2, round: 0, validatorIndex: 0 },
+			{ blockNumber: 2, round: 0, validatorIndex: 0 },
+		]);
+		const process = stub(messageProcessor, "process").resolvedValue(Enums.Consensus.ProcessorResult.Accepted);
+		const resetLastMessageTime = stub(state, "resetLastMessageTime");
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(peer);
+		await sleep(10);
+
+		assert.false(downloader.isDownloading());
+		process.calledTimes(2);
+		resetLastMessageTime.calledOnce();
+		banPeer.neverCalled();
+	});
+
+	it("#download - should not download twice for the same messages while pending", ({ downloader, peer }) => {
+		const getMessages = stub(communicator, "getMessages").returnValue(new Promise(() => {}));
+
+		downloader.download(peer);
+		downloader.download(peer);
+
+		getMessages.calledOnce();
+	});
+
+	it("#download - should skip a peer that has nothing to serve", ({ downloader, ourHeader, peer }) => {
+		const getMessages = stub(communicator, "getMessages");
+
+		downloader.download({ ...peer, header: { ...peer.header, blockNumber: 3 } });
+		downloader.download({
+			...peer,
+			header: {
+				...peer.header,
+				validatorsSignedPrecommit: [false, false],
+				validatorsSignedPrevote: [false, false],
+			},
+		});
+
+		ourHeader.round = 1;
+		downloader.download(peer);
+
+		// No requests go out; `isDownloading()` is not asserted because the eligibility
+		// check itself pre-creates empty bitmap entries.
+		getMessages.neverCalled();
+	});
+
+	it("#download - should download a full round when the peer is ahead", async ({ downloader, peer }) => {
+		// Round 1 with a blocking minority (> 1/3) of prevotes: the full round is downloaded.
+		peer.header.round = 1;
+		peer.header.validatorsSignedPrevote = [true, false];
+
+		const getMessages = stub(communicator, "getMessages").resolvedValue({ precommits: [], prevotes: [] });
+
+		downloader.download(peer);
+		assert.true(downloader.isDownloading());
+		downloader.download(peer);
+
+		await sleep(10);
+
+		getMessages.calledOnce();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#download - should ban the peer when a message is for another block", async ({ downloader, peer }) => {
+		stub(communicator, "getMessages").resolvedValue({ precommits: [], prevotes: [Buffer.alloc(1)] });
+		stub(factory, "makeMessageFromBytes").resolvedValue({ blockNumber: 3, round: 0, validatorIndex: 0 });
+		const banPeer = stub(peerDisposer, "banPeer");
+
+		downloader.download(peer);
+		await sleep(10);
+
+		assert.false(downloader.isDownloading());
+		banPeer.calledOnce();
+	});
+
+	it("#download - should ban the peer and retry when a message is invalid", async ({ downloader, peer }) => {
+		stub(communicator, "getMessages").resolvedValue({ precommits: [], prevotes: [Buffer.alloc(1)] });
+		stub(factory, "makeMessageFromBytes").resolvedValue({ blockNumber: 2, round: 0, validatorIndex: 0 });
+		stub(messageProcessor, "process").resolvedValue(Enums.Consensus.ProcessorResult.Invalid);
+		const banPeer = stub(peerDisposer, "banPeer");
+		const getPeers = stub(repository, "getPeers").returnValue([]);
+
+		downloader.download(peer);
+		await sleep(10);
+
+		assert.false(downloader.isDownloading());
+		banPeer.calledOnce();
+		getPeers.calledOnce();
+	});
+
+	it("#tryToDownload - should download from an eligible peer", async ({ downloader, peer }) => {
+		const getMessages = stub(communicator, "getMessages").resolvedValue({ precommits: [], prevotes: [] });
+		stub(repository, "getPeers").returnValue([peer]);
+
+		downloader.tryToDownload();
+		assert.true(downloader.isDownloading());
+
+		await sleep(10);
+		getMessages.calledOnce();
+	});
+
+	it("#tryToDownload - should do nothing while the block downloader is downloading", ({ downloader, peer }) => {
+		const getMessages = stub(communicator, "getMessages");
+		stub(repository, "getPeers").returnValue([peer]);
+		stub(blockDownloader, "isDownloading").returnValue(true);
+
+		downloader.tryToDownload();
+		downloader.download(peer);
+
+		getMessages.neverCalled();
+		assert.false(downloader.isDownloading());
+	});
+
+	it("#initialize - should purge pending downloads for the applied block number", async ({
+		downloader,
+		peer,
+		appliedListener,
+	}) => {
+		// Two requests that never settle keep a partial and a full download pending.
+		stub(communicator, "getMessages").returnValue(new Promise(() => {}));
+
+		downloader.download(peer);
+		downloader.download({
+			...peer,
+			header: { ...peer.header, round: 1, validatorsSignedPrevote: [true, false] },
+		});
+		assert.true(downloader.isDownloading());
+
+		// An unrelated block number leaves the downloads alone; the applied one purges them.
+		await appliedListener.handle({ data: { number: 3 } });
+		assert.true(downloader.isDownloading());
+
+		await appliedListener.handle({ data: { number: 2 } });
+		assert.false(downloader.isDownloading());
+	});
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
- blocks that were already applied while a download was running are now skipped instead of getting the peer wrongly banned
- `tryToDownload` no longer loops forever when no new download can be started
- retrying the only remaining download now asks for the right amount of blocks and can use peers that only have part of them
- removed an unused field from download jobs


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
