### PR TITLE
fix(transaction-pool-service): clean up rebroadcast cooldowns when transactions leave the pool

### DIFF
--- a/packages/transaction-pool-service/source/mempool.ts
+++ b/packages/transaction-pool-service/source/mempool.ts
@@ -104,7 +104,7 @@ export class Mempool implements Contracts.TransactionPool.Mempool {
 		for (const removed of removedTransactions) {
 			this.storage.removeTransaction(removed.hash);
 			this.logger.debug(`Removed overwritten tx ${removed.hash}`);
-			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, removed.data);
+			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, removed.toData());
 		}
 	}
 

--- a/packages/transaction-pool-service/source/service.test.ts
+++ b/packages/transaction-pool-service/source/service.test.ts
@@ -1,0 +1,344 @@
+import { Events, Identifiers } from "@mainsail/constants";
+import { Application } from "@mainsail/kernel";
+import { describe } from "@mainsail/test-runner";
+
+import { Service } from "./service";
+
+const makeTransaction = (index: number): any => ({
+	from: `sender-${index}`,
+	gasPrice: 100 * 1e9,
+	hash: `tx-${index}`,
+	senderPublicKey: `sender-public-key-${index}`,
+	serialized: Buffer.from(`dummy-${index}`),
+	toData: () => ({ hash: `tx-${index}` }),
+});
+
+describe<{
+	app: Application;
+	service: Service;
+	blockNumber: number;
+	listeners: Record<string, any>;
+	poolTransactions: any[];
+	config: Record<string, number>;
+	broadcaster: any;
+	events: any;
+	mempool: any;
+	poolQuery: any;
+	stateStore: any;
+	storage: any;
+}>("Service", ({ it, beforeEach, stub, spy }) => {
+	beforeEach((context) => {
+		context.blockNumber = 100;
+		context.poolTransactions = [];
+
+		context.config = {
+			maxTransactionAge: 2700,
+			maxTransactionsInPool: 15_000,
+			maxTransactionsPerRequest: 40,
+			rebroadcastCooldownBlocks: 1,
+			rebroadcastThreshold: 60,
+		};
+
+		context.broadcaster = {
+			broadcastTransactions: async () => {},
+		};
+
+		context.listeners = {};
+		context.events = {
+			dispatch: async () => {},
+			forget: () => {},
+			listen: (name: string, listener: any) => {
+				context.listeners[name] = listener;
+				return () => {};
+			},
+		};
+
+		context.mempool = {
+			addTransaction: async () => {},
+			flush: () => {},
+			getSize: () => context.poolTransactions.length,
+			reAddTransactions: async () => [],
+			removeTransaction: async () => [],
+		};
+
+		context.poolQuery = {
+			getFromHighestPriority: () => ({ all: async () => context.poolTransactions }),
+			getFromLowestPriority: () => ({ first: async () => context.poolTransactions.at(-1) }),
+		};
+
+		context.stateStore = {
+			getBlockNumber: () => context.blockNumber,
+		};
+
+		context.storage = {
+			addTransaction: () => {},
+			flush: () => {},
+			getAllTransactions: () => [],
+			getOldTransactions: () => [],
+			hasTransaction: () => false,
+			removeTransaction: () => {},
+		};
+
+		context.app = new Application();
+		context.app.bind(Identifiers.ServiceProvider.Configuration).toConstantValue({
+			getRequired: (key: string) => context.config[key],
+		});
+		context.app.bind(Identifiers.Cryptography.Identity.Address.Factory).toConstantValue({
+			fromPublicKey: async (publicKey: string) => publicKey,
+		});
+		context.app.bind(Identifiers.State.Store).toConstantValue(context.stateStore);
+		context.app.bind(Identifiers.TransactionPool.Broadcaster).toConstantValue(context.broadcaster);
+		context.app.bind(Identifiers.Cryptography.Configuration).toConstantValue({
+			getMilestone: () => ({ block: { maxGasLimit: 10_000_000 } }),
+		});
+		context.app.bind(Identifiers.TransactionPool.Storage).toConstantValue(context.storage);
+		context.app.bind(Identifiers.TransactionPool.Mempool).toConstantValue(context.mempool);
+		context.app.bind(Identifiers.TransactionPool.Query).toConstantValue(context.poolQuery);
+		context.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue(context.events);
+		context.app.bind(Identifiers.Services.Log.Service).toConstantValue({
+			debug: () => {},
+			error: () => {},
+			info: () => {},
+			warn: () => {},
+		});
+		context.app.bind(Identifiers.Cryptography.Transaction.Factory).toConstantValue({
+			fromBytes: async () => {
+				throw new Error("not implemented");
+			},
+		});
+
+		context.service = context.app.resolve(Service);
+	});
+
+	it("commit - should remove re-added transactions from storage and dispatch events", async (context) => {
+		const transaction = makeTransaction(0);
+		stub(context.mempool, "reAddTransactions").resolvedValue([transaction]);
+		const removeTransaction = spy(context.storage, "removeTransaction");
+		const dispatch = spy(context.events, "dispatch");
+
+		await context.service.commit([transaction.from], 0, true);
+
+		removeTransaction.calledWith(transaction.hash);
+		dispatch.calledWith(Events.TransactionEvent.RemovedFromPool, transaction.toData());
+	});
+
+	it("commit - should expire old transactions and dispatch them", async (context) => {
+		const transaction = makeTransaction(0);
+		stub(context.storage, "getOldTransactions").returnValue([
+			{
+				blockNumber: 1,
+				hash: transaction.hash,
+				senderPublicKey: transaction.senderPublicKey,
+				serialized: transaction.serialized,
+			},
+		]);
+		stub(context.mempool, "removeTransaction").resolvedValue([transaction]);
+		const removeTransaction = spy(context.storage, "removeTransaction");
+		const dispatch = spy(context.events, "dispatch");
+
+		await context.service.commit([], 0, true);
+
+		removeTransaction.calledWith(transaction.hash);
+		dispatch.calledWith(Events.TransactionEvent.Expired, transaction.toData());
+	});
+
+	it("commit - should remove an expired transaction from storage even when it is no longer in the mempool", async (context) => {
+		const transaction = makeTransaction(0);
+		stub(context.storage, "getOldTransactions").returnValue([
+			{
+				blockNumber: 1,
+				hash: transaction.hash,
+				senderPublicKey: transaction.senderPublicKey,
+				serialized: transaction.serialized,
+			},
+		]);
+		const removeTransaction = spy(context.storage, "removeTransaction");
+		const dispatch = spy(context.events, "dispatch");
+
+		await context.service.commit([], 0, true);
+
+		removeTransaction.calledWith(transaction.hash);
+		dispatch.neverCalled();
+	});
+
+	it("commit - should rebroadcast pool transactions when the block is not full", async (context) => {
+		context.poolTransactions = [makeTransaction(0), makeTransaction(1)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, false);
+
+		broadcastTransactions.calledOnce();
+		broadcastTransactions.calledWith(context.poolTransactions);
+	});
+
+	it("commit - should not rebroadcast within the cooldown window", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		// The cooldown is blockNumber + 1 (rebroadcastCooldownBlocks: 1), so the next block skips it.
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+	});
+
+	it("commit - should rebroadcast again after the cooldown window has passed", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		context.blockNumber += 2;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledTimes(2);
+	});
+
+	it("commit - should not rebroadcast when syncing", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, true);
+
+		broadcastTransactions.neverCalled();
+	});
+
+	it("commit - should not rebroadcast when the block is sufficiently full", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		// rebroadcastThreshold is 60% of maxGasLimit 10_000_000.
+		await context.service.commit([], 6_000_001, false);
+
+		broadcastTransactions.neverCalled();
+	});
+
+	it("commit - should limit rebroadcast to maxTransactionsPerRequest", async (context) => {
+		context.config.maxTransactionsPerRequest = 2;
+		context.poolTransactions = [makeTransaction(0), makeTransaction(1), makeTransaction(2)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, false);
+
+		broadcastTransactions.calledWith([context.poolTransactions[0], context.poolTransactions[1]]);
+	});
+
+	it("addTransaction - should hold back rebroadcast of a just-added transaction until the next block", async (context) => {
+		const transaction = makeTransaction(0);
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.addTransaction(transaction);
+		context.poolTransactions = [transaction];
+
+		// Still within the same block as the add: the add-time cooldown suppresses it.
+		await context.service.commit([], 0, false);
+		broadcastTransactions.neverCalled();
+
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+	});
+
+	it("flush - should flush mempool and storage and clear the cooldowns of the flushed transactions", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+		const mempoolFlush = spy(context.mempool, "flush");
+		const storageFlush = spy(context.storage, "flush");
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		await context.service.flush();
+		mempoolFlush.calledOnce();
+		storageFlush.calledOnce();
+
+		// Without the cleanup the pending cooldown (blockNumber + 1) would still suppress this.
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledTimes(2);
+	});
+
+	it("boot - should clear a pending cooldown when a removal event arrives", async (context) => {
+		const transaction = makeTransaction(0);
+		context.poolTransactions = [transaction];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.boot();
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		await context.listeners[Events.TransactionEvent.RemovedFromPool].handle({
+			data: transaction.toData(),
+			name: Events.TransactionEvent.RemovedFromPool,
+		});
+
+		// Without the listener the pending cooldown (blockNumber + 1) would still suppress this.
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledTimes(2);
+	});
+
+	it("boot - should clear a pending cooldown when an expiry event arrives", async (context) => {
+		const transaction = makeTransaction(0);
+		context.poolTransactions = [transaction];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.boot();
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		await context.listeners[Events.TransactionEvent.Expired].handle({
+			data: transaction.toData(),
+			name: Events.TransactionEvent.Expired,
+		});
+
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledTimes(2);
+	});
+
+	it("reAddTransactions - should clear cooldowns of transactions that are not re-added", async (context) => {
+		context.config.maxTransactionAge = 10;
+		const [expiredTransaction, failingTransaction] = [makeTransaction(0), makeTransaction(1)];
+		context.poolTransactions = [expiredTransaction, failingTransaction];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledOnce();
+
+		// One stored transaction is expired, the other fails re-adding (factory throws).
+		stub(context.storage, "getAllTransactions").returnValue([
+			{ blockNumber: 80, hash: expiredTransaction.hash, serialized: expiredTransaction.serialized },
+			{ blockNumber: 95, hash: failingTransaction.hash, serialized: failingTransaction.serialized },
+		]);
+		await context.service.reAddTransactions();
+
+		// Without the cooldown cleanup the pending cooldowns (blockNumber + 1) would suppress both.
+		context.blockNumber++;
+		await context.service.commit([], 0, false);
+		broadcastTransactions.calledTimes(2);
+		broadcastTransactions.calledWith([expiredTransaction, failingTransaction]);
+	});
+
+	it("dispose - should unsubscribe the removal listener", async (context) => {
+		const forget = spy(context.events, "forget");
+
+		context.service.dispose();
+
+		forget.calledTimes(2);
+	});
+
+	it("commit - should do nothing when disposed", async (context) => {
+		context.poolTransactions = [makeTransaction(0)];
+		const broadcastTransactions = spy(context.broadcaster, "broadcastTransactions");
+
+		context.service.dispose();
+		await context.service.commit([], 0, false);
+
+		broadcastTransactions.neverCalled();
+	});
+});

