### PR TITLE
fix(p2p): request the correct range when retrying a block download

### DIFF
--- a/packages/p2p/source/downloader/block-downloader.test.ts
+++ b/packages/p2p/source/downloader/block-downloader.test.ts
@@ -272,6 +272,65 @@ describe<{
 		assert.false(downloader.isDownloading());
 	});
 
+	it("#download - should cap the replay of the only queued job at the maximum batch size", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+		const replayPeer = makePeer(100_000, "2.2.2.2");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		// Job for blocks 1-400 (a full batch) fails; the replacement range must be measured
+		// from the job's start, not from the end of the failed job (which allowed 800).
+		downloader.download(makePeer(500));
+		rejecters[0](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(2);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 1, limit: 400 });
+	});
+
+	it("#download - should accept a replay peer that can serve the shrunken range", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+
+		// Job for blocks 1-400 fails after blocks up to 390 were applied meanwhile; a peer
+		// holding blocks up to 394 (short of the original range's end) can serve the rest.
+		downloader.download(makePeer(500));
+		stub(stateStore, "getBlockNumber").returnValue(390);
+		const replayPeer = makePeer(395, "3.3.3.3");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		rejecters[0](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(2);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 391, limit: 4 });
+		assert.true(downloader.isDownloading());
+	});
+
+	it("#download - should keep the exact range when replaying a job with successors", async ({ downloader }) => {
+		const rejecters: any[] = [];
+		const getBlocks = stub(communicator, "getBlocks").callsFake(
+			() => new Promise((_, reject) => rejecters.push(reject)),
+		);
+		const replayPeer = makePeer(100_000, "2.2.2.2");
+		stub(repository, "getPeers").returnValue([replayPeer]);
+
+		// Jobs for blocks 1-400 and 401-800; the second fails and must be replayed unchanged
+		// so the requested ranges stay contiguous.
+		downloader.download(makePeer(500));
+		downloader.download(makePeer(900));
+		rejecters[1](new Error("boom"));
+		await sleep(10);
+
+		getBlocks.calledTimes(3);
+		getBlocks.calledWith(replayPeer, { fromBlockNumber: 401, limit: 400 });
+		assert.true(downloader.isDownloading());
+	});
+
 	it("#download - should not ban when the short reply was near the payload limit", async ({ downloader }) => {
 		// 3 MiB of block data: adding another maxPayload (2 MiB) block could exceed the 5 MiB
 		// response limit, so the short reply is legitimate.

--- a/packages/p2p/source/downloader/block-downloader.ts
+++ b/packages/p2p/source/downloader/block-downloader.ts
@@ -65,7 +65,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		const downloadJob: DownloadJob = {
 			blockNumberFrom: this.#getLastRequestedBlockNumber() + 1,
-			blockNumberTo: this.#calculateBlockNumberTo(peer),
+			blockNumberTo: this.#calculateBlockNumberTo(peer, this.#getLastRequestedBlockNumber()),
 			blocks: [],
 			peer,
 			status: JobStatus.Downloading,
@@ -257,11 +257,14 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 		}
 
 		const isFirstJob = index === 0;
+		const isSoleJob = this.#downloadJobs.length === 1;
 		const blockNumberFrom = isFirstJob ? this.stateStore.getBlockNumber() + 1 : job.blockNumberFrom;
 
-		const peers = this.repository
-			.getPeers()
-			.filter((peer) => peer.header.blockNumber > Math.max(blockNumberFrom, job.blockNumberTo));
+		// A sole job may shrink to whatever the new peer can serve; a job with successors must
+		// keep its exact range so the requested ranges stay contiguous.
+		const requiredBlockNumber = isSoleJob ? blockNumberFrom : Math.max(blockNumberFrom, job.blockNumberTo);
+
+		const peers = this.repository.getPeers().filter((peer) => peer.header.blockNumber > requiredBlockNumber);
 
 		if (peers.length === 0) {
 			// Remove higher jobs, because peer is no longer available
@@ -271,7 +274,7 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 
 		const peer = getRandomPeer(peers);
 
-		const blockNumberTo = this.#downloadJobs.length === 1 ? this.#calculateBlockNumberTo(peer) : job.blockNumberTo;
+		const blockNumberTo = isSoleJob ? this.#calculateBlockNumberTo(peer, blockNumberFrom - 1) : job.blockNumberTo;
 
 		// Skip if blockNumberFrom is higher than blockNumberTo
 		if (isFirstJob && blockNumberFrom > blockNumberTo) {
@@ -292,10 +295,10 @@ export class BlockDownloader implements Contracts.P2P.Downloader {
 		void this.#downloadBlocksFromPeer(newJob);
 	}
 
-	#calculateBlockNumberTo(peer: Contracts.P2P.Peer): number {
+	#calculateBlockNumberTo(peer: Contracts.P2P.Peer, lastRequestedBlockNumber: number): number {
 		// Check that we don't exceed maxDownloadBlocks
-		return peer.header.blockNumber - this.#getLastRequestedBlockNumber() > constants.MAX_DOWNLOAD_BLOCKS
-			? this.#getLastRequestedBlockNumber() + constants.MAX_DOWNLOAD_BLOCKS
+		return peer.header.blockNumber - lastRequestedBlockNumber > constants.MAX_DOWNLOAD_BLOCKS
+			? lastRequestedBlockNumber + constants.MAX_DOWNLOAD_BLOCKS
 			: peer.header.blockNumber - 1; // Stored block number is always 1 less than the consensus block number
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
- Retrying the only queued batch calculated the new range from the failed job's end instead of its start, requesting up to double the batch cap
- Retries required the new peer to send the entire original range, rejecting peers that could serve the blocks still missing and stalling the download
- The only pending batch may now shrink to what's still needed

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
