### PR TITLE
fix: use arrow functions for hapi extension handlers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,7 +71,7 @@ export default [
 			"@typescript-eslint/require-await": "off",
 			"@typescript-eslint/restrict-plus-operands": "off",
 			"@typescript-eslint/restrict-template-expressions": "off",
-			"@typescript-eslint/unbound-method": "warn",
+			"@typescript-eslint/unbound-method": "error",
 			"@typescript-eslint/typedef": [
 				"error",
 				{
@@ -106,6 +106,20 @@ export default [
 			"no-empty": ["error", { allowEmptyCatch: true }],
 			"no-nested-ternary": "warn",
 			"no-prototype-builtins": "off",
+			"no-restricted-syntax": [
+				"error",
+				{
+					message:
+						"Write this handler as an arrow function (`method: async (request, h) => {...}`). In a plain `method() {}`, hapi replaces `this` with whatever was last passed to server.bind() — usually a route controller — so `this.x` silently reads from the wrong object.",
+					selector: "CallExpression[callee.property.name='ext'] > ObjectExpression > Property[method=true]",
+				},
+				{
+					message:
+						"Do not pass `this.<handler>` to server.ext: when hapi calls the handler later, `this` is no longer your plugin. Reference it through the plugin object's name instead (e.g. myPlugin.onRequest).",
+					selector:
+						"CallExpression[callee.property.name='ext'] > MemberExpression[object.type='ThisExpression']:not([property.name='ext'])",
+				},
+			],
 			"no-unneeded-ternary": "warn",
 			"no-unused-expressions": "off",
 			"no-unused-vars": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,7 +111,14 @@ export default [
 				{
 					message:
 						"Write this handler as an arrow function (`method: async (request, h) => {...}`). In a plain `method() {}`, hapi replaces `this` with whatever was last passed to server.bind() — usually a route controller — so `this.x` silently reads from the wrong object.",
-					selector: "CallExpression[callee.property.name='ext'] > ObjectExpression > Property[method=true]",
+					selector:
+						"CallExpression[callee.property.name='ext'] > ObjectExpression > Property[method=true], CallExpression[callee.property.name='ext'] > ArrayExpression > ObjectExpression > Property[method=true]",
+				},
+				{
+					message:
+						"Write this handler as an arrow function. A plain `function` handler gets `this` rebound by hapi exactly like a shorthand method — to whatever was last passed to server.bind().",
+					selector:
+						"CallExpression[callee.property.name='ext'] > FunctionExpression, CallExpression[callee.property.name='ext'] > ObjectExpression > Property[method=false][key.name='method'] > FunctionExpression, CallExpression[callee.property.name='ext'] > ArrayExpression > ObjectExpression > Property[method=false][key.name='method'] > FunctionExpression, CallExpression[callee.property.name='ext'] > ObjectExpression > Property[method=false][key.name='method'] > ArrayExpression > FunctionExpression, CallExpression[callee.property.name='ext'] > ArrayExpression > ObjectExpression > Property[method=false][key.name='method'] > ArrayExpression > FunctionExpression",
 				},
 				{
 					message:

--- a/packages/api-common/source/plugins/comma-separated-query.ts
+++ b/packages/api-common/source/plugins/comma-separated-query.ts
@@ -4,7 +4,7 @@ import { set } from "@mainsail/utils";
 
 export const commaArrayQuery = {
 	name: "comma-array-query",
-	onRequest(request: Hapi.Request, h: Hapi.ResponseToolkit): Hapi.Lifecycle.ReturnValue {
+	onRequest: (request: Hapi.Request, h: Hapi.ResponseToolkit): Hapi.Lifecycle.ReturnValue => {
 		const query = {};
 		const separator = ",";
 
@@ -24,7 +24,7 @@ export const commaArrayQuery = {
 	},
 
 	register(server: Hapi.Server): void {
-		server.ext("onRequest", this.onRequest);
+		server.ext("onRequest", commaArrayQuery.onRequest);
 	},
 
 	version: "1.0.0",

--- a/packages/api-common/source/plugins/dot-separated-query.ts
+++ b/packages/api-common/source/plugins/dot-separated-query.ts
@@ -4,7 +4,7 @@ import { set } from "@mainsail/utils";
 
 export const dotSeparatedQuery = {
 	name: "dot-separated-query",
-	onRequest(request: Hapi.Request, h: Hapi.ResponseToolkit): Hapi.Lifecycle.ReturnValue {
+	onRequest: (request: Hapi.Request, h: Hapi.ResponseToolkit): Hapi.Lifecycle.ReturnValue => {
 		const query = {};
 		for (const [key, value] of Object.entries(request.query)) {
 			set(query, key, value);
@@ -14,7 +14,7 @@ export const dotSeparatedQuery = {
 	},
 
 	register(server: Hapi.Server): void {
-		server.ext("onRequest", this.onRequest);
+		server.ext("onRequest", dotSeparatedQuery.onRequest);
 	},
 
 	version: "1.0.0",

--- a/packages/api-common/source/plugins/rate-limit.ts
+++ b/packages/api-common/source/plugins/rate-limit.ts
@@ -53,7 +53,7 @@ export const rateLimit = {
 		});
 
 		server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				try {
 					const rateLimitRes: RateLimiterRes = await rateLimiter.consume(
 						getIp(request, options.trustProxy),
@@ -87,7 +87,7 @@ export const rateLimit = {
 		});
 
 		server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				if (request.plugins["rate-limit"]) {
 					const data = request.plugins["rate-limit"] as RateLimitPluginData;
 

--- a/packages/api-common/source/plugins/rpc-response-handler.ts
+++ b/packages/api-common/source/plugins/rpc-response-handler.ts
@@ -12,7 +12,7 @@ export const rpcResponseHandler = {
 	name: "rcpResponseHandler",
 	register: (server: HapiServer): void => {
 		server.ext({
-			method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				const response = request.response;
 
 				if (

--- a/packages/api-common/source/plugins/whitelist.ts
+++ b/packages/api-common/source/plugins/whitelist.ts
@@ -9,7 +9,7 @@ export const whitelist = {
 	name: "whitelist",
 	register(server: Hapi.Server, options: { whitelist: string[]; trustProxy: boolean }): void {
 		server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				if (!options.whitelist) {
 					return h.continue;
 				}

--- a/packages/cli/source/output/output.ts
+++ b/packages/cli/source/output/output.ts
@@ -11,7 +11,7 @@ enum OutputVerbosity {
 export class Output {
 	#verbosity: number = OutputVerbosity.Normal;
 
-	#realStdout: (message: string) => boolean = process.stdout.write;
+	#realStdout: (message: string) => boolean = process.stdout.write.bind(process.stdout);
 
 	public mute(): void {
 		process.stdout.write = (message: string) => true;

--- a/packages/p2p/source/socket-server/plugins/accept-peer.test.ts
+++ b/packages/p2p/source/socket-server/plugins/accept-peer.test.ts
@@ -56,6 +56,9 @@ describe<{
 		};
 
 		const server = new Server({ port: 4100 });
+		// Mirror Server.initialize(): routes pass their controller to server.bind(), which is
+		// what hapi hands to non-arrow extensions as `this`.
+		server.bind({ handle: routeByPath["/p2p/peer/mockroute"].handler });
 		server.route(route);
 
 		const spyExtension = spy(server, "ext");

--- a/packages/p2p/source/socket-server/plugins/accept-peer.ts
+++ b/packages/p2p/source/socket-server/plugins/accept-peer.ts
@@ -14,12 +14,10 @@ export class AcceptPeerPlugin {
 	private readonly peerProcessor!: Contracts.P2P.PeerProcessor;
 
 	public register(server: Hapi.Server) {
-		const peerProcessor = this.peerProcessor;
-
 		server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				const ip = getPeerIp(request as Contracts.P2P.Request);
-				void peerProcessor.validateAndAcceptPeer(ip);
+				void this.peerProcessor.validateAndAcceptPeer(ip);
 
 				return h.continue;
 			},

--- a/packages/p2p/source/socket-server/plugins/base-plugin.ts
+++ b/packages/p2p/source/socket-server/plugins/base-plugin.ts
@@ -1,7 +1,6 @@
 import type { Contracts } from "@mainsail/contracts";
 
 import Boom from "@hapi/boom";
-import { ResponseToolkit } from "@hapi/hapi";
 import { Identifiers } from "@mainsail/constants";
 import { inject, injectable } from "@mainsail/container";
 
@@ -11,24 +10,12 @@ export class BasePlugin {
 	@inject(Identifiers.P2P.Peer.Disposer)
 	protected readonly peerDisposer!: Contracts.P2P.PeerDisposer;
 
-	protected disposeAndReturnBadRequest = (
-		request: Contracts.P2P.Request,
-		h: ResponseToolkit,
-		error: string,
-	): Boom.Boom => {
-		h.response().header("connection", "close").code(500);
-
+	protected disposeAndReturnBadRequest = (request: Contracts.P2P.Request, error: string): Boom.Boom => {
 		this.peerDisposer.disposePeer(getPeerIp(request));
 		return Boom.badRequest(error);
 	};
 
-	protected banAndReturnBadRequest = (
-		request: Contracts.P2P.Request,
-		h: ResponseToolkit,
-		error: string,
-	): Boom.Boom => {
-		h.response().header("connection", "close").code(500);
-
+	protected banAndReturnBadRequest = (request: Contracts.P2P.Request, error: string): Boom.Boom => {
 		this.peerDisposer.banPeer(getPeerIp(request), new Error(error));
 		return Boom.badRequest(error);
 	};

--- a/packages/p2p/source/socket-server/plugins/codec.test.ts
+++ b/packages/p2p/source/socket-server/plugins/codec.test.ts
@@ -1,0 +1,116 @@
+import { Server } from "@hapi/hapi";
+import { Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { describe } from "@mainsail/test-runner";
+
+import { CodecPlugin } from "./codec";
+
+describe<{
+	app: Application;
+	codecPlugin: CodecPlugin;
+	peerDisposer: { banPeer: (ip: string, error: Error) => void; disposePeer: (ip: string) => void };
+	server: Server;
+	handlerPayloads: unknown[];
+}>("CodecPlugin", ({ it, assert, beforeEach, spy }) => {
+	const logger = { error: () => {} };
+	const configuration = { getRequired: () => false };
+
+	const deserialized = { fields: "deserialized" };
+	const responsePayload = { status: "ok" };
+
+	const route = {
+		getRoutesConfigByPath: () => ({
+			"/p2p/peer/mockroute": {
+				codec: {
+					request: {
+						deserialize: (payload: Buffer) => {
+							if (payload[0] === 0xff) {
+								throw new Error("Bitmap of 10 validators must be 2 bytes, got 1");
+							}
+
+							return deserialized;
+						},
+					},
+					response: {
+						serialize: (object: unknown) => Buffer.from(JSON.stringify(object)),
+					},
+				},
+			},
+		}),
+	};
+
+	beforeEach((context) => {
+		context.app = new Application();
+
+		context.peerDisposer = { banPeer: () => {}, disposePeer: () => {} };
+
+		context.app.bind(Identifiers.Services.Log.Service).toConstantValue(logger);
+		context.app.bind(Identifiers.ServiceProvider.Configuration).toConstantValue(configuration);
+		context.app.bind(Identifiers.P2P.Peer.Disposer).toConstantValue(context.peerDisposer);
+		context.app.bind(Identifiers.P2P.Routes).toConstantValue(route);
+
+		context.codecPlugin = context.app.resolve(CodecPlugin);
+
+		// Wired like Server.initialize(): routes register first — each Route.register() calls
+		// server.bind(controller), so that controller is what hapi hands to
+		// extensions as `this` — and only then the codec plugin adds its extensions.
+		context.handlerPayloads = [];
+		const controller = {
+			handle: (request) => {
+				context.handlerPayloads.push(request.payload);
+				return responsePayload;
+			},
+		};
+
+		context.server = new Server({ port: 4102 });
+		context.server.bind(controller);
+		context.server.route({
+			method: "POST",
+			options: {
+				handler: controller.handle.bind(controller),
+				payload: { parse: false },
+			},
+			path: "/p2p/peer/mockroute",
+		});
+
+		context.codecPlugin.register(context.server);
+	});
+
+	it("should deserialize the request payload and serialize the response", async ({
+		server,
+		handlerPayloads,
+		peerDisposer,
+	}) => {
+		const disposePeer = spy(peerDisposer, "disposePeer");
+
+		const response = await server.inject({
+			method: "POST",
+			payload: Buffer.from("aa", "hex"),
+			url: "/p2p/peer/mockroute",
+		});
+
+		assert.equal(response.statusCode, 200);
+		assert.equal(handlerPayloads, [deserialized]);
+		disposePeer.neverCalled();
+	});
+
+	it("should dispose the peer and return a bad request when deserializing fails", async ({
+		server,
+		peerDisposer,
+		handlerPayloads,
+	}) => {
+		const disposePeer = spy(peerDisposer, "disposePeer");
+
+		const response = await server.inject({
+			method: "POST",
+			payload: Buffer.from("ff", "hex"),
+			url: "/p2p/peer/mockroute",
+		});
+
+		assert.equal(response.statusCode, 400);
+		assert.true(response.payload.startsWith("Payload deserializing failed"));
+		assert.equal(handlerPayloads, []);
+		disposePeer.calledOnce();
+		disposePeer.calledWith("127.0.0.1");
+	});
+});

--- a/packages/p2p/source/socket-server/plugins/codec.ts
+++ b/packages/p2p/source/socket-server/plugins/codec.ts
@@ -32,7 +32,7 @@ export class CodecPlugin extends BasePlugin {
 		);
 
 		server.ext({
-			async method(request, h) {
+			method: async (request, h) => {
 				try {
 					request.payload = allRoutesConfigByPath[request.path].codec.request.deserialize(request.payload);
 				} catch (rawError) {

--- a/packages/p2p/source/socket-server/plugins/codec.ts
+++ b/packages/p2p/source/socket-server/plugins/codec.ts
@@ -37,7 +37,7 @@ export class CodecPlugin extends BasePlugin {
 					request.payload = allRoutesConfigByPath[request.path].codec.request.deserialize(request.payload);
 				} catch (rawError) {
 					const error = ensureError(rawError);
-					return this.disposeAndReturnBadRequest(request, h, `Payload deserializing failed: ${error}`);
+					return this.disposeAndReturnBadRequest(request, `Payload deserializing failed: ${error}`);
 				}
 				return h.continue;
 			},

--- a/packages/p2p/source/socket-server/plugins/header-handle.test.ts
+++ b/packages/p2p/source/socket-server/plugins/header-handle.test.ts
@@ -1,0 +1,79 @@
+import { Server } from "@hapi/hapi";
+import { Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { describe } from "@mainsail/test-runner";
+
+import { HeaderHandlePlugin } from "./header-handle";
+
+describe<{
+	app: Application;
+	headerHandlePlugin: HeaderHandlePlugin;
+	headerService: { handle: (peer: unknown, header: unknown) => Promise<void> };
+	peerRepository: { getPeer: (ip: string) => unknown; hasPeer: (ip: string) => boolean };
+	server: Server;
+}>("HeaderHandlePlugin", ({ it, assert, beforeEach, spy }) => {
+	const peer = { ip: "127.0.0.1" };
+	const headers = { blockNumber: 3, round: 1 };
+	const responsePayload = { status: "ok" };
+
+	beforeEach((context) => {
+		context.app = new Application();
+
+		context.headerService = { handle: async () => {} };
+		context.peerRepository = { getPeer: () => peer, hasPeer: () => true };
+
+		context.app.bind(Identifiers.P2P.Header.Service).toConstantValue(context.headerService);
+		context.app.bind(Identifiers.P2P.Peer.Repository).toConstantValue(context.peerRepository);
+
+		context.headerHandlePlugin = context.app.resolve(HeaderHandlePlugin);
+
+		// Wired like Server.initialize(): routes register first — each Route.register() calls
+		// server.bind(controller), so that controller is what hapi hands to
+		// extensions as `this` — and only then the plugin adds its extension.
+		const controller = { handle: () => responsePayload };
+		context.server = new Server({ port: 4103 });
+		context.server.bind(controller);
+		context.server.route({
+			method: "POST",
+			options: { handler: controller.handle.bind(controller) },
+			path: "/p2p/peer/mockroute",
+		});
+
+		context.headerHandlePlugin.register(context.server);
+	});
+
+	it("should hand the request headers to the header service for a known peer", async ({
+		server,
+		headerService,
+		peerRepository,
+	}) => {
+		const handle = spy(headerService, "handle");
+		const hasPeer = spy(peerRepository, "hasPeer");
+
+		const response = await server.inject({
+			method: "POST",
+			payload: { headers },
+			url: "/p2p/peer/mockroute",
+		});
+
+		assert.equal(response.statusCode, 200);
+		assert.equal(JSON.parse(response.payload), responsePayload);
+		hasPeer.calledWith("127.0.0.1");
+		handle.calledOnce();
+		handle.calledWith(peer, headers);
+	});
+
+	it("should not call the header service for an unknown peer", async ({ server, headerService, peerRepository }) => {
+		peerRepository.hasPeer = () => false;
+		const handle = spy(headerService, "handle");
+
+		const response = await server.inject({
+			method: "POST",
+			payload: { headers },
+			url: "/p2p/peer/mockroute",
+		});
+
+		assert.equal(response.statusCode, 200);
+		handle.neverCalled();
+	});
+});

--- a/packages/p2p/source/socket-server/plugins/header-handle.ts
+++ b/packages/p2p/source/socket-server/plugins/header-handle.ts
@@ -17,17 +17,14 @@ export class HeaderHandlePlugin {
 	private readonly peerRepository!: Contracts.P2P.PeerRepository;
 
 	public register(server) {
-		const headerService = this.headerService;
-		const peerRepository = this.peerRepository;
-
 		server.ext({
-			async method(request: Contracts.P2P.Request, h) {
+			method: async (request: Contracts.P2P.Request, h) => {
 				const peerIp = getPeerIp(request);
 
-				if (peerRepository.hasPeer(peerIp)) {
-					const peer = peerRepository.getPeer(peerIp);
+				if (this.peerRepository.hasPeer(peerIp)) {
+					const peer = this.peerRepository.getPeer(peerIp);
 
-					void headerService.handle(peer, request.payload.headers);
+					void this.headerService.handle(peer, request.payload.headers);
 				}
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/plugins/header-include.test.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.test.ts
@@ -1,0 +1,48 @@
+import { Server } from "@hapi/hapi";
+import { Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { describe } from "@mainsail/test-runner";
+
+import { HeaderIncludePlugin } from "./header-include";
+
+describe<{
+	app: Application;
+	headerIncludePlugin: HeaderIncludePlugin;
+	server: Server;
+}>("HeaderIncludePlugin", ({ it, assert, beforeEach }) => {
+	const headerData = { blockNumber: 3, round: 1, step: 0 };
+	const responsePayload = { status: "ok" };
+
+	beforeEach((context) => {
+		context.app = new Application();
+
+		context.app.bind(Identifiers.P2P.Header.Factory).toConstantValue(() => ({ toData: () => headerData }));
+
+		context.headerIncludePlugin = context.app.resolve(HeaderIncludePlugin);
+
+		// Wired like Server.initialize(): routes register first — each Route.register() calls
+		// server.bind(controller), so that controller is what hapi hands to
+		// extensions as `this` — and only then the plugin adds its extension.
+		const controller = { handle: () => responsePayload };
+		context.server = new Server({ port: 4104 });
+		context.server.bind(controller);
+		context.server.route({
+			method: "POST",
+			options: { handler: controller.handle.bind(controller) },
+			path: "/p2p/peer/mockroute",
+		});
+
+		context.headerIncludePlugin.register(context.server);
+	});
+
+	it("should include our header in the response", async ({ server }) => {
+		const response = await server.inject({
+			method: "POST",
+			payload: {},
+			url: "/p2p/peer/mockroute",
+		});
+
+		assert.equal(response.statusCode, 200);
+		assert.equal(JSON.parse(response.payload), { ...responsePayload, headers: headerData });
+	});
+});

--- a/packages/p2p/source/socket-server/plugins/header-include.ts
+++ b/packages/p2p/source/socket-server/plugins/header-include.ts
@@ -13,13 +13,11 @@ export class HeaderIncludePlugin {
 	private readonly headerFactory!: Contracts.P2P.HeaderFactory;
 
 	public register(server) {
-		const headerFactory = this.headerFactory;
-
 		server.ext({
-			async method(request, h: ResponseToolkit) {
+			method: async (request, h: ResponseToolkit) => {
 				request.response.source = {
 					...request.response.source,
-					headers: headerFactory().toData(),
+					headers: this.headerFactory().toData(),
 				};
 
 				return h.continue;

--- a/packages/p2p/source/socket-server/plugins/validate-data.ts
+++ b/packages/p2p/source/socket-server/plugins/validate-data.ts
@@ -38,14 +38,13 @@ export class ValidateDataPlugin extends BasePlugin {
 				if (version && !isValidVersion(this.app, version)) {
 					return this.disposeAndReturnBadRequest(
 						request,
-						h,
 						`[${request.path}] Validation failed (invalid version)`,
 					);
 				}
 
 				const result = allRoutesConfigByPath[request.path]?.validation?.validate(request.payload);
 				if (result && result.error) {
-					return this.banAndReturnBadRequest(request, h, `[${request.path}] Validation failed (bad payload)`);
+					return this.banAndReturnBadRequest(request, `[${request.path}] Validation failed (bad payload)`);
 				}
 				return h.continue;
 			},

--- a/packages/p2p/source/socket-server/plugins/validate-ip.ts
+++ b/packages/p2p/source/socket-server/plugins/validate-ip.ts
@@ -27,11 +27,11 @@ export class ValidateIpPlugin extends BasePlugin {
 				const ip = getPeerIp(peerRequest);
 
 				if (this.peerDisposer.isBanned(ip)) {
-					return this.banAndReturnBadRequest(peerRequest, h, "Validation failed (peer is bannned)");
+					return this.banAndReturnBadRequest(peerRequest, "Validation failed (peer is bannned)");
 				}
 
 				if (!this.peerProcessor.validatePeerIp(ip)) {
-					return this.disposeAndReturnBadRequest(peerRequest, h, "Validation failed (bad ip)");
+					return this.disposeAndReturnBadRequest(peerRequest, "Validation failed (bad ip)");
 				}
 
 				return h.continue;

--- a/packages/utils/source/semver.ts
+++ b/packages/utils/source/semver.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-const { compare } = new Intl.Collator(0, { numeric: 1 });
+const collator = new Intl.Collator(undefined, { numeric: true });
 
 const isEqual = (value: string, other: string): boolean => comparator(value, other) === 0;
 
@@ -16,19 +15,19 @@ export const comparator = (value: string, other: string): number => {
 	const a: string[] = value.split(".");
 	const b: string[] = other.split(".");
 
-	const hasSameMajor: number = compare(a[0], b[0]);
+	const hasSameMajor: number = collator.compare(a[0], b[0]);
 
 	if (hasSameMajor) {
 		return hasSameMajor;
 	}
 
-	const hasSameMinor: number = compare(a[1], b[1]);
+	const hasSameMinor: number = collator.compare(a[1], b[1]);
 
 	if (hasSameMinor) {
 		return hasSameMinor;
 	}
 
-	return compare(a.slice(2).join("."), b.slice(2).join("."));
+	return collator.compare(a.slice(2).join("."), b.slice(2).join("."));
 };
 
 export const semver = {

--- a/packages/webhooks/source/server/plugins/whitelist.ts
+++ b/packages/webhooks/source/server/plugins/whitelist.ts
@@ -7,7 +7,7 @@ export const whitelist = {
 	name: "whitelist",
 	register(server: Hapi.Server, options: { whitelist: string[] }): void {
 		server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				if (!options.whitelist) {
 					return h.continue;
 				}

--- a/packages/webhooks/source/server/server.ts
+++ b/packages/webhooks/source/server/server.ts
@@ -41,7 +41,7 @@ export class Server {
 		this.#server.app.database = this.database;
 
 		this.#server.ext({
-			async method(request: Hapi.Request, h: Hapi.ResponseToolkit) {
+			method: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 				request.headers["content-type"] = "application/json";
 
 				return h.continue;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

hapi calls extension handlers written as plain object methods with this pointing at the last thing passed to `server.bind` (a route controller) not the plugin that registered them. 
 
In the p2p codec plugin this broke the error path: a peer sending an undecodable payload triggered a crash in the handler, so the node replied 500 and kept the peer connected instead of replying 400 and disposing it.

All hapi extension handlers have been upadted and eslint rules now ban the pattern from being used.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