--- a/packages/transaction-pool-service/source/service.ts
+++ b/packages/transaction-pool-service/source/service.ts
@@ -1,9 +1,8 @@
-import type { Contracts } from "@mainsail/contracts";
-
 import { EnvironmentVariables, Events, Identifiers } from "@mainsail/constants";
 import { inject, injectable, tagged } from "@mainsail/container";
+import { type Contracts } from "@mainsail/contracts";
 import { PoolError, TransactionAlreadyInPoolError, TransactionPoolFullError } from "@mainsail/exceptions";
-import { ensureError, Lock, randomNumber } from "@mainsail/utils";
+import { assert, ensureError, Lock, randomNumber } from "@mainsail/utils";
 
 @injectable()
 export class Service implements Contracts.TransactionPool.Service {
@@ -45,9 +44,21 @@ export class Service implements Contracts.TransactionPool.Service {
 	readonly #lock = new Lock();
 	readonly #txRebroadcastCooldowns = new Map<string, number>();
 
+	readonly #removalListener: Contracts.Kernel.EventListener = {
+		handle: async ({ data }): Promise<void> => {
+			const { hash } = data as Contracts.Crypto.TransactionData;
+			assert.string(hash);
+
+			this.#txRebroadcastCooldowns.delete(hash);
+		},
+	};
+
 	#disposed = false;
 
 	public async boot(): Promise<void> {
+		this.events.listen(Events.TransactionEvent.RemovedFromPool, this.#removalListener);
+		this.events.listen(Events.TransactionEvent.Expired, this.#removalListener);
+
 		if (
 			process.env[EnvironmentVariables.MAINSAIL_RESET_DATABASE] ||
 			process.env[EnvironmentVariables.MAINSAIL_RESET_POOL]
@@ -57,6 +68,9 @@ export class Service implements Contracts.TransactionPool.Service {
 	}
 
 	public dispose(): void {
+		this.events.forget(Events.TransactionEvent.RemovedFromPool, this.#removalListener);
+		this.events.forget(Events.TransactionEvent.Expired, this.#removalListener);
+
 		this.#disposed = true;
 	}
 
@@ -76,7 +90,7 @@ export class Service implements Contracts.TransactionPool.Service {
 				this.storage.removeTransaction(transaction.hash);
 				this.#txRebroadcastCooldowns.delete(transaction.hash);
 				this.logger.debug(`Removed tx ${transaction.hash}`);
-				void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, transaction);
+				void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, transaction.toData());
 			}
 
 			await this.#cleanUp();
@@ -153,12 +167,14 @@ export class Service implements Contracts.TransactionPool.Service {
 					} catch (rawError) {
 						const error = ensureError(rawError);
 						this.storage.removeTransaction(hash);
+						this.#txRebroadcastCooldowns.delete(hash);
 						this.logger.debug(`Failed to re-add previously stored tx ${hash}: ${error.message}`);
 
 						previouslyStoredFailures++;
 					}
 				} else {
 					this.storage.removeTransaction(hash);
+					this.#txRebroadcastCooldowns.delete(hash);
 					this.logger.debug(`Not re-adding previously stored expired tx ${hash}`);
 					previouslyStoredExpirations++;
 				}
@@ -184,6 +200,7 @@ export class Service implements Contracts.TransactionPool.Service {
 
 			this.mempool.flush();
 			this.storage.flush();
+			this.#txRebroadcastCooldowns.clear();
 		});
 	}
 
@@ -210,8 +227,10 @@ export class Service implements Contracts.TransactionPool.Service {
 				this.storage.removeTransaction(removedTransactionHash);
 				this.#txRebroadcastCooldowns.delete(removedTransactionHash);
 				this.logger.debug(`Removed old tx ${removedTransactionHash}`);
+			}
 
-				void this.events.dispatch(Events.TransactionEvent.Expired, removedTransactionHash);
+			for (const removedTransaction of removedTransactions) {
+				void this.events.dispatch(Events.TransactionEvent.Expired, removedTransaction.toData());
 			}
 		}
 	}
