### PR TITLE
fix(consensus): prevent double signing after a crash or restart

### DIFF
--- a/packages/consensus/package.json
+++ b/packages/consensus/package.json
@@ -23,6 +23,7 @@
 		"@mainsail/blockchain-utils": "workspace:*",
 		"@mainsail/constants": "workspace:*",
 		"@mainsail/container": "workspace:*",
+		"@mainsail/exceptions": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
 		"@mainsail/utils": "workspace:*",
 		"dayjs": "1.11.20"

--- a/packages/consensus/source/consensus.test.ts
+++ b/packages/consensus/source/consensus.test.ts
@@ -1,5 +1,6 @@
 import type { Contracts } from "@mainsail/contracts";
 import { Identifiers, Events, Enums } from "@mainsail/constants";
+import { DoubleSignError } from "@mainsail/exceptions";
 import { Lock } from "@mainsail/utils";
 
 import { Application } from "@mainsail/kernel";
@@ -90,6 +91,7 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 
 		context.logger = {
 			info: () => {},
+			warn: () => {},
 		};
 
 		context.eventDispatcher = {
@@ -401,6 +403,99 @@ describe<Context>("Consensus", ({ it, beforeEach, assert, stub, spy, clock, each
 		spyProposalProcess.calledWith(proposal);
 
 		assert.equal(consensus.getStep(), Enums.Consensus.Step.Propose);
+	});
+
+	it("#onTimeoutStartRound - should skip the proposal and continue when the double-sign guard refuses", async ({
+		consensus,
+		validatorsRepository,
+		roundStateRepository,
+		validatorSet,
+		proposalProcessor,
+		proposer,
+		logger,
+		forger,
+		block,
+	}) => {
+		const position = { blockNumber: 1, round: 0, step: Enums.Consensus.Step.Propose, value: "blockHash" };
+		const validator = {
+			propose: () => {},
+		};
+
+		stub(forger, "forgeBlock").resolvedValue(block);
+		stub(validator, "propose").rejectedValue(
+			new DoubleSignError("publicKey", { ...position, value: "conflictingHash" }, position),
+		);
+		stub(roundStateRepository, "getRoundState").returnValue({ hasProposal: () => false, proposer });
+		stub(validatorsRepository, "getValidator").returnValue(validator);
+		stub(validatorSet, "getValidatorIndexByWalletAddress").returnValue(1);
+
+		const spyProposalProcess = spy(proposalProcessor, "process");
+		const spyLoggerWarn = spy(logger, "warn");
+
+		await consensus.startRound(0);
+		await consensus.onTimeoutStartRound();
+
+		spyLoggerWarn.calledOnce();
+		spyProposalProcess.neverCalled();
+		assert.equal(consensus.getStep(), Enums.Consensus.Step.Propose);
+	});
+
+	it("#prevote - should skip the vote and continue when the double-sign guard refuses", async ({
+		consensus,
+		validatorSet,
+		validatorsRepository,
+		messageProcessor,
+		logger,
+		proposer,
+	}) => {
+		const position = { blockNumber: 1, round: 0, step: Enums.Consensus.Step.Prevote, value: "blockHash" };
+		const validator = {
+			prevote: () => {},
+		};
+
+		stub(validator, "prevote").rejectedValue(
+			new DoubleSignError("publicKey", { ...position, value: "conflictingHash" }, position),
+		);
+		stub(validatorSet, "getRoundValidators").returnValue([proposer]);
+		stub(validatorsRepository, "getValidator").returnValue(validator);
+		stub(validatorSet, "getValidatorIndexByWalletAddress").returnValue(1);
+
+		const spyMessageProcess = spy(messageProcessor, "process");
+		const spyLoggerWarn = spy(logger, "warn");
+
+		await consensus.prevote("blockHash");
+
+		spyMessageProcess.neverCalled();
+		spyLoggerWarn.calledOnce();
+	});
+
+	it("#precommit - should skip the vote and continue when the double-sign guard refuses", async ({
+		consensus,
+		validatorSet,
+		validatorsRepository,
+		messageProcessor,
+		logger,
+		proposer,
+	}) => {
+		const position = { blockNumber: 1, round: 0, step: Enums.Consensus.Step.Precommit, value: "blockHash" };
+		const validator = {
+			precommit: () => {},
+		};
+
+		stub(validator, "precommit").rejectedValue(
+			new DoubleSignError("publicKey", { ...position, value: "conflictingHash" }, position),
+		);
+		stub(validatorSet, "getRoundValidators").returnValue([proposer]);
+		stub(validatorsRepository, "getValidator").returnValue(validator);
+		stub(validatorSet, "getValidatorIndexByWalletAddress").returnValue(1);
+
+		const spyMessageProcess = spy(messageProcessor, "process");
+		const spyLoggerWarn = spy(logger, "warn");
+
+		await consensus.precommit("blockHash");
+
+		spyMessageProcess.neverCalled();
+		spyLoggerWarn.calledOnce();
 	});
 
 	it("#startRound - local validator should locked value", async () => {});

--- a/packages/consensus/source/consensus.ts
+++ b/packages/consensus/source/consensus.ts
@@ -2,6 +2,7 @@ import type { Contracts } from "@mainsail/contracts";
 
 import { Enums, Events, Identifiers, Locale } from "@mainsail/constants";
 import { inject, injectable } from "@mainsail/container";
+import { DoubleSignError } from "@mainsail/exceptions";
 import { assert, ensureError, Lock } from "@mainsail/utils";
 import dayjs from "dayjs";
 
@@ -75,7 +76,7 @@ export class Consensus implements Contracts.Consensus.Service {
 	#pendingJobs = new Set<Contracts.Consensus.RoundState>();
 
 	#proposedBlock?: Contracts.Crypto.Block;
-	#proposalPromise?: Promise<Contracts.Crypto.Proposal>;
+	#proposalPromise?: Promise<Contracts.Crypto.Proposal | undefined>;
 	#roundStartTime = 0;
 
 	// Handler lock is different than commit lock. It is used to prevent parallel processing and it is similar to queue.
@@ -244,11 +245,19 @@ export class Consensus implements Contracts.Consensus.Service {
 
 		if (this.#proposalPromise) {
 			const proposal = await this.#proposalPromise;
+			this.#proposalPromise = undefined;
+
+			if (proposal === undefined) {
+				// The double-sign guard refused to sign; the propose timeout scheduled above lets the
+				// round time out and the machinery continue to later rounds, where signing is allowed
+				// again once the round passes the recorded watermark.
+				return;
+			}
+
 			assert.defined(this.#proposedBlock);
 
 			this.logger.info(`Proposing block ${this.#getBlockString(this.#proposedBlock)}`, "consensus");
 
-			this.#proposalPromise = undefined;
 			this.#proposedBlock = undefined;
 			await this.proposalProcessor.process(proposal);
 		}
@@ -510,6 +519,22 @@ export class Consensus implements Contracts.Consensus.Service {
 	async #makeProposal(
 		roundState: Contracts.Consensus.RoundState,
 		registeredProposer: Contracts.Validator.Validator,
+	): Promise<Contracts.Crypto.Proposal | undefined> {
+		try {
+			return await this.#signProposal(roundState, registeredProposer);
+		} catch (error) {
+			if (error instanceof DoubleSignError) {
+				this.logger.warn(`Skipped proposal for ${this.#getHeightRoundString()}: ${error.message}`, "consensus");
+				return undefined;
+			}
+
+			throw error;
+		}
+	}
+
+	async #signProposal(
+		roundState: Contracts.Consensus.RoundState,
+		registeredProposer: Contracts.Validator.Validator,
 	): Promise<Contracts.Crypto.Proposal> {
 		if (this.#validValue) {
 			this.#proposedBlock = this.#validValue.getBlock();
@@ -559,7 +584,20 @@ export class Consensus implements Contracts.Consensus.Service {
 				continue;
 			}
 
-			const prevote = await localValidator.prevote(validatorIndex, this.#blockNumber, this.#round, value);
+			let prevote: Contracts.Crypto.Message;
+			try {
+				prevote = await localValidator.prevote(validatorIndex, this.#blockNumber, this.#round, value);
+			} catch (error) {
+				if (error instanceof DoubleSignError) {
+					this.logger.warn(
+						`Skipped prevote for ${this.#getHeightRoundString()}: ${error.message}`,
+						"consensus",
+					);
+					continue;
+				}
+
+				throw error;
+			}
 
 			void this.messageProcessor.process(prevote);
 		}
@@ -578,7 +616,20 @@ export class Consensus implements Contracts.Consensus.Service {
 				continue;
 			}
 
-			const precommit = await localValidator.precommit(validatorIndex, this.#blockNumber, this.#round, value);
+			let precommit: Contracts.Crypto.Message;
+			try {
+				precommit = await localValidator.precommit(validatorIndex, this.#blockNumber, this.#round, value);
+			} catch (error) {
+				if (error instanceof DoubleSignError) {
+					this.logger.warn(
+						`Skipped precommit for ${this.#getHeightRoundString()}: ${error.message}`,
+						"consensus",
+					);
+					continue;
+				}
+
+				throw error;
+			}
 
 			void this.messageProcessor.process(precommit);
 		}

--- a/packages/constants/source/identifiers.ts
+++ b/packages/constants/source/identifiers.ts
@@ -318,6 +318,7 @@ export const Identifiers = {
 		},
 	},
 	Validator: {
+		DoubleSignGuard: Symbol("Validator<DoubleSignGuard>"),
 		Repository: Symbol("Validator<Repository>"),
 	},
 	ValidatorSet: {

--- a/packages/contracts/source/contracts/validator.ts
+++ b/packages/contracts/source/contracts/validator.ts
@@ -1,3 +1,4 @@
+import type { Step } from "./consensus/enums.js";
 import type { AggregatedSignature, Block, KeyPair, Message, Proposal } from "./crypto/index.js";
 
 export interface ValidatorKeyPair {
@@ -32,4 +33,15 @@ export interface Validator {
 export interface ValidatorRepository {
 	getValidator(publicKey: string): Validator | undefined;
 	printLoadedValidators(): void;
+}
+
+export interface SigningPosition {
+	readonly blockNumber: number;
+	readonly round: number;
+	readonly step: Step;
+	readonly value?: string; // block hash being signed; undefined for a nil vote
+}
+
+export interface DoubleSignGuard {
+	guard(publicKey: string, position: SigningPosition): Promise<void>;
 }

--- a/packages/exceptions/source/consensus.ts
+++ b/packages/exceptions/source/consensus.ts
@@ -1,7 +1,21 @@
+import type { Contracts } from "@mainsail/contracts";
+
 import { Exception } from "./base.js";
 
 export class NotEnoughRoundValidatorsError extends Exception {
 	public constructor(actual: number, expected: number) {
 		super(`Expected ${expected} round validators, but got ${actual}`);
+	}
+}
+
+export class DoubleSignError extends Exception {
+	public constructor(
+		publicKey: string,
+		last: Contracts.Validator.SigningPosition,
+		next: Contracts.Validator.SigningPosition,
+	) {
+		super(
+			`Refusing to sign ${next.blockNumber}/${next.round}/${next.step} (${next.value || "nil"}) for ${publicKey}, because ${last.blockNumber}/${last.round}/${last.step} (${last.value || "nil"}) was already signed and signing again would double-sign`,
+		);
 	}
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -23,6 +23,7 @@
 		"@chainsafe/bls-keystore": "3.1.0",
 		"@mainsail/constants": "workspace:*",
 		"@mainsail/container": "workspace:*",
+		"@mainsail/exceptions": "workspace:*",
 		"@mainsail/kernel": "workspace:*",
 		"@mainsail/utils": "workspace:*"
 	},

--- a/packages/validator/source/double-sign-guard.test.ts
+++ b/packages/validator/source/double-sign-guard.test.ts
@@ -10,8 +10,8 @@ import { DoubleSignGuard } from "./double-sign-guard";
 
 const { Propose, Prevote, Precommit } = Enums.Consensus.Step;
 
-const KEY = "97a8...bls";
-const OTHER_KEY = "b12c...bls";
+const KEY = "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb";
+const OTHER_KEY = "a7e75af9dd4d868a41ad2f5a5b021d653e31084261724fb40ae2f1b1c31c778d3b9464502d599cf6720723ec5c68b59d";
 const A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 

--- a/packages/validator/source/double-sign-guard.test.ts
+++ b/packages/validator/source/double-sign-guard.test.ts
@@ -1,0 +1,141 @@
+import { Enums, Identifiers } from "@mainsail/constants";
+import { DoubleSignError } from "@mainsail/exceptions";
+import { Application } from "@mainsail/kernel";
+import { describe } from "@mainsail/test-runner";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { DoubleSignGuard } from "./double-sign-guard";
+
+const { Propose, Prevote, Precommit } = Enums.Consensus.Step;
+
+const KEY = "97a8...bls";
+const OTHER_KEY = "b12c...bls";
+const A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const at = (blockNumber: number, round: number, step: Enums.Consensus.Step, value = A) => ({
+	blockNumber,
+	round,
+	step,
+	value,
+});
+
+describe<{
+	dataDirectory: string;
+	stateFile: string;
+	guard: DoubleSignGuard;
+	// Resolves a fresh guard over the same data directory, as the service provider would after a restart.
+	resolveGuard: () => DoubleSignGuard;
+}>("DoubleSignGuard", ({ it, assert, beforeEach, afterEach }) => {
+	beforeEach((context) => {
+		context.dataDirectory = mkdtempSync(join(tmpdir(), "double-sign-guard-"));
+		context.stateFile = join(context.dataDirectory, "validator-state.json");
+
+		context.resolveGuard = () => {
+			const app = new Application();
+			app.bind("path.data").toConstantValue(context.dataDirectory);
+			app.bind(Identifiers.Services.Filesystem.Service).toConstantValue({ existsSync: () => true });
+			return app.resolve(DoubleSignGuard);
+		};
+
+		context.guard = context.resolveGuard();
+	});
+
+	afterEach(({ dataDirectory }) => {
+		rmSync(dataDirectory, { force: true, recursive: true });
+	});
+
+	it("should allow a strictly increasing sequence of positions", async ({ guard }) => {
+		await guard.guard(KEY, at(1, 0, Propose));
+		await guard.guard(KEY, at(1, 0, Prevote));
+		await guard.guard(KEY, at(1, 0, Precommit));
+		await guard.guard(KEY, at(1, 1, Prevote)); // next round
+		await guard.guard(KEY, at(2, 0, Prevote)); // next block number
+	});
+
+	it("should reject a conflicting vote at the same block number, round and step", async ({ guard }) => {
+		await guard.guard(KEY, at(5, 2, Prevote, A));
+
+		await assert.rejects(() => guard.guard(KEY, at(5, 2, Prevote, B)), DoubleSignError);
+	});
+
+	it("should reject a nil vote conflicting with a prior value vote at the same position", async ({ guard }) => {
+		await guard.guard(KEY, at(5, 2, Precommit, A));
+
+		await assert.rejects(() => guard.guard(KEY, { blockNumber: 5, round: 2, step: Precommit }), DoubleSignError);
+	});
+
+	it("should reject a position that goes backwards", async ({ guard }) => {
+		await guard.guard(KEY, at(5, 2, Precommit));
+
+		await assert.rejects(() => guard.guard(KEY, at(5, 2, Prevote)), DoubleSignError); // earlier step
+		await assert.rejects(() => guard.guard(KEY, at(5, 1, Precommit)), DoubleSignError); // earlier round
+		await assert.rejects(() => guard.guard(KEY, at(4, 9, Precommit)), DoubleSignError); // earlier block number
+	});
+
+	it("should allow an idempotent re-sign of the identical position and value", async ({ guard }) => {
+		await guard.guard(KEY, at(5, 2, Prevote, A));
+
+		await guard.guard(KEY, at(5, 2, Prevote, A)); // resolves; a second identical sign is allowed
+	});
+
+	it("should track keys independently", async ({ guard }) => {
+		await guard.guard(KEY, at(5, 2, Precommit));
+
+		// A different key at an "earlier" position is unaffected by KEY's watermark.
+		await guard.guard(OTHER_KEY, at(1, 0, Propose));
+	});
+
+	it("should persist the watermark to the state file before resolving", async ({ guard, stateFile }) => {
+		await guard.guard(KEY, at(7, 3, Precommit, A));
+
+		assert.equal(JSON.parse(readFileSync(stateFile, "utf8")), {
+			[KEY]: { blockNumber: 7, round: 3, step: Precommit, value: A },
+		});
+	});
+
+	it("should enforce the watermark across a restart", async ({ guard, resolveGuard }) => {
+		// Pre-crash: the node prevotes block A at (9, 0) and the record is written to the state file.
+		await guard.guard(KEY, at(9, 0, Prevote, A));
+
+		// After a restart a fresh guard reads the state file from disk and still refuses to prevote
+		// a different block at the same (blockNumber, round).
+		const afterRestart = resolveGuard();
+		await assert.rejects(() => afterRestart.guard(KEY, at(9, 0, Prevote, B)), DoubleSignError);
+
+		// It may still move forward to a later round.
+		await afterRestart.guard(KEY, at(9, 1, Prevote, B));
+	});
+
+	it("should enforce a persisted nil vote across a restart", async ({ guard, resolveGuard }) => {
+		const nil = { blockNumber: 9, round: 0, step: Prevote };
+		await guard.guard(KEY, nil);
+
+		// A nil vote is stored without a value key, and must read back as the same nil vote.
+		const afterRestart = resolveGuard();
+		await afterRestart.guard(KEY, nil); // idempotent nil re-sign is allowed
+		await assert.rejects(() => afterRestart.guard(KEY, at(9, 0, Prevote, B)), DoubleSignError);
+	});
+
+	it("should not be affected by a temporary file left behind by an interrupted write", async ({
+		guard,
+		resolveGuard,
+		stateFile,
+	}) => {
+		await guard.guard(KEY, at(3, 0, Prevote, A));
+		writeFileSync(`${stateFile}.tmp`, "garbage from a write that never completed");
+
+		// The state file is only ever replaced atomically, so the leftover temporary is ignored.
+		const afterRestart = resolveGuard();
+		await assert.rejects(() => afterRestart.guard(KEY, at(3, 0, Prevote, B)), DoubleSignError);
+		await afterRestart.guard(KEY, at(3, 1, Prevote, B));
+	});
+
+	it("should refuse to start on a corrupt state file instead of discarding it", ({ resolveGuard, stateFile }) => {
+		writeFileSync(stateFile, "{ not json");
+
+		assert.throws(() => resolveGuard());
+	});
+});

--- a/packages/validator/source/double-sign-guard.ts
+++ b/packages/validator/source/double-sign-guard.ts
@@ -1,0 +1,82 @@
+import type { Contracts } from "@mainsail/contracts";
+
+import { Identifiers } from "@mainsail/constants";
+import { inject, injectable, postConstruct } from "@mainsail/container";
+import { DoubleSignError } from "@mainsail/exceptions";
+import { closeSync, existsSync, fsyncSync, openSync, readFileSync, renameSync, writeSync } from "fs";
+import { dirname } from "path";
+
+@injectable()
+export class DoubleSignGuard implements Contracts.Validator.DoubleSignGuard {
+	@inject(Identifiers.Application.Instance)
+	private readonly app!: Contracts.Kernel.Application;
+
+	#path!: string;
+
+	#watermarks: Record<string, Contracts.Validator.SigningPosition> = {};
+
+	@postConstruct()
+	public initialize(): void {
+		this.#path = this.app.dataPath("validator-state.json");
+
+		if (existsSync(this.#path)) {
+			this.#watermarks = JSON.parse(readFileSync(this.#path, "utf8"));
+		}
+	}
+
+	public async guard(publicKey: string, position: Contracts.Validator.SigningPosition): Promise<void> {
+		const last = this.#watermarks[publicKey];
+
+		if (last !== undefined) {
+			const order = this.#compare(position, last);
+
+			if (order < 0) {
+				throw new DoubleSignError(publicKey, last, position);
+			}
+
+			if (order === 0) {
+				if (position.value !== last.value) {
+					throw new DoubleSignError(publicKey, last, position);
+				}
+
+				return; // identical position and value: an idempotent re-sign, already durable.
+			}
+		}
+
+		// Persist before updating memory, so the record is durable before the caller releases the
+		// signature and a failed write never leaves memory ahead of disk.
+		const next = { ...this.#watermarks, [publicKey]: position };
+		this.#persist(next);
+		this.#watermarks = next;
+	}
+
+	// Write-fsync-rename-fsync: the temporary file is flushed before it atomically replaces the
+	// state file, and the directory is flushed so the replacement itself survives power loss.
+	// A crash anywhere in between leaves the previous state intact.
+	#persist(watermarks: Record<string, Contracts.Validator.SigningPosition>): void {
+		const temporary = `${this.#path}.tmp`;
+
+		const fd = openSync(temporary, "w");
+		writeSync(fd, JSON.stringify(watermarks));
+		fsyncSync(fd);
+		closeSync(fd);
+
+		renameSync(temporary, this.#path);
+
+		const directory = openSync(dirname(this.#path), "r");
+		fsyncSync(directory);
+		closeSync(directory);
+	}
+
+	#compare(a: Contracts.Validator.SigningPosition, b: Contracts.Validator.SigningPosition): number {
+		if (a.blockNumber !== b.blockNumber) {
+			return a.blockNumber - b.blockNumber;
+		}
+
+		if (a.round !== b.round) {
+			return a.round - b.round;
+		}
+
+		return a.step - b.step;
+	}
+}

--- a/packages/validator/source/service-provider.test.ts
+++ b/packages/validator/source/service-provider.test.ts
@@ -37,6 +37,7 @@ describe<{
 		context.app.bind(Identifiers.Cryptography.Message.Factory).toConstantValue({});
 		context.app.bind(Identifiers.Cryptography.Proposal.Factory).toConstantValue({});
 		context.app.bind(Identifiers.State.Store).toConstantValue({});
+		context.app.bind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: () => {} });
 
 		// A stub repository so boot's `configure(validators)` call is observable.
 		context.repository = { configure: () => {} };

--- a/packages/validator/source/service-provider.ts
+++ b/packages/validator/source/service-provider.ts
@@ -6,6 +6,7 @@ import { injectable } from "@mainsail/container";
 import { Providers } from "@mainsail/kernel";
 import { assert } from "@mainsail/utils";
 
+import { DoubleSignGuard } from "./double-sign-guard.js";
 import { BIP38, BIP39 } from "./keys/index.js";
 import { ValidatorRepository } from "./validator-repository.js";
 import { Validator } from "./validator.js";
@@ -13,6 +14,7 @@ import { Validator } from "./validator.js";
 @injectable()
 export class ServiceProvider extends Providers.ServiceProvider {
 	public async register(): Promise<void> {
+		this.app.bind(Identifiers.Validator.DoubleSignGuard).to(DoubleSignGuard).inSingletonScope();
 		this.app.bind(Identifiers.Validator.Repository).to(ValidatorRepository).inSingletonScope();
 	}
 

--- a/packages/validator/source/validator.ts
+++ b/packages/validator/source/validator.ts
@@ -17,6 +17,9 @@ export class Validator implements Contracts.Validator.Validator {
 	@inject(Identifiers.State.Store)
 	private readonly stateStore!: Contracts.State.Store;
 
+	@inject(Identifiers.Validator.DoubleSignGuard)
+	private readonly doubleSignGuard!: Contracts.Validator.DoubleSignGuard;
+
 	#keyPair!: Contracts.Validator.ValidatorKeyPair;
 
 	public configure(keyPair: Contracts.Validator.ValidatorKeyPair): Contracts.Validator.Validator {
@@ -36,6 +39,13 @@ export class Validator implements Contracts.Validator.Validator {
 		block: Contracts.Crypto.Block,
 		lockProof?: Contracts.Crypto.AggregatedSignature,
 	): Promise<Contracts.Crypto.Proposal> {
+		await this.doubleSignGuard.guard(this.#keyPair.publicKey, {
+			blockNumber: block.number,
+			round,
+			step: Enums.Consensus.Step.Propose,
+			value: block.hash,
+		});
+
 		const serializedProposedData = await this.proposalSerializer.serializePayload({ block, lockProof });
 		return this.proposalFactory.makeProposal(
 			{
@@ -54,6 +64,13 @@ export class Validator implements Contracts.Validator.Validator {
 		round: number,
 		blockHash: string | undefined,
 	): Promise<Contracts.Crypto.Message> {
+		await this.doubleSignGuard.guard(this.#keyPair.publicKey, {
+			blockNumber,
+			round,
+			step: Enums.Consensus.Step.Prevote,
+			value: blockHash,
+		});
+
 		return this.messageFactory.makeMessage(
 			{
 				blockHash,
@@ -73,6 +90,13 @@ export class Validator implements Contracts.Validator.Validator {
 		round: number,
 		blockHash: string | undefined,
 	): Promise<Contracts.Crypto.Message> {
+		await this.doubleSignGuard.guard(this.#keyPair.publicKey, {
+			blockNumber,
+			round,
+			step: Enums.Consensus.Step.Precommit,
+			value: blockHash,
+		});
+
 		return this.messageFactory.makeMessage(
 			{
 				blockHash,

--- a/packages/validator/test/helpers/prepare-sandbox.ts
+++ b/packages/validator/test/helpers/prepare-sandbox.ts
@@ -100,4 +100,6 @@ export const prepareSandbox = async (context: { app?: Application }): Promise<vo
 	context.app.bind(Identifiers.ValidatorSet.Service).toConstantValue({
 		getValidatorIndexByWalletPublicKey: () => 0,
 	});
+
+	context.app.bind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: () => {} });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3213,6 +3213,9 @@ importers:
       '@mainsail/container':
         specifier: workspace:*
         version: link:../container
+      '@mainsail/exceptions':
+        specifier: workspace:*
+        version: link:../exceptions
       '@mainsail/kernel':
         specifier: workspace:*
         version: link:../kernel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       '@mainsail/container':
         specifier: workspace:*
         version: link:../container
+      '@mainsail/exceptions':
+        specifier: workspace:*
+        version: link:../exceptions
       '@mainsail/kernel':
         specifier: workspace:*
         version: link:../kernel

--- a/tests/functional/consensus/source/double-sign.test.ts
+++ b/tests/functional/consensus/source/double-sign.test.ts
@@ -1,0 +1,122 @@
+import { Enums, Identifiers } from "@mainsail/constants";
+import { describe } from "@mainsail/test-runner";
+import { DoubleSignGuard } from "@mainsail/validator/distribution/double-sign-guard.js";
+import { writeFileSync } from "fs";
+
+import crypto from "../config/crypto.json" with { type: "json" };
+import validators from "../config/validators.json" with { type: "json" };
+import { assertBlockHash, assertBlockNumber, assertBlockRound } from "./asserts.js";
+import { Validator } from "./contracts.js";
+import { P2PRegistry } from "./p2p.js";
+import { bootMany, bootstrapMany, runMany, setup, stopMany } from "./setup.js";
+import { getValidators, prepareNodeValidators, snoozeForBlock } from "./utilities.js";
+import type { Contracts } from "@mainsail/contracts";
+
+const { Propose, Prevote } = Enums.Consensus.Step;
+
+describe<{
+	nodes: Contracts.Kernel.Application[],
+	validators: Validator[];
+	p2p: P2PRegistry;
+}>("DoubleSign", ({ beforeEach, afterEach, it, assert }) => {
+	const totalNodes = 5;
+
+	// The state file a validator wrote before it crashed: it already signed `position`, and only
+	// this record survived the restart. The node keeps the real double-sign guard (setup replaces
+	// it with a noop for the scenarios that deliberately equivocate).
+	const restoreCrashedValidator = (
+		node: Contracts.Kernel.Application,
+		validator: Validator,
+		position: { blockNumber: number; round: number; step: Enums.Consensus.Step; value?: string },
+	) => {
+		writeFileSync(
+			node.dataPath("validator-state.json"),
+			JSON.stringify({ [validator.consensusPublicKey]: position }),
+		);
+		node.rebind(Identifiers.Validator.DoubleSignGuard).to(DoubleSignGuard).inSingletonScope();
+	};
+
+	beforeEach(async (context) => {
+		context.p2p = new P2PRegistry();
+
+		context.nodes = [];
+		for (let index = 0; index < totalNodes; index++) {
+			context.nodes.push(
+				await setup(index, context.p2p, crypto, prepareNodeValidators(validators, index, totalNodes)),
+			);
+		}
+
+		context.validators = await getValidators(context.nodes[0], validators);
+	});
+
+	afterEach(async ({ nodes }) => {
+		await stopMany(nodes);
+	});
+
+	it("should skip the conflicting prevote after a restart and still confirm the block", async ({
+		nodes,
+		validators,
+		p2p,
+	}) => {
+		// Node 1 prevoted some other block at (1, 0) in its previous life and crashed before the
+		// network decided; prevoting the freshly proposed block now would double-sign.
+		restoreCrashedValidator(nodes[1], validators[1], {
+			blockNumber: 1,
+			round: 0,
+			step: Prevote,
+			value: "ff".repeat(32),
+		});
+
+		await bootMany(nodes);
+		await bootstrapMany(nodes);
+		await runMany(nodes);
+		await snoozeForBlock(nodes);
+
+		// The restarted validator skipped its prevote at the recorded position...
+		assert.equal(p2p.prevotes.getMessagesByValidator(1, 0, 1).length, 0);
+		assert.equal(p2p.prevotes.getMessages(1, 0).length, totalNodes - 1);
+
+		// ...but the remaining +2/3 prevotes confirm the block on every node, including node 1,
+		// and later steps at the same position are past the watermark and unaffected.
+		assert.equal(p2p.precommits.getMessages(1, 0).length, totalNodes);
+		await assertBlockNumber(nodes, 1);
+		await assertBlockRound(nodes, 0);
+		await assertBlockHash(nodes);
+
+		// The chain has moved past the watermark, so the validator signs again normally.
+		await snoozeForBlock(nodes);
+		await assertBlockNumber(nodes, 2);
+		assert.equal(p2p.prevotes.getMessages(2, 0).length, totalNodes);
+	});
+
+	it("should skip the conflicting re-proposal after a restart and confirm the block in the next round", async ({
+		nodes,
+		validators,
+		p2p,
+	}) => {
+		// Node 0 - the proposer - proposed some other block at (1, 0) and crashed; rebuilding and
+		// signing a new block for the same position would double-propose.
+		restoreCrashedValidator(nodes[0], validators[0], {
+			blockNumber: 1,
+			round: 0,
+			step: Propose,
+			value: "ff".repeat(32),
+		});
+
+		await bootMany(nodes);
+		await bootstrapMany(nodes);
+		await runMany(nodes);
+		await snoozeForBlock(nodes);
+
+		// No proposal went out at round 0; every validator (the proposer included) prevoted nil
+		// after the propose timeout, which is a later step and past the watermark.
+		assert.equal(p2p.proposals.getMessages(1, 0).length, 0);
+		assert.equal(p2p.prevotes.getMessages(1, 0).length, totalNodes);
+
+		// The next round is past the watermark, so the same proposer proposes and the block confirms.
+		assert.equal(p2p.proposals.getMessages(1, 1).length, 1);
+		await assertBlockNumber(nodes, 1);
+		await assertBlockRound(nodes, 1);
+		await assertBlockHash(nodes);
+	});
+});

--- a/tests/functional/consensus/source/setup.ts
+++ b/tests/functional/consensus/source/setup.ts
@@ -14,41 +14,43 @@ import { Worker } from "./worker.js";
 
 type PluginOptions = Record<string, any>;
 
-const setup = async (id: number, p2pRegistry: P2PRegistry, crypto: any, validators: ValidatorsJson): Promise<Contracts.Kernel.Application> => {
+const setup = async (
+	id: number,
+	p2pRegistry: P2PRegistry,
+	crypto: any,
+	validators: ValidatorsJson,
+): Promise<Contracts.Kernel.Application> => {
 	const app = new Application();
 
 	// Basic binds and mocks
 	app.bind(Identifiers.Application.Name).toConstantValue("mainsail");
 	app.bind(Identifiers.Config.Flags).toConstantValue({});
 	app.bind(Identifiers.Config.Plugins).toConstantValue({});
-	app
-		.bind(Identifiers.Services.EventDispatcher.Service)
-		.to(Services.Events.MemoryEventDispatcher)
-		.inSingletonScope();
+	app.bind(Identifiers.Services.EventDispatcher.Service).to(Services.Events.MemoryEventDispatcher).inSingletonScope();
 
 	p2pRegistry.registerNode(id, app);
 	app.bind(Identifiers.P2P.Broadcaster).toConstantValue(p2pRegistry.makeBroadcaster(id));
-	app.bind(Identifiers.P2P.Statistic.Service).toConstantValue({ newRound: () => { } });
+	app.bind(Identifiers.P2P.Statistic.Service).toConstantValue({ newRound: () => {} });
 
 	app.bind(Identifiers.ConsensusStorage.Service).toConstantValue(<Contracts.ConsensusStorage.Service>{
 		getMessages: async () => [],
 		getProposals: async () => [],
-		getState: async () => { },
-		persist: async () => { },
+		getState: async () => {},
+		persist: async () => {},
 	});
 
 	app.bind(Identifiers.TransactionPool.Worker).toConstantValue({
 		getTransactions: async () => ({ remaining: 0, transactions: [] }),
-		onCommit: async () => { },
+		onCommit: async () => {},
 	});
 	app.bind(Identifiers.Evm.Worker).toConstantValue({
-		onCommit: async () => { },
+		onCommit: async () => {},
 	});
 
 	app.bind(Identifiers.CryptoWorker.Worker.Instance).to(Worker).inSingletonScope();
-	app
-		.bind(Identifiers.CryptoWorker.WorkerPool)
-		.toConstantValue({ getWorker: () => app.get<Worker>(Identifiers.CryptoWorker.Worker.Instance) });
+	app.bind(Identifiers.CryptoWorker.WorkerPool).toConstantValue({
+		getWorker: () => app.get<Worker>(Identifiers.CryptoWorker.Worker.Instance),
+	});
 
 	// Bootstrap
 	await app.resolve<Contracts.Kernel.Bootstrapper>(Bootstrap.RegisterBaseServiceProviders).bootstrap();
@@ -69,9 +71,7 @@ const setup = async (id: number, p2pRegistry: P2PRegistry, crypto: any, validato
 	configRepository.set("crypto", crypto);
 
 	// Set logger
-	const logManager: Services.Log.LogManager = app.get<Services.Log.LogManager>(
-		Identifiers.Services.Log.Manager,
-	);
+	const logManager: Services.Log.LogManager = app.get<Services.Log.LogManager>(Identifiers.Services.Log.Manager);
 	await logManager.extend("test", async () => app.resolve<TestLogger>(TestLogger).make({ id }));
 	logManager.setDefaultDriver("test");
 
@@ -119,6 +119,7 @@ const setup = async (id: number, p2pRegistry: P2PRegistry, crypto: any, validato
 
 	// Rebinds
 	app.rebind(Identifiers.BlockchainUtils.ProposerCalculator).to(ProposerCalculator).inSingletonScope();
+	app.rebind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: async () => {} });
 
 	return app;
 };
@@ -155,7 +156,7 @@ const getPluginConfiguration = async (
 			.resolve(Providers.PluginConfiguration)
 			.from(packageId, defaults)
 			.merge(options[packageId] || {});
-	} catch { }
+	} catch {}
 	return undefined;
 };
 
@@ -187,9 +188,9 @@ const bootstrap = async (app: Contracts.Kernel.Application) => {
 	// const validatorSet = app.get<Contracts.ValidatorSet.Service>(Identifiers.ValidatorSet.Service);
 	// await validatorSet.restore();
 
-	const commitState = app.get<Contracts.Consensus.CommitStateFactory>(
-		Identifiers.Consensus.CommitState.Factory,
-	)(genesisCommit);
+	const commitState = app.get<Contracts.Consensus.CommitStateFactory>(Identifiers.Consensus.CommitState.Factory)(
+		genesisCommit,
+	);
 
 	const blockProcessor = app.get<Contracts.Processor.BlockProcessor>(Identifiers.Processor.BlockProcessor);
 

--- a/tests/functional/resync/source/setup.ts
+++ b/tests/functional/resync/source/setup.ts
@@ -167,16 +167,14 @@ const setupNode = async (app: Application, dataDirectory: string, configDirector
 		await loadPlugin(app, packageId, options);
 	}
 
-	// The durable double-sign guard fsyncs every signature, which is too slow for the block times
-	// these scenarios expect when all validators sign on a single node.
-	app.rebind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: async () => { } });
+	app.rebind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: async () => {} });
 
 	for (const packageId of packages) {
 		await bootPlugin(app, packageId);
 	}
 
 	await bootstrap(app);
-}
+};
 
 const loadPlugin = async (app: Application, packageId: string, options: PluginOptions) => {
 	const serviceProviderRepository = app.get<Providers.ServiceProviderRepository>(

--- a/tests/functional/resync/source/setup.ts
+++ b/tests/functional/resync/source/setup.ts
@@ -167,6 +167,10 @@ const setupNode = async (app: Application, dataDirectory: string, configDirector
 		await loadPlugin(app, packageId, options);
 	}
 
+	// The durable double-sign guard fsyncs every signature, which is too slow for the block times
+	// these scenarios expect when all validators sign on a single node.
+	app.rebind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: async () => { } });
+
 	for (const packageId of packages) {
 		await bootPlugin(app, packageId);
 	}

--- a/tests/functional/transaction-pool-api/source/setup.ts
+++ b/tests/functional/transaction-pool-api/source/setup.ts
@@ -114,6 +114,8 @@ const setup = async (): Promise<Contracts.Kernel.Application> => {
 		await loadPlugin(app, packageId, options);
 	}
 
+	app.rebind(Identifiers.Validator.DoubleSignGuard).toConstantValue({ guard: async () => {} });
+
 	for (const packageId of packages) {
 		await bootPlugin(app, packageId);
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
- Validators now durably record the last signed position (blockNumber/round/step + value)
- After a restart signing a conflicting message at or below the recorded position throws `DoubleSignError` instead
- The proposal/prevote/precommit is skipped with a warning and the validator resumes at the next round/height on its own

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