@@ -229,7 +248,7 @@ export class Service implements Contracts.TransactionPool.Service {
 			this.storage.removeTransaction(removedTransaction.hash);
 			this.#txRebroadcastCooldowns.delete(removedTransaction.hash);
 			this.logger.debug(`Removed lowest priority tx ${removedTransaction.hash}`);
-			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, removedTransaction.data);
+			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, removedTransaction.toData());
 		}
 	}
 

--- a/packages/transaction-pool-worker/source/handlers/remove-transaction.test.ts
+++ b/packages/transaction-pool-worker/source/handlers/remove-transaction.test.ts
@@ -1,4 +1,4 @@
-import { Identifiers } from "@mainsail/constants";
+import { Events, Identifiers } from "@mainsail/constants";
 import { Application } from "@mainsail/kernel";
 
 import { describe } from "@mainsail/test-runner";
@@ -7,14 +7,17 @@ import { RemoveTransactionHandler } from "./remove-transaction";
 describe<{
 	app: Application;
 	handler: RemoveTransactionHandler;
+	events: any;
 	mempool: any;
 	storage: any;
 }>("RemoveTransactionHandler", ({ beforeEach, it, spy }) => {
 	beforeEach((context) => {
-		context.mempool = { removeTransaction: async () => {} };
+		context.events = { dispatch: async () => {} };
+		context.mempool = { removeTransaction: async () => [] };
 		context.storage = { removeTransaction: () => {} };
 
 		context.app = new Application();
+		context.app.bind(Identifiers.Services.EventDispatcher.Service).toConstantValue(context.events);
 		context.app.bind(Identifiers.TransactionPool.Mempool).toConstantValue(context.mempool);
 		context.app.bind(Identifiers.TransactionPool.Storage).toConstantValue(context.storage);
 
@@ -31,5 +34,30 @@ describe<{
 		fromMempool.calledWith("address-1", "hash-1");
 		fromStorage.calledOnce();
 		fromStorage.calledWith("hash-1");
+	});
+
+	it("removes the sender's higher-nonce transactions from storage and dispatches removal events", async ({
+		handler,
+		events,
+		mempool,
+		storage,
+	}) => {
+		const removed = [
+			{ hash: "hash-1", toData: () => ({ hash: "hash-1" }) },
+			{ hash: "hash-2", toData: () => ({ hash: "hash-2" }) },
+		];
+		mempool.removeTransaction = async () => removed;
+
+		const fromStorage = spy(storage, "removeTransaction");
+		const dispatch = spy(events, "dispatch");
+
+		await handler.handle("address-1", "hash-1");
+
+		fromStorage.calledTimes(2);
+		fromStorage.calledWith("hash-1");
+		fromStorage.calledWith("hash-2");
+		dispatch.calledTimes(2);
+		dispatch.calledWith(Events.TransactionEvent.RemovedFromPool, removed[0].toData());
+		dispatch.calledWith(Events.TransactionEvent.RemovedFromPool, removed[1].toData());
 	});
 });

--- a/packages/transaction-pool-worker/source/handlers/remove-transaction.ts
+++ b/packages/transaction-pool-worker/source/handlers/remove-transaction.ts
@@ -1,6 +1,6 @@
 import type { Contracts } from "@mainsail/contracts";
 
-import { Identifiers } from "@mainsail/constants";
+import { Events, Identifiers } from "@mainsail/constants";
 import { inject, injectable } from "@mainsail/container";
 
 @injectable()
@@ -11,8 +11,22 @@ export class RemoveTransactionHandler {
 	@inject(Identifiers.TransactionPool.Storage)
 	private readonly storage!: Contracts.TransactionPool.Storage;
 
+	@inject(Identifiers.Services.EventDispatcher.Service)
+	private readonly events!: Contracts.Kernel.EventDispatcher;
+
 	public async handle(address: string, hash: string): Promise<void> {
-		await this.mempool.removeTransaction(address, hash);
-		this.storage.removeTransaction(hash);
+		// Removing a transaction also removes the sender's higher-nonce transactions.
+		const removedTransactions = await this.mempool.removeTransaction(address, hash);
+
+		const removedTransactionHashes = new Set(removedTransactions.map(({ hash }) => hash));
+		removedTransactionHashes.add(hash);
+
+		for (const removedTransactionHash of removedTransactionHashes) {
+			this.storage.removeTransaction(removedTransactionHash);
+		}
+
+		for (const removedTransaction of removedTransactions) {
+			void this.events.dispatch(Events.TransactionEvent.RemovedFromPool, removedTransaction.toData());
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
The rebroadcast cooldown map grew forever, some removal paths (fee replacement, `RemoveTransactionHandler`, ...) never cleaned it up. Cheap to abuse since replacements pay no fees, so memory slowly runs out.

The service now listens for removal/expiry events and drops entries no matter which path removed the transaction.


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
